### PR TITLE
fix: clear worker execution timeout timers

### DIFF
--- a/src/core/worker.ts
+++ b/src/core/worker.ts
@@ -48,12 +48,13 @@ export async function executeWorker(job: Job): Promise<WorkerResult> {
     return executeIsolated(job, worker.isolation, timeout);
   }
 
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
   try {
     const result = await Promise.race([
       worker.perform(job),
-      new Promise<WorkerResult>((_, reject) =>
-        setTimeout(() => reject(new Error(`Job timed out after ${timeout}ms`)), timeout)
-      )
+      new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => reject(new Error(`Job timed out after ${timeout}ms`)), timeout);
+      })
     ]);
 
     if (result === undefined) {
@@ -66,6 +67,10 @@ export async function executeWorker(job: Job): Promise<WorkerResult> {
       status: 'error',
       error: error instanceof Error ? error : new Error(String(error))
     };
+  } finally {
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+    }
   }
 }
 

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -220,6 +220,24 @@ describe('Worker Module', () => {
         expect((result.error as Error).message).toContain('timed out');
       }
     });
+
+    it('should clear the timeout after a worker completes', async () => {
+      jest.useFakeTimers();
+      try {
+        registerWorker({
+          name: 'FastWorker',
+          perform: async () => WorkerResults.ok(),
+          timeout: 60000
+        });
+
+        const result = await executeWorker(createMockJob({ worker: 'FastWorker' }));
+
+        expect(result.status).toBe('ok');
+        expect(jest.getTimerCount()).toBe(0);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
   });
 
   describe('WorkerResults', () => {


### PR DESCRIPTION
## Summary

Fixes #38.

`executeWorker` now clears its timeout handle whenever the worker settles, including success and error paths. This prevents completed jobs from retaining pending timers until the configured timeout expires.

## Tests

- `npm run build`
- `npm test -- --runInBand tests/worker.test.ts` — 20 passed
- Full local run after native rebuild — 243 passed, 1 unrelated failure in `plugins.test.ts`
- `git diff --check`
