### PR TITLE
0.4.1: fix better-sqlite3 peer range, add MySQL coverage, order claimed jobs by priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 While the version is below 1.0.0, breaking changes are released as minor versions.
 
+## [0.4.1] - 2026-08-04
+
+### Fixed
+
+- **`npm install izi-queue better-sqlite3` failed.** The `better-sqlite3` peer
+  range was `^9.0.0` while the library is developed and tested against v12, so
+  npm either resolved a version with no prebuilt binary for current Node (which
+  fails to compile) or refused the install with `ERESOLVE`. The range is now
+  `>=9.0.0 <14.0.0`. Verified against 11.10.0, 12.11.1 and 13.0.2; v9 and v10
+  cannot be built on Node 24 to test, but remain within the declared range so
+  that existing installs on older Node are not broken. ([#50])
+- **Claimed jobs were handed to the executor in arbitrary order** on PostgreSQL
+  and MySQL, so a high-priority job could start after a low-priority one from
+  the same batch. Priority still governed which jobs were claimed, but not the
+  order they ran. PostgreSQL `RETURNING` follows physical update order rather
+  than the subquery's `ORDER BY`, and the MySQL adapter's post-claim `SELECT`
+  had no `ORDER BY` at all. Both now order by priority, schedule and id, which
+  is what SQLite already did. Found by the new MySQL coverage below.
+- Worker execution timeout timers are now cleared when a job settles, instead
+  of being retained for the full timeout. Thanks to @gentosai404. ([#38], [#47])
+
+### Added
+
+- Test coverage for the MySQL adapter against a real server, enabled by setting
+  `IZI_TEST_MYSQL_URL`. MySQL previously had no automated tests at all despite
+  being listed as production ready.
+
 ## [0.4.0] - 2026-08-04
 
 Three defects in this release could each cause data loss or an outage in
@@ -84,4 +111,8 @@ production. Anyone running 0.3.0 or earlier should upgrade.
 [#15]: https://github.com/iagocavalcante/izi-queue/issues/15
 [#16]: https://github.com/iagocavalcante/izi-queue/issues/16
 [#17]: https://github.com/iagocavalcante/izi-queue/issues/17
+[#38]: https://github.com/iagocavalcante/izi-queue/issues/38
+[#47]: https://github.com/iagocavalcante/izi-queue/pull/47
+[#50]: https://github.com/iagocavalcante/izi-queue/issues/50
 [0.4.0]: https://github.com/iagocavalcante/izi-queue/compare/v0.3.0...v0.4.0
+[0.4.1]: https://github.com/iagocavalcante/izi-queue/compare/v0.4.0...v0.4.1

--- a/README.md
+++ b/README.md
@@ -230,6 +230,10 @@ async perform(job) {
 
 **PostgreSQL** is recommended for production due to `FOR UPDATE SKIP LOCKED` support for efficient concurrent job fetching.
 
+**MySQL requires 8.0.1 or later** for `FOR UPDATE SKIP LOCKED`. MariaDB does not implement it and is not supported.
+
+Driver versions covered by the test suite: `better-sqlite3` 11-13, `pg` 8, `mysql2` 3.
+
 ## Examples
 
 Check out the [examples](./examples) directory:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "izi-queue",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "izi-queue",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.0",
@@ -15,9 +15,10 @@
         "@types/pg": "^8.10.0",
         "@typescript-eslint/eslint-plugin": "^6.13.0",
         "@typescript-eslint/parser": "^6.13.0",
-        "better-sqlite3": "^12.5.0",
+        "better-sqlite3": "^12.11.1",
         "eslint": "^8.55.0",
         "jest": "^29.7.0",
+        "mysql2": "^3.23.2",
         "pg": "^8.22.0",
         "ts-jest": "^29.1.0",
         "tsx": "^4.21.0",
@@ -1791,6 +1792,7 @@
       "integrity": "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2171,6 +2173,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/aws-ssl-profiles": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
+      "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/babel-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
@@ -2336,9 +2348,9 @@
       }
     },
     "node_modules/better-sqlite3": {
-      "version": "12.5.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.5.0.tgz",
-      "integrity": "sha512-WwCZ/5Diz7rsF29o27o0Gcc1Du+l7Zsv7SYtVPG0X3G/uUI1LqdxrQI7c9Hs2FWpqXXERjW9hp6g3/tH7DlVKg==",
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2347,7 +2359,7 @@
         "prebuild-install": "^7.1.1"
       },
       "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
       }
     },
     "node_modules/bindings": {
@@ -2761,6 +2773,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/detect-libc": {
@@ -3363,6 +3385,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -3598,6 +3630,23 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -3787,6 +3836,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -4618,6 +4674,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4626,6 +4689,22 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lru.min": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.4.tgz",
+      "integrity": "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=1.30.0",
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wellwelwel"
       }
     },
     "node_modules/make-dir": {
@@ -4755,6 +4834,42 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/mysql2": {
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.23.2.tgz",
+      "integrity": "sha512-fxh3HpQ8vJtu/Mmnd4Xsur19jGjHGzRLMxptiDtOkbX7EVBgnafGSGDx1WGGVmJLClVh2LeeBMMo24IFv8wCyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aws-ssl-profiles": "^1.1.2",
+        "denque": "^2.1.0",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.7.2",
+        "long": "^5.3.2",
+        "lru.min": "^1.1.4",
+        "named-placeholders": "^1.1.6",
+        "sql-escaper": "^1.5.1"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">= 8"
+      }
+    },
+    "node_modules/named-placeholders": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.6.tgz",
+      "integrity": "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lru.min": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
@@ -4777,9 +4892,9 @@
       "license": "MIT"
     },
     "node_modules/node-abi": {
-      "version": "3.85.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.85.0.tgz",
-      "integrity": "sha512-zsFhmbkAzwhTft6nd3VxcG0cvJsT70rL+BIGHWVq5fi6MwGrHwzqKaxXE+Hl2GmnGItnDKPPkO5/LQqjVkIdFg==",
+      "version": "3.94.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
+      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5235,6 +5350,7 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
       "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5311,9 +5427,9 @@
       }
     },
     "node_modules/pump": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5574,6 +5690,13 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -5719,6 +5842,22 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/sql-escaper": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/sql-escaper/-/sql-escaper-1.5.1.tgz",
+      "integrity": "sha512-4toX5E1fQbBrpfXidaHnF0669nkAdETeIPTs2SUjxxD7RRIs9ICG4gtpmfc68JCEKehsdwLFqBu9VlQqZ1P1gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=2.0.0",
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/mysqljs/sql-escaper?sponsor=1"
+      }
+    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -5854,9 +5993,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "izi-queue",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A minimal, reliable, database-backed job queue for Node.js inspired by Oban",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -53,7 +53,7 @@
     "node": ">=18.0.0"
   },
   "peerDependencies": {
-    "better-sqlite3": "^9.0.0",
+    "better-sqlite3": ">=9.0.0 <14.0.0",
     "mysql2": "^3.0.0",
     "pg": "^8.0.0"
   },
@@ -75,9 +75,10 @@
     "@types/pg": "^8.10.0",
     "@typescript-eslint/eslint-plugin": "^6.13.0",
     "@typescript-eslint/parser": "^6.13.0",
-    "better-sqlite3": "^12.5.0",
+    "better-sqlite3": "^12.11.1",
     "eslint": "^8.55.0",
     "jest": "^29.7.0",
+    "mysql2": "^3.23.2",
     "pg": "^8.22.0",
     "ts-jest": "^29.1.0",
     "tsx": "^4.21.0",

--- a/src/database/adapter.ts
+++ b/src/database/adapter.ts
@@ -41,16 +41,19 @@ export const SQL = {
       RETURNING *
     `,
     fetchJobs: `
-      UPDATE izi_jobs
-      SET state = 'executing', attempted_at = NOW(), attempt = attempt + 1, attempted_by = $3
-      WHERE id IN (
-        SELECT id FROM izi_jobs
-        WHERE queue = $1 AND state = 'available'
-        ORDER BY priority ASC, scheduled_at ASC, id ASC
-        LIMIT $2
-        FOR UPDATE SKIP LOCKED
+      WITH claimed AS (
+        UPDATE izi_jobs
+        SET state = 'executing', attempted_at = NOW(), attempt = attempt + 1, attempted_by = $3
+        WHERE id IN (
+          SELECT id FROM izi_jobs
+          WHERE queue = $1 AND state = 'available'
+          ORDER BY priority ASC, scheduled_at ASC, id ASC
+          LIMIT $2
+          FOR UPDATE SKIP LOCKED
+        )
+        RETURNING *
       )
-      RETURNING *
+      SELECT * FROM claimed ORDER BY priority ASC, scheduled_at ASC, id ASC
     `,
     updateJob: `
       UPDATE izi_jobs

--- a/src/database/mysql.ts
+++ b/src/database/mysql.ts
@@ -158,9 +158,12 @@ export class MySQLAdapter extends BaseAdapter {
 
       await connection.commit();
 
-      // Fetch the updated jobs
+      // Fetch the updated jobs. The ORDER BY matters: without it the rows come
+      // back in whatever order the server chooses, so a high-priority job could
+      // be handed to the executor after a low-priority one from the same batch.
       const [updatedRows] = await connection.query<RowDataPacket[]>(
-        `SELECT * FROM izi_jobs WHERE id IN (?)`,
+        `SELECT * FROM izi_jobs WHERE id IN (?)
+         ORDER BY priority ASC, scheduled_at ASC, id ASC`,
         [ids]
       );
 

--- a/tests/mysql-adapter.test.ts
+++ b/tests/mysql-adapter.test.ts
@@ -1,0 +1,230 @@
+import mysql from 'mysql2/promise';
+import { createMySQLAdapter, MySQLAdapter } from '../src/database/mysql.js';
+import type { Job } from '../src/types.js';
+
+/**
+ * These tests need a real MySQL server (8.0.1+ for FOR UPDATE SKIP LOCKED).
+ * Set IZI_TEST_MYSQL_URL to run them.
+ *
+ *   docker run -d --rm -e MYSQL_ROOT_PASSWORD=izi -e MYSQL_DATABASE=izi \
+ *     -p 33306:3306 mysql:8
+ *   IZI_TEST_MYSQL_URL=mysql://root:izi@localhost:33306/izi npm test
+ */
+const CONNECTION_STRING = process.env.IZI_TEST_MYSQL_URL;
+const describeMySQL = CONNECTION_STRING ? describe : describe.skip;
+
+function jobData(overrides: Partial<Omit<Job, 'id' | 'insertedAt'>> = {}): Omit<Job, 'id' | 'insertedAt'> {
+  return {
+    state: 'available',
+    queue: 'default',
+    worker: 'TestWorker',
+    args: {},
+    meta: {},
+    tags: [],
+    errors: [],
+    attempt: 0,
+    maxAttempts: 20,
+    priority: 0,
+    scheduledAt: new Date(),
+    attemptedAt: null,
+    attemptedBy: null,
+    completedAt: null,
+    discardedAt: null,
+    cancelledAt: null,
+    ...overrides,
+  };
+}
+
+describeMySQL('MySQLAdapter', () => {
+  let pool: mysql.Pool;
+  let adapter: MySQLAdapter;
+
+  beforeAll(async () => {
+    // `timezone: 'Z'` keeps JS Dates and the server's NOW() on the same clock;
+    // scheduled_at is a TIMESTAMP and is otherwise interpreted in local time.
+    pool = mysql.createPool({ uri: CONNECTION_STRING, timezone: 'Z' });
+    adapter = createMySQLAdapter(pool as never);
+    await adapter.migrate();
+  });
+
+  afterAll(async () => {
+    await pool.query('DROP TABLE IF EXISTS izi_jobs, izi_nodes, izi_migrations');
+    await pool.end();
+  });
+
+  beforeEach(async () => {
+    await pool.query('DELETE FROM izi_jobs');
+    await pool.query('DELETE FROM izi_nodes');
+  });
+
+  async function countByState(): Promise<Record<string, number>> {
+    const [rows] = await pool.query<mysql.RowDataPacket[]>(
+      'SELECT state, COUNT(*) AS count FROM izi_jobs GROUP BY state'
+    );
+    return Object.fromEntries(rows.map((r) => [r.state as string, Number(r.count)]));
+  }
+
+  it('applies every migration', async () => {
+    const status = await adapter.getMigrationStatus();
+    expect(status.length).toBeGreaterThan(0);
+    expect(status.every((m) => m.applied)).toBe(true);
+  });
+
+  it('round-trips a job through insert and read', async () => {
+    const inserted = await adapter.insertJob(
+      jobData({
+        args: { userId: 123, nested: { deep: true } },
+        meta: { source: 'api' },
+        tags: ['urgent', 'email'],
+        priority: -5,
+        maxAttempts: 3,
+      })
+    );
+
+    const job = await adapter.getJob(inserted.id);
+
+    expect(job?.args).toEqual({ userId: 123, nested: { deep: true } });
+    expect(job?.meta).toEqual({ source: 'api' });
+    expect(job?.tags).toEqual(['urgent', 'email']);
+    expect(job?.priority).toBe(-5);
+    expect(job?.maxAttempts).toBe(3);
+  });
+
+  it('claims jobs and stamps the fetching node', async () => {
+    await adapter.insertJob(jobData());
+
+    const jobs = await adapter.fetchJobs('default', 5, 'node-a');
+
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0].state).toBe('executing');
+    expect(jobs[0].attempt).toBe(1);
+    expect(jobs[0].attemptedBy).toBe('node-a');
+  });
+
+  it('claims no more than the requested limit', async () => {
+    for (let i = 0; i < 5; i++) await adapter.insertJob(jobData());
+
+    const jobs = await adapter.fetchJobs('default', 2, 'node-a');
+
+    expect(jobs).toHaveLength(2);
+    expect(await countByState()).toEqual({ available: 3, executing: 2 });
+  });
+
+  it('orders claimed jobs by priority', async () => {
+    await adapter.insertJob(jobData({ priority: 5, args: { order: 'last' } }));
+    await adapter.insertJob(jobData({ priority: -5, args: { order: 'first' } }));
+
+    const jobs = await adapter.fetchJobs('default', 2, 'node-a');
+
+    expect((jobs[0].args as { order: string }).order).toBe('first');
+  });
+
+  it('stages both scheduled and retryable jobs once due', async () => {
+    await pool.query(
+      `INSERT INTO izi_jobs (state, queue, worker, args, meta, tags, errors, scheduled_at)
+       VALUES ('scheduled', 'default', 'W', '{}', '{}', '[]', '[]', NOW() - INTERVAL 1 SECOND),
+              ('retryable', 'default', 'W', '{}', '{}', '[]', '[]', NOW() - INTERVAL 1 SECOND),
+              ('retryable', 'default', 'W', '{}', '{}', '[]', '[]', NOW() + INTERVAL 1 HOUR)`
+    );
+
+    const staged = await adapter.stageJobs();
+
+    expect(staged).toBe(2);
+    expect(await countByState()).toEqual({ available: 2, retryable: 1 });
+  });
+
+  it('updates a job and preserves untouched columns', async () => {
+    const job = await adapter.insertJob(jobData({ args: { keep: true } }));
+
+    const updated = await adapter.updateJob(job.id, {
+      state: 'completed',
+      completedAt: new Date(),
+    });
+
+    expect(updated?.state).toBe('completed');
+    expect(updated?.args).toEqual({ keep: true });
+    expect(updated?.completedAt).toBeInstanceOf(Date);
+  });
+
+  it('rescues orphans but leaves jobs owned by a live node alone', async () => {
+    await adapter.heartbeat('live-node');
+    await pool.query(
+      `INSERT INTO izi_jobs (state, queue, worker, args, meta, tags, errors, attempt, max_attempts, attempted_at, attempted_by)
+       VALUES ('executing', 'default', 'W', '{}', '{}', '[]', '[]', 1, 20, NOW() - INTERVAL 1 HOUR, 'live-node'),
+              ('executing', 'default', 'W', '{}', '{}', '[]', '[]', 1, 20, NOW() - INTERVAL 1 HOUR, 'dead-node'),
+              ('executing', 'default', 'W', '{}', '{}', '[]', '[]', 3, 3,  NOW() - INTERVAL 1 HOUR, 'dead-node'),
+              ('executing', 'default', 'W', '{}', '{}', '[]', '[]', 1, 20, NOW() - INTERVAL 1 HOUR, NULL)`
+    );
+
+    const rescued = await adapter.rescueStuckJobs(300);
+
+    expect(rescued).toBe(3);
+    expect(await countByState()).toEqual({ available: 2, discarded: 1, executing: 1 });
+  });
+
+  it('treats a node with a stale heartbeat as dead', async () => {
+    await adapter.heartbeat('stale-node');
+    await pool.query('UPDATE izi_nodes SET heartbeat_at = NOW() - INTERVAL 1 HOUR');
+    await pool.query(
+      `INSERT INTO izi_jobs (state, queue, worker, args, meta, tags, errors, attempt, attempted_at, attempted_by)
+       VALUES ('executing', 'default', 'W', '{}', '{}', '[]', '[]', 1, NOW() - INTERVAL 1 HOUR, 'stale-node')`
+    );
+
+    expect(await adapter.rescueStuckJobs(300)).toBe(1);
+  });
+
+  it('does not rescue a job still inside the rescue window', async () => {
+    await pool.query(
+      `INSERT INTO izi_jobs (state, queue, worker, args, meta, tags, errors, attempt, attempted_at, attempted_by)
+       VALUES ('executing', 'default', 'W', '{}', '{}', '[]', '[]', 1, NOW() - INTERVAL 10 SECOND, 'dead-node')`
+    );
+
+    expect(await adapter.rescueStuckJobs(300)).toBe(0);
+  });
+
+  it('upserts a single row per node and removes it on deregistration', async () => {
+    await adapter.heartbeat('node-a');
+    await adapter.heartbeat('node-a');
+
+    const [rows] = await pool.query<mysql.RowDataPacket[]>('SELECT name FROM izi_nodes');
+    expect(rows).toHaveLength(1);
+
+    await adapter.removeNode('node-a');
+    const [after] = await pool.query<mysql.RowDataPacket[]>('SELECT name FROM izi_nodes');
+    expect(after).toHaveLength(0);
+  });
+
+  it('cancels jobs by criteria without touching terminal ones', async () => {
+    await adapter.insertJob(jobData({ worker: 'A' }));
+    await adapter.insertJob(jobData({ worker: 'B' }));
+    await adapter.insertJob(jobData({ worker: 'A', state: 'completed' }));
+
+    const cancelled = await adapter.cancelJobs({ worker: 'A' });
+
+    expect(cancelled).toBe(1);
+    expect(await countByState()).toEqual({ available: 1, cancelled: 1, completed: 1 });
+  });
+
+  it('detects a duplicate unique job', async () => {
+    await adapter.insertJob(jobData({ args: { userId: 1 } }));
+
+    const conflict = await adapter.checkUnique({ period: 60 }, jobData({ args: { userId: 1 } }));
+    const distinct = await adapter.checkUnique({ period: 60 }, jobData({ args: { userId: 2 } }));
+
+    expect(conflict).not.toBeNull();
+    expect(distinct).toBeNull();
+  });
+
+  it('prunes only terminal jobs past the age cutoff', async () => {
+    await pool.query(
+      `INSERT INTO izi_jobs (state, queue, worker, args, meta, tags, errors, completed_at)
+       VALUES ('completed', 'default', 'W', '{}', '{}', '[]', '[]', NOW() - INTERVAL 2 HOUR)`
+    );
+    await adapter.insertJob(jobData());
+
+    const pruned = await adapter.pruneJobs(3600);
+
+    expect(pruned).toBe(1);
+    expect(await countByState()).toEqual({ available: 1 });
+  });
+});

--- a/tests/postgres-adapter.test.ts
+++ b/tests/postgres-adapter.test.ts
@@ -71,6 +71,15 @@ describePostgres('PostgresAdapter', () => {
     expect(jobs[0].attemptedBy).toBe('node-a');
   });
 
+  it('orders claimed jobs by priority', async () => {
+    await adapter.insertJob(jobData({ priority: 5, args: { order: 'last' } }));
+    await adapter.insertJob(jobData({ priority: -5, args: { order: 'first' } }));
+
+    const jobs = await adapter.fetchJobs('default', 2, 'node-a');
+
+    expect((jobs[0].args as { order: string }).order).toBe('first');
+  });
+
   it('stages both scheduled and retryable jobs once due', async () => {
     await pool.query(
       `INSERT INTO izi_jobs (state, queue, worker, args, scheduled_at)


### PR DESCRIPTION
Closes #50. Also releases the timer-leak fix from #47, already merged to main.

## 1. `npm install izi-queue better-sqlite3` was broken (#50)

The peer range was `^9.0.0` while the library is developed and tested against v12. On Node 24 that means:

```
$ npm install izi-queue better-sqlite3
npm error gyp ERR! not ok            # resolves 9.6.0, no prebuild, fails to compile

$ npm install izi-queue better-sqlite3@^12.5.0
npm error Conflicting peer dependency: better-sqlite3@9.6.0
```

Every SQLite user on a recent Node hit this, for the database the README's Quick Start uses.

Now `>=9.0.0 <14.0.0`, **verified rather than asserted** — I ran the SQLite suites against each major:

| better-sqlite3 | Result |
|---|---|
| 13.0.2 | 63 passed |
| 12.11.1 | 63 passed |
| 11.10.0 | 63 passed |
| 10.x, 9.x | cannot build on Node 24, untestable here |

v9/v10 stay inside the declared range so a patch release doesn't break existing installs on older Node, where they do have prebuilds. `pg` and `mysql2` are both still on their current majors and are unchanged.

Confirmed fixed by packing the tarball and running the exact failing command, with no `--legacy-peer-deps`: resolves better-sqlite3 13.0.2, and an end-to-end retry smoke test passes.

## 2. MySQL had zero test coverage

It was listed "Production Ready: Yes" in the README with not one test ever executed against a MySQL server. Adds a suite covering claiming, ordering, staging, updates, all four rescue branches, cancellation, uniqueness and pruning — gated on `IZI_TEST_MYSQL_URL`, same pattern as the PostgreSQL suite.

13 of 14 passed on the first run, which was reassuring. The one failure was real:

## 3. Claimed jobs ran in arbitrary order (found by the above)

```
● orders claimed jobs by priority
  Expected: "first"
  Received: "last"
```

The MySQL adapter's post-claim `SELECT` had no `ORDER BY`. I then tested PostgreSQL for the same thing and it failed too — `RETURNING` follows physical update order, not the subquery's `ORDER BY`.

So on two of three adapters, priority governed *which* jobs were claimed but not which **ran first** within a batch. A high-priority job could start after a low-priority one. SQLite was already correct. Both are now fixed and covered — PostgreSQL via a CTE, since `RETURNING` can't take an `ORDER BY` directly.

## Verification

**283 tests passing** against SQLite, PostgreSQL 16 and MySQL 8.4 (up from 261; MySQL was previously untestable).

```bash
docker run -d --rm -e POSTGRES_PASSWORD=izi -e POSTGRES_DB=izi -p 55432:5432 postgres:16-alpine
docker run -d --rm -e MYSQL_ROOT_PASSWORD=izi -e MYSQL_DATABASE=izi -p 33306:3306 mysql:8
IZI_TEST_POSTGRES_URL=postgres://postgres:izi@localhost:55432/izi \
IZI_TEST_MYSQL_URL=mysql://root:izi@localhost:33306/izi npm test
```

README now documents the MySQL 8.0.1+ requirement, that MariaDB is unsupported, and which driver versions are actually covered by tests.