### PR TITLE
Make unique jobs actually unique, and migrations concurrency-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,64 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 While the version is below 1.0.0, breaking changes are released as minor versions.
 
+## [Unreleased]
+
+### Fixed
+
+- **Unique job keys could alter the SQL they were looked up with.** `unique.keys`
+  entries were interpolated straight into the query in all three adapters. Keys
+  are now hashed in JavaScript and never reach a query, so the injection vector
+  is gone rather than merely parameterised. ([#18])
+- **Unique jobs were not actually unique.** The check and the insert were
+  separate statements with no lock, so concurrent callers all saw "no conflict"
+  and all inserted. Measured on PostgreSQL: 20 simultaneous inserts of the same
+  unique job produced **3 rows**. They now produce exactly one, guarded by an
+  advisory lock on PostgreSQL, `GET_LOCK` on MySQL, and an immediate transaction
+  on SQLite. ([#19])
+- **Jobs with payloads over roughly 2.7KB could not be inserted on PostgreSQL.**
+  A btree index covered the raw `args` column, and a JSONB value that does not
+  compress below the btree entry limit fails the insert outright with
+  `index row size N exceeds btree version 4 maximum 2704`. The index is now on a
+  fixed-width digest. ([#20])
+- **Duplicate detection disagreed between adapters.** SQLite compared serialized
+  JSON, so `{a:1,b:2}` and `{b:2,a:1}` were different jobs; PostgreSQL compared
+  JSONB and considered them the same. All adapters now agree, because the
+  comparison happens on a canonicalized digest computed before the query.
+  ([#45])
+- **Concurrent boots could crash on migrations.** Two instances starting at once
+  both saw the same version missing, both applied it, and the second failed on
+  the primary key -- so a rolling deploy could kill a fresh node. Migrations now
+  hold an advisory lock. Verified with 6 simultaneous migrators. ([#25])
+- **Migration SQL is no longer split on `;`.** Statements are declared as
+  arrays, so a future migration containing a function body, trigger, or a
+  semicolon inside a string literal will not be silently torn in half. ([#25])
+
+### Added
+
+- `computeUniqueKey` and `advisoryLockKey` are exported for adapter authors.
+- `DatabaseAdapter.insertUnique`, an atomic insert-if-absent. Optional, so
+  existing adapters keep working; those that do not implement it fall back to
+  the previous non-atomic path.
+- `Job.uniqueKey` records the digest a unique job was inserted under.
+
+### Breaking
+
+- **Uniqueness now only considers jobs that were themselves inserted with
+  `unique` options.** Previously a job enqueued without `unique` could block a
+  later unique insert, because the comparison was made against raw args. A
+  plain insert now carries no unique key and does not participate. Two unique
+  inserts still deduplicate, and now do so atomically. This matches Oban, where
+  uniqueness is a property of how a job was enqueued.
+- `Job.uniqueKey` is a required field on the `Job` interface. Code constructing
+  `Job` literals must add it; use `uniqueKey: null`.
+- `Migration.up` and `Migration.down` are `string[]` rather than `string`. Only
+  affects code importing the migration definitions directly.
+
+### Migrations
+
+- PostgreSQL 7, SQLite 6, MySQL 6 -- add `unique_key`, index it, and drop the
+  index over raw `args`.
+
 ## [0.4.1] - 2026-08-04
 
 ### Fixed
@@ -111,7 +169,12 @@ production. Anyone running 0.3.0 or earlier should upgrade.
 [#15]: https://github.com/iagocavalcante/izi-queue/issues/15
 [#16]: https://github.com/iagocavalcante/izi-queue/issues/16
 [#17]: https://github.com/iagocavalcante/izi-queue/issues/17
+[#18]: https://github.com/iagocavalcante/izi-queue/issues/18
+[#19]: https://github.com/iagocavalcante/izi-queue/issues/19
+[#20]: https://github.com/iagocavalcante/izi-queue/issues/20
+[#25]: https://github.com/iagocavalcante/izi-queue/issues/25
 [#38]: https://github.com/iagocavalcante/izi-queue/issues/38
+[#45]: https://github.com/iagocavalcante/izi-queue/issues/45
 [#47]: https://github.com/iagocavalcante/izi-queue/pull/47
 [#50]: https://github.com/iagocavalcante/izi-queue/issues/50
 [0.4.0]: https://github.com/iagocavalcante/izi-queue/compare/v0.3.0...v0.4.0

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -32,3 +32,4 @@ export {
   initializeIsolation,
   shutdownIsolation
 } from './isolation/index.js';
+export { computeUniqueKey, advisoryLockKey } from './unique.js';

--- a/src/core/izi-queue.ts
+++ b/src/core/izi-queue.ts
@@ -12,6 +12,7 @@ import type {
 } from '../types.js';
 import type { Plugin, PluginContext } from '../plugins/plugin.js';
 import { createJob } from './job.js';
+import { computeUniqueKey } from './unique.js';
 import { Queue } from './queue.js';
 import { telemetry } from './telemetry.js';
 import {
@@ -240,19 +241,26 @@ export class IziQueue {
       priority: options.priority ?? workerDef?.priority ?? 0
     });
 
-    if (options.unique && this.config.database.checkUnique) {
-      const existingJob = await this.config.database.checkUnique(
-        options.unique,
-        jobData as Omit<Job, 'id' | 'insertedAt'>
-      );
+    if (options.unique) {
+      const data = {
+        ...jobData,
+        uniqueKey: computeUniqueKey(jobData, options.unique)
+      } as Omit<Job, 'id' | 'insertedAt'>;
 
-      if (existingJob) {
+      const result = this.config.database.insertUnique
+        ? await this.config.database.insertUnique(data, options.unique)
+        : await this.insertUniqueUnsafely(data, options.unique);
+
+      if (result.conflict) {
         telemetry.emit('job:unique_conflict', {
-          job: existingJob,
-          queue: existingJob.queue
+          job: result.job,
+          queue: result.job.queue
         });
-        return { job: existingJob as Job<T>, conflict: true };
+      } else if (this.started && this.config.database.notify) {
+        await this.config.database.notify(result.job.queue);
       }
+
+      return { job: result.job as Job<T>, conflict: result.conflict };
     }
 
     const job = await this.config.database.insertJob(jobData as Omit<Job, 'id' | 'insertedAt'>);
@@ -262,6 +270,23 @@ export class IziQueue {
     }
 
     return { job: job as Job<T>, conflict: false };
+  }
+
+  /**
+   * Fallback for adapters predating `insertUnique`. The check and the insert are
+   * separate statements, so two callers racing on the same unique job can both
+   * observe "no conflict" and both insert.
+   */
+  private async insertUniqueUnsafely(
+    data: Omit<Job, 'id' | 'insertedAt'>,
+    unique: NonNullable<JobInsertOptions['unique']>
+  ): Promise<{ job: Job; conflict: boolean }> {
+    if (this.config.database.checkUnique) {
+      const existing = await this.config.database.checkUnique(unique, data);
+      if (existing) return { job: existing, conflict: true };
+    }
+
+    return { job: await this.config.database.insertJob(data), conflict: false };
   }
 
   async insertAll<T = Record<string, unknown>>(

--- a/src/core/job.ts
+++ b/src/core/job.ts
@@ -43,6 +43,7 @@ export function createJob<T = Record<string, unknown>>(
     scheduledAt,
     attemptedAt: null,
     attemptedBy: null,
+    uniqueKey: null,
     completedAt: null,
     discardedAt: null,
     cancelledAt: null

--- a/src/core/unique.ts
+++ b/src/core/unique.ts
@@ -1,0 +1,91 @@
+import { createHash } from 'crypto';
+import type { Job, UniqueOptions } from '../types.js';
+
+export const DEFAULT_UNIQUE_FIELDS: NonNullable<UniqueOptions['fields']> = [
+  'worker',
+  'queue',
+  'args'
+];
+
+export const DEFAULT_UNIQUE_STATES: NonNullable<UniqueOptions['states']> = [
+  'available',
+  'scheduled',
+  'executing',
+  'retryable'
+];
+
+export const DEFAULT_UNIQUE_PERIOD = 60;
+
+/**
+ * Recursively sorts object keys so that two payloads differing only in key
+ * order hash identically. Array order is preserved: `[1, 2]` and `[2, 1]` are
+ * genuinely different values.
+ */
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalize);
+  }
+
+  if (value !== null && typeof value === 'object') {
+    const source = value as Record<string, unknown>;
+    return Object.keys(source)
+      .sort()
+      .map(key => [key, canonicalize(source[key])]);
+  }
+
+  return value;
+}
+
+/**
+ * Derives the value that decides whether two jobs are "the same" for uniqueness
+ * purposes.
+ *
+ * Hashing here rather than in SQL buys three things: the key never reaches a
+ * query, so arg key names cannot alter one; every adapter agrees on what a
+ * duplicate is, rather than inheriting its database's JSON comparison rules;
+ * and what gets indexed is a fixed-width digest instead of an unbounded
+ * payload, which a btree index cannot always accommodate.
+ */
+export function computeUniqueKey<T = Record<string, unknown>>(
+  job: Pick<Job<T>, 'worker' | 'queue' | 'args'>,
+  options: UniqueOptions
+): string {
+  const fields = options.fields ?? DEFAULT_UNIQUE_FIELDS;
+  const parts: Array<[string, unknown]> = [];
+
+  if (fields.includes('worker')) {
+    parts.push(['worker', job.worker]);
+  }
+
+  if (fields.includes('queue')) {
+    parts.push(['queue', job.queue]);
+  }
+
+  if (fields.includes('args')) {
+    const args = (job.args ?? {}) as Record<string, unknown>;
+
+    if (options.keys && options.keys.length > 0) {
+      // `undefined` would vanish from the digest, making "key absent" collide
+      // with a key explicitly set to null. Mark absence distinctly instead.
+      const selected = [...options.keys]
+        .sort()
+        .map(key => [key, key in args ? canonicalize(args[key]) : ['__absent__']]);
+      parts.push(['args', selected]);
+    } else {
+      parts.push(['args', canonicalize(args)]);
+    }
+  }
+
+  return createHash('sha256').update(JSON.stringify(parts)).digest('hex').slice(0, 32);
+}
+
+/**
+ * Projects a unique key onto a signed 64-bit integer for `pg_advisory_xact_lock`,
+ * which only accepts a bigint. Returned as a string because the value does not
+ * fit in a JS number and drivers accept the textual form.
+ */
+export function advisoryLockKey(uniqueKey: string): string {
+  const unsigned = BigInt(`0x${uniqueKey.slice(0, 16)}`);
+  const signed = unsigned >= 2n ** 63n ? unsigned - 2n ** 64n : unsigned;
+  return signed.toString();
+}

--- a/src/database/adapter.ts
+++ b/src/database/adapter.ts
@@ -1,4 +1,5 @@
 import type { DatabaseAdapter, Job, JobState } from '../types.js';
+import { DEFAULT_UNIQUE_PERIOD, DEFAULT_UNIQUE_STATES } from '../core/unique.js';
 
 /**
  * Seconds a node may go without a heartbeat before it is presumed dead and its
@@ -36,8 +37,8 @@ export const SQL = {
       'CREATE INDEX IF NOT EXISTS izi_jobs_state_idx ON izi_jobs (state)'
     ],
     insertJob: `
-      INSERT INTO izi_jobs (state, queue, worker, args, meta, tags, errors, attempt, max_attempts, priority, scheduled_at)
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+      INSERT INTO izi_jobs (state, queue, worker, args, meta, tags, errors, attempt, max_attempts, priority, scheduled_at, unique_key)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
       RETURNING *
     `,
     fetchJobs: `
@@ -139,8 +140,8 @@ export const SQL = {
       )
     `,
     insertJob: `
-      INSERT INTO izi_jobs (state, queue, worker, args, meta, tags, errors, attempt, max_attempts, priority, scheduled_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO izi_jobs (state, queue, worker, args, meta, tags, errors, attempt, max_attempts, priority, scheduled_at, unique_key)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `,
     fetchJobs: `
       SELECT * FROM izi_jobs
@@ -238,8 +239,8 @@ export const SQL = {
       'CREATE INDEX IF NOT EXISTS izi_jobs_state_idx ON izi_jobs (state)'
     ],
     insertJob: `
-      INSERT INTO izi_jobs (state, queue, worker, args, meta, tags, errors, attempt, max_attempts, priority, scheduled_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO izi_jobs (state, queue, worker, args, meta, tags, errors, attempt, max_attempts, priority, scheduled_at, unique_key)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `,
     fetchJobs: `
       UPDATE izi_jobs
@@ -345,6 +346,7 @@ export function rowToJob(row: Record<string, unknown>): Job {
     scheduledAt: parseDate(row.scheduled_at) as Date,
     attemptedAt: parseDate(row.attempted_at),
     attemptedBy: (row.attempted_by as string | null) ?? null,
+    uniqueKey: (row.unique_key as string | null) ?? null,
     completedAt: parseDate(row.completed_at),
     discardedAt: parseDate(row.discarded_at),
     cancelledAt: parseDate(row.cancelled_at)
@@ -361,5 +363,15 @@ export abstract class BaseAdapter implements DatabaseAdapter {
   abstract stageJobs(): Promise<number>;
   abstract cancelJobs(criteria: { queue?: string; worker?: string; state?: JobState[] }): Promise<number>;
   abstract rescueStuckJobs(rescueAfter: number, nodeTtl?: number): Promise<number>;
+
+  /** Shared predicate for locating an existing unique job. */
+  protected uniqueLookup(options: import('../types.js').UniqueOptions): {
+    states: string[];
+    period: number | null;
+  } {
+    const states = options.states ?? DEFAULT_UNIQUE_STATES;
+    const period = options.period === 'infinity' ? null : (options.period ?? DEFAULT_UNIQUE_PERIOD);
+    return { states, period };
+  }
   abstract close(): Promise<void>;
 }

--- a/src/database/migrations.ts
+++ b/src/database/migrations.ts
@@ -1,16 +1,21 @@
 export interface Migration {
   version: number;
   name: string;
-  up: string;
-  down?: string;
+  /**
+   * One entry per statement. Deliberately not a single blob split on `;`:
+   * that breaks on function bodies, triggers, and semicolons inside string
+   * literals.
+   */
+  up: string[];
+  down?: string[];
 }
 
 export const postgresMigrations: Migration[] = [
   {
     version: 1,
     name: 'create_izi_jobs_table',
-    up: `
-      CREATE TABLE IF NOT EXISTS izi_jobs (
+    up: [
+      `CREATE TABLE IF NOT EXISTS izi_jobs (
         id BIGSERIAL PRIMARY KEY,
         state VARCHAR(20) NOT NULL DEFAULT 'available',
         queue VARCHAR(255) NOT NULL DEFAULT 'default',
@@ -28,82 +33,99 @@ export const postgresMigrations: Migration[] = [
         completed_at TIMESTAMP WITH TIME ZONE,
         discarded_at TIMESTAMP WITH TIME ZONE,
         cancelled_at TIMESTAMP WITH TIME ZONE
-      );
-
-      CREATE INDEX IF NOT EXISTS izi_jobs_queue_state_idx ON izi_jobs (queue, state);
-      CREATE INDEX IF NOT EXISTS izi_jobs_scheduled_at_idx ON izi_jobs (scheduled_at) WHERE state = 'scheduled';
-      CREATE INDEX IF NOT EXISTS izi_jobs_state_idx ON izi_jobs (state);
-    `,
-    down: 'DROP TABLE IF EXISTS izi_jobs;'
+      )`,
+      `CREATE INDEX IF NOT EXISTS izi_jobs_queue_state_idx ON izi_jobs (queue, state)`,
+      `CREATE INDEX IF NOT EXISTS izi_jobs_scheduled_at_idx ON izi_jobs (scheduled_at) WHERE state = 'scheduled'`,
+      `CREATE INDEX IF NOT EXISTS izi_jobs_state_idx ON izi_jobs (state)`
+    ],
+    down: [
+      `DROP TABLE IF EXISTS izi_jobs`
+    ]
   },
   {
     version: 2,
     name: 'create_migrations_table',
-    up: `
-      CREATE TABLE IF NOT EXISTS izi_migrations (
+    up: [
+      `CREATE TABLE IF NOT EXISTS izi_migrations (
         version INTEGER PRIMARY KEY,
         name VARCHAR(255) NOT NULL,
         applied_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
-      );
-    `,
-    down: 'DROP TABLE IF EXISTS izi_migrations;'
+      )`
+    ],
+    down: [
+      `DROP TABLE IF EXISTS izi_migrations`
+    ]
   },
   {
     version: 3,
     name: 'add_unique_index',
-    up: `
-      CREATE INDEX IF NOT EXISTS izi_jobs_worker_queue_args_idx
+    up: [
+      `CREATE INDEX IF NOT EXISTS izi_jobs_worker_queue_args_idx
       ON izi_jobs (worker, queue, args)
-      WHERE state IN ('available', 'scheduled', 'executing', 'retryable');
-    `,
-    down: 'DROP INDEX IF EXISTS izi_jobs_worker_queue_args_idx;'
+      WHERE state IN ('available', 'scheduled', 'executing', 'retryable')`
+    ],
+    down: [
+      `DROP INDEX IF EXISTS izi_jobs_worker_queue_args_idx`
+    ]
   },
   {
     version: 4,
     name: 'add_attempted_at_index',
-    up: `
-      CREATE INDEX IF NOT EXISTS izi_jobs_executing_attempted_idx
+    up: [
+      `CREATE INDEX IF NOT EXISTS izi_jobs_executing_attempted_idx
       ON izi_jobs (attempted_at)
-      WHERE state = 'executing';
-    `,
-    down: 'DROP INDEX IF EXISTS izi_jobs_executing_attempted_idx;'
+      WHERE state = 'executing'`
+    ],
+    down: [
+      `DROP INDEX IF EXISTS izi_jobs_executing_attempted_idx`
+    ]
   },
   {
     version: 5,
     name: 'widen_stager_index_to_retryable',
-    up: `
-      CREATE INDEX IF NOT EXISTS izi_jobs_stageable_idx
+    up: [
+      `CREATE INDEX IF NOT EXISTS izi_jobs_stageable_idx
       ON izi_jobs (scheduled_at)
-      WHERE state IN ('scheduled', 'retryable');
-
-      DROP INDEX IF EXISTS izi_jobs_scheduled_at_idx;
-    `,
-    down: `
-      CREATE INDEX IF NOT EXISTS izi_jobs_scheduled_at_idx
+      WHERE state IN ('scheduled', 'retryable')`,
+      `DROP INDEX IF EXISTS izi_jobs_scheduled_at_idx`
+    ],
+    down: [
+      `CREATE INDEX IF NOT EXISTS izi_jobs_scheduled_at_idx
       ON izi_jobs (scheduled_at)
-      WHERE state = 'scheduled';
-
-      DROP INDEX IF EXISTS izi_jobs_stageable_idx;
-    `
+      WHERE state = 'scheduled'`,
+      `DROP INDEX IF EXISTS izi_jobs_stageable_idx`
+    ]
   },
   {
     version: 6,
     name: 'add_node_ownership',
-    up: `
-      ALTER TABLE izi_jobs ADD COLUMN IF NOT EXISTS attempted_by VARCHAR(255);
-
-      CREATE TABLE IF NOT EXISTS izi_nodes (
+    up: [
+      `ALTER TABLE izi_jobs ADD COLUMN IF NOT EXISTS attempted_by VARCHAR(255)`,
+      `CREATE TABLE IF NOT EXISTS izi_nodes (
         name VARCHAR(255) PRIMARY KEY,
         started_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
         heartbeat_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
-      );
-
-      CREATE INDEX IF NOT EXISTS izi_nodes_heartbeat_idx ON izi_nodes (heartbeat_at);
-    `,
-    down: `
-      DROP TABLE IF EXISTS izi_nodes;
-      ALTER TABLE izi_jobs DROP COLUMN IF EXISTS attempted_by;
-    `
+      )`,
+      `CREATE INDEX IF NOT EXISTS izi_nodes_heartbeat_idx ON izi_nodes (heartbeat_at)`
+    ],
+    down: [
+      `DROP TABLE IF EXISTS izi_nodes`,
+      `ALTER TABLE izi_jobs DROP COLUMN IF EXISTS attempted_by`
+    ]
+  },
+  {
+    version: 7,
+    name: 'add_unique_key',
+    up: [
+      `ALTER TABLE izi_jobs ADD COLUMN IF NOT EXISTS unique_key VARCHAR(64)`,
+      `CREATE INDEX IF NOT EXISTS izi_jobs_unique_key_idx ON izi_jobs (unique_key) WHERE unique_key IS NOT NULL`,
+      `DROP INDEX IF EXISTS izi_jobs_worker_queue_args_idx`
+    ],
+    down: [
+      `CREATE INDEX IF NOT EXISTS izi_jobs_worker_queue_args_idx ON izi_jobs (worker, queue, args) WHERE state IN ('available', 'scheduled', 'executing', 'retryable')`,
+      `DROP INDEX IF EXISTS izi_jobs_unique_key_idx`,
+      `ALTER TABLE izi_jobs DROP COLUMN IF EXISTS unique_key`
+    ]
   }
 ];
 
@@ -111,8 +133,8 @@ export const sqliteMigrations: Migration[] = [
   {
     version: 1,
     name: 'create_izi_jobs_table',
-    up: `
-      CREATE TABLE IF NOT EXISTS izi_jobs (
+    up: [
+      `CREATE TABLE IF NOT EXISTS izi_jobs (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         state TEXT NOT NULL DEFAULT 'available',
         queue TEXT NOT NULL DEFAULT 'default',
@@ -130,59 +152,78 @@ export const sqliteMigrations: Migration[] = [
         completed_at TEXT,
         discarded_at TEXT,
         cancelled_at TEXT
-      );
-
-      CREATE INDEX IF NOT EXISTS izi_jobs_queue_state_idx ON izi_jobs (queue, state);
-      CREATE INDEX IF NOT EXISTS izi_jobs_scheduled_at_idx ON izi_jobs (scheduled_at);
-      CREATE INDEX IF NOT EXISTS izi_jobs_state_idx ON izi_jobs (state);
-    `,
-    down: 'DROP TABLE IF EXISTS izi_jobs;'
+      )`,
+      `CREATE INDEX IF NOT EXISTS izi_jobs_queue_state_idx ON izi_jobs (queue, state)`,
+      `CREATE INDEX IF NOT EXISTS izi_jobs_scheduled_at_idx ON izi_jobs (scheduled_at)`,
+      `CREATE INDEX IF NOT EXISTS izi_jobs_state_idx ON izi_jobs (state)`
+    ],
+    down: [
+      `DROP TABLE IF EXISTS izi_jobs`
+    ]
   },
   {
     version: 2,
     name: 'create_migrations_table',
-    up: `
-      CREATE TABLE IF NOT EXISTS izi_migrations (
+    up: [
+      `CREATE TABLE IF NOT EXISTS izi_migrations (
         version INTEGER PRIMARY KEY,
         name TEXT NOT NULL,
         applied_at TEXT NOT NULL DEFAULT (datetime('now'))
-      );
-    `,
-    down: 'DROP TABLE IF EXISTS izi_migrations;'
+      )`
+    ],
+    down: [
+      `DROP TABLE IF EXISTS izi_migrations`
+    ]
   },
   {
     version: 3,
     name: 'add_unique_index',
-    up: `
-      CREATE INDEX IF NOT EXISTS izi_jobs_worker_queue_args_idx
-      ON izi_jobs (worker, queue, args);
-    `,
-    down: 'DROP INDEX IF EXISTS izi_jobs_worker_queue_args_idx;'
+    up: [
+      `CREATE INDEX IF NOT EXISTS izi_jobs_worker_queue_args_idx
+      ON izi_jobs (worker, queue, args)`
+    ],
+    down: [
+      `DROP INDEX IF EXISTS izi_jobs_worker_queue_args_idx`
+    ]
   },
   {
     version: 4,
     name: 'add_attempted_at_index',
-    up: `
-      CREATE INDEX IF NOT EXISTS izi_jobs_executing_attempted_idx
-      ON izi_jobs (attempted_at);
-    `,
-    down: 'DROP INDEX IF EXISTS izi_jobs_executing_attempted_idx;'
+    up: [
+      `CREATE INDEX IF NOT EXISTS izi_jobs_executing_attempted_idx
+      ON izi_jobs (attempted_at)`
+    ],
+    down: [
+      `DROP INDEX IF EXISTS izi_jobs_executing_attempted_idx`
+    ]
   },
   {
     version: 5,
     name: 'add_node_ownership',
-    up: `
-      ALTER TABLE izi_jobs ADD COLUMN attempted_by TEXT;
-
-      CREATE TABLE IF NOT EXISTS izi_nodes (
+    up: [
+      `ALTER TABLE izi_jobs ADD COLUMN attempted_by TEXT`,
+      `CREATE TABLE IF NOT EXISTS izi_nodes (
         name TEXT PRIMARY KEY,
         started_at TEXT NOT NULL DEFAULT (datetime('now')),
         heartbeat_at TEXT NOT NULL DEFAULT (datetime('now'))
-      );
-
-      CREATE INDEX IF NOT EXISTS izi_nodes_heartbeat_idx ON izi_nodes (heartbeat_at);
-    `,
-    down: 'DROP TABLE IF EXISTS izi_nodes;'
+      )`,
+      `CREATE INDEX IF NOT EXISTS izi_nodes_heartbeat_idx ON izi_nodes (heartbeat_at)`
+    ],
+    down: [
+      `DROP TABLE IF EXISTS izi_nodes`
+    ]
+  },
+  {
+    version: 6,
+    name: 'add_unique_key',
+    up: [
+      `ALTER TABLE izi_jobs ADD COLUMN unique_key TEXT`,
+      `CREATE INDEX IF NOT EXISTS izi_jobs_unique_key_idx ON izi_jobs (unique_key)`,
+      `DROP INDEX IF EXISTS izi_jobs_worker_queue_args_idx`
+    ],
+    down: [
+      `DROP INDEX IF EXISTS izi_jobs_unique_key_idx`
+    ]
   }
 ];
 
@@ -190,8 +231,8 @@ export const mysqlMigrations: Migration[] = [
   {
     version: 1,
     name: 'create_izi_jobs_table',
-    up: `
-      CREATE TABLE IF NOT EXISTS izi_jobs (
+    up: [
+      `CREATE TABLE IF NOT EXISTS izi_jobs (
         id BIGINT AUTO_INCREMENT PRIMARY KEY,
         state VARCHAR(20) NOT NULL DEFAULT 'available',
         queue VARCHAR(255) NOT NULL DEFAULT 'default',
@@ -212,51 +253,72 @@ export const mysqlMigrations: Migration[] = [
         INDEX idx_queue_state (queue, state),
         INDEX idx_scheduled_at (scheduled_at),
         INDEX idx_state (state)
-      );
-    `,
-    down: 'DROP TABLE IF EXISTS izi_jobs;'
+      )`
+    ],
+    down: [
+      `DROP TABLE IF EXISTS izi_jobs`
+    ]
   },
   {
     version: 2,
     name: 'create_migrations_table',
-    up: `
-      CREATE TABLE IF NOT EXISTS izi_migrations (
+    up: [
+      `CREATE TABLE IF NOT EXISTS izi_migrations (
         version INT PRIMARY KEY,
         name VARCHAR(255) NOT NULL,
         applied_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
-      );
-    `,
-    down: 'DROP TABLE IF EXISTS izi_migrations;'
+      )`
+    ],
+    down: [
+      `DROP TABLE IF EXISTS izi_migrations`
+    ]
   },
   {
     version: 3,
     name: 'add_unique_index',
-    up: `
-      CREATE INDEX izi_jobs_worker_queue_idx ON izi_jobs (worker, queue);
-    `,
-    down: 'DROP INDEX izi_jobs_worker_queue_idx ON izi_jobs;'
+    up: [
+      `CREATE INDEX izi_jobs_worker_queue_idx ON izi_jobs (worker, queue)`
+    ],
+    down: [
+      `DROP INDEX izi_jobs_worker_queue_idx ON izi_jobs`
+    ]
   },
   {
     version: 4,
     name: 'add_attempted_at_index',
-    up: `
-      CREATE INDEX izi_jobs_attempted_at_idx ON izi_jobs (attempted_at);
-    `,
-    down: 'DROP INDEX izi_jobs_attempted_at_idx ON izi_jobs;'
+    up: [
+      `CREATE INDEX izi_jobs_attempted_at_idx ON izi_jobs (attempted_at)`
+    ],
+    down: [
+      `DROP INDEX izi_jobs_attempted_at_idx ON izi_jobs`
+    ]
   },
   {
     version: 5,
     name: 'add_node_ownership',
-    up: `
-      ALTER TABLE izi_jobs ADD COLUMN attempted_by VARCHAR(255) NULL;
-
-      CREATE TABLE IF NOT EXISTS izi_nodes (
+    up: [
+      `ALTER TABLE izi_jobs ADD COLUMN attempted_by VARCHAR(255) NULL`,
+      `CREATE TABLE IF NOT EXISTS izi_nodes (
         name VARCHAR(255) PRIMARY KEY,
         started_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
         heartbeat_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
         INDEX idx_heartbeat (heartbeat_at)
-      );
-    `,
-    down: 'DROP TABLE IF EXISTS izi_nodes;'
+      )`
+    ],
+    down: [
+      `DROP TABLE IF EXISTS izi_nodes`
+    ]
+  },
+  {
+    version: 6,
+    name: 'add_unique_key',
+    up: [
+      `ALTER TABLE izi_jobs ADD COLUMN unique_key VARCHAR(64) NULL`,
+      `CREATE INDEX izi_jobs_unique_key_idx ON izi_jobs (unique_key)`,
+      `DROP INDEX izi_jobs_worker_queue_idx ON izi_jobs`
+    ],
+    down: [
+      `DROP INDEX izi_jobs_unique_key_idx ON izi_jobs`
+    ]
   }
 ];

--- a/src/database/mysql.ts
+++ b/src/database/mysql.ts
@@ -25,6 +25,10 @@ interface Pool {
 }
 import type { Job, JobState, UniqueOptions } from '../types.js';
 import { BaseAdapter, DEFAULT_NODE_TTL, SQL, rowToJob } from './adapter.js';
+import { computeUniqueKey } from '../core/unique.js';
+
+/** Arbitrary but fixed: all izi-queue instances must agree on this value. */
+const MIGRATION_LOCK_NAME = 'izi_queue_migrations';
 import { mysqlMigrations } from './migrations.js';
 
 export class MySQLAdapter extends BaseAdapter {
@@ -36,7 +40,20 @@ export class MySQLAdapter extends BaseAdapter {
   }
 
   async migrate(): Promise<void> {
-    await this.pool.query(`
+    const connection = await this.pool.getConnection();
+    try {
+      // Serialises concurrent boots; without it two instances racing the same
+      // version both apply it and the second fails on the primary key.
+      await connection.query('SELECT GET_LOCK(?, ?)', [MIGRATION_LOCK_NAME, 60]);
+      await this.runMigrations(connection);
+    } finally {
+      await connection.query('SELECT RELEASE_LOCK(?)', [MIGRATION_LOCK_NAME]).catch(() => {});
+      connection.release();
+    }
+  }
+
+  private async runMigrations(connection: PoolConnection): Promise<void> {
+    await connection.query(`
       CREATE TABLE IF NOT EXISTS izi_migrations (
         version INT PRIMARY KEY,
         name VARCHAR(255) NOT NULL,
@@ -44,37 +61,25 @@ export class MySQLAdapter extends BaseAdapter {
       )
     `);
 
-    const [rows] = await this.pool.query<RowDataPacket[]>('SELECT version FROM izi_migrations ORDER BY version');
+    const [rows] = await connection.query<RowDataPacket[]>('SELECT version FROM izi_migrations ORDER BY version');
     const appliedVersions = new Set(rows.map((r: RowDataPacket) => r.version as number));
 
     for (const migration of mysqlMigrations) {
-      if (!appliedVersions.has(migration.version)) {
-        console.warn(`[izi-queue] Applying migration ${migration.version}: ${migration.name}`);
+      if (appliedVersions.has(migration.version)) continue;
 
-        const connection = await this.pool.getConnection();
-        try {
-          await connection.beginTransaction();
+      console.warn(`[izi-queue] Applying migration ${migration.version}: ${migration.name}`);
 
-          const statements = migration.up.split(';').filter(s => s.trim());
-          for (const stmt of statements) {
-            if (stmt.trim()) {
-              await connection.query(stmt);
-            }
-          }
-
-          await connection.query(
-            'INSERT INTO izi_migrations (version, name) VALUES (?, ?)',
-            [migration.version, migration.name]
-          );
-
-          await connection.commit();
-        } catch (error) {
-          await connection.rollback();
-          throw error;
-        } finally {
-          connection.release();
-        }
+      // DDL is not transactional in MySQL, so a failure part-way leaves the
+      // schema changed but the version unrecorded. The lock at least stops two
+      // nodes doing it at the same time.
+      for (const statement of migration.up) {
+        await connection.query(statement);
       }
+
+      await connection.query(
+        'INSERT INTO izi_migrations (version, name) VALUES (?, ?)',
+        [migration.version, migration.name]
+      );
     }
   }
 
@@ -92,7 +97,9 @@ export class MySQLAdapter extends BaseAdapter {
         const connection = await this.pool.getConnection();
         try {
           await connection.beginTransaction();
-          await connection.query(migration.down);
+          for (const statement of migration.down) {
+            await connection.query(statement);
+          }
           await connection.query('DELETE FROM izi_migrations WHERE version = ?', [migration.version]);
           await connection.commit();
         } catch (error) {
@@ -128,7 +135,8 @@ export class MySQLAdapter extends BaseAdapter {
       job.attempt,
       job.maxAttempts,
       job.priority,
-      job.scheduledAt
+      job.scheduledAt,
+      job.uniqueKey ?? null
     ]);
 
     const insertedJob = await this.getJob(result.insertId);
@@ -247,45 +255,79 @@ export class MySQLAdapter extends BaseAdapter {
     await this.pool.query(SQL.mysql.removeNode, [node]);
   }
 
+  private uniqueLookupSql(withPeriod: boolean): string {
+    return `
+      SELECT * FROM izi_jobs
+      WHERE unique_key = ?
+        AND state IN (?)
+        ${withPeriod ? 'AND inserted_at > DATE_SUB(NOW(), INTERVAL ? SECOND)' : ''}
+      ORDER BY id ASC
+      LIMIT 1
+    `;
+  }
+
   async checkUnique(options: UniqueOptions, job: Omit<Job, 'id' | 'insertedAt'>): Promise<Job | null> {
-    const fields = options.fields ?? ['worker', 'queue', 'args'];
-    const states = options.states ?? ['available', 'scheduled', 'executing', 'retryable'];
-    const period = options.period === 'infinity' ? 999999999 : (options.period ?? 60);
+    const { states, period } = this.uniqueLookup(options);
+    const uniqueKey = job.uniqueKey ?? computeUniqueKey(job, options);
+    const params: unknown[] = period !== null ? [uniqueKey, states, period] : [uniqueKey, states];
 
-    let sql = 'SELECT * FROM izi_jobs WHERE state IN (?)';
-    const params: unknown[] = [states];
-
-    if (period !== 999999999) {
-      sql += ' AND inserted_at > DATE_SUB(NOW(), INTERVAL ? SECOND)';
-      params.push(period);
-    }
-
-    if (fields.includes('worker')) {
-      sql += ' AND worker = ?';
-      params.push(job.worker);
-    }
-
-    if (fields.includes('queue')) {
-      sql += ' AND queue = ?';
-      params.push(job.queue);
-    }
-
-    if (fields.includes('args')) {
-      if (options.keys && options.keys.length > 0) {
-        for (const key of options.keys) {
-          sql += ` AND JSON_EXTRACT(args, '$.${key}') = ?`;
-          params.push(JSON.stringify((job.args as Record<string, unknown>)[key] ?? null));
-        }
-      } else {
-        sql += ' AND args = CAST(? AS JSON)';
-        params.push(JSON.stringify(job.args));
-      }
-    }
-
-    sql += ' LIMIT 1';
-
-    const [rows] = await this.pool.query<RowDataPacket[]>(sql, params);
+    const [rows] = await this.pool.query<RowDataPacket[]>(this.uniqueLookupSql(period !== null), params);
     return rows[0] ? rowToJob(rows[0] as Record<string, unknown>) : null;
+  }
+
+  async insertUnique(
+    job: Omit<Job, 'id' | 'insertedAt'>,
+    options: UniqueOptions
+  ): Promise<{ job: Job; conflict: boolean }> {
+    const { states, period } = this.uniqueLookup(options);
+    const uniqueKey = job.uniqueKey ?? computeUniqueKey(job, options);
+    // GET_LOCK names are capped at 64 characters; the digest is 32.
+    const lockName = `izi_unique_${uniqueKey}`;
+
+    const connection = await this.pool.getConnection();
+    try {
+      // Connection-scoped rather than transaction-scoped, so it must be
+      // released explicitly -- see the finally block.
+      await connection.query('SELECT GET_LOCK(?, ?)', [lockName, 10]);
+      await connection.beginTransaction();
+
+      const params: unknown[] = period !== null ? [uniqueKey, states, period] : [uniqueKey, states];
+      const [existing] = await connection.query<RowDataPacket[]>(
+        this.uniqueLookupSql(period !== null),
+        params
+      );
+
+      if (existing[0]) {
+        await connection.commit();
+        return { job: rowToJob(existing[0] as Record<string, unknown>), conflict: true };
+      }
+
+      const [result] = await connection.query<ResultSetHeader>(SQL.mysql.insertJob, [
+        job.state,
+        job.queue,
+        job.worker,
+        JSON.stringify(job.args),
+        JSON.stringify(job.meta),
+        JSON.stringify(job.tags),
+        JSON.stringify(job.errors),
+        job.attempt,
+        job.maxAttempts,
+        job.priority,
+        job.scheduledAt,
+        uniqueKey
+      ]);
+
+      await connection.commit();
+
+      const [rows] = await connection.query<RowDataPacket[]>(SQL.mysql.getJob, [result.insertId]);
+      return { job: rowToJob(rows[0] as Record<string, unknown>), conflict: false };
+    } catch (error) {
+      await connection.rollback().catch(() => {});
+      throw error;
+    } finally {
+      await connection.query('SELECT RELEASE_LOCK(?)', [lockName]).catch(() => {});
+      connection.release();
+    }
   }
 
   async close(): Promise<void> {

--- a/src/database/postgres.ts
+++ b/src/database/postgres.ts
@@ -1,6 +1,21 @@
 import type { Pool, PoolClient } from 'pg';
 import type { Job, JobState, UniqueOptions } from '../types.js';
 import { BaseAdapter, DEFAULT_NODE_TTL, SQL, rowToJob } from './adapter.js';
+import { advisoryLockKey, computeUniqueKey } from '../core/unique.js';
+
+/** Arbitrary but fixed: all izi-queue instances must agree on this value. */
+const MIGRATION_LOCK_KEY = '7451092386401173';
+
+function uniqueLookupSql(withPeriod: boolean): string {
+  return `
+    SELECT * FROM izi_jobs
+    WHERE unique_key = $1
+      AND state = ANY($2)
+      ${withPeriod ? "AND inserted_at > NOW() - INTERVAL '1 second' * $3" : ''}
+    ORDER BY id ASC
+    LIMIT 1
+  `;
+}
 import { postgresMigrations } from './migrations.js';
 
 export class PostgresAdapter extends BaseAdapter {
@@ -50,7 +65,21 @@ export class PostgresAdapter extends BaseAdapter {
   }
 
   async migrate(): Promise<void> {
-    await this.pool.query(`
+    const client = await this.pool.connect();
+    try {
+      // Serialises concurrent boots. Without it, two instances starting at once
+      // both see the same version missing, both run it, and the second fails on
+      // the primary key -- so a rolling deploy can crash a fresh node.
+      await client.query('SELECT pg_advisory_lock($1)', [MIGRATION_LOCK_KEY]);
+      await this.runMigrations(client);
+    } finally {
+      await client.query('SELECT pg_advisory_unlock($1)', [MIGRATION_LOCK_KEY]).catch(() => {});
+      client.release();
+    }
+  }
+
+  private async runMigrations(client: PoolClient): Promise<void> {
+    await client.query(`
       CREATE TABLE IF NOT EXISTS izi_migrations (
         version INTEGER PRIMARY KEY,
         name VARCHAR(255) NOT NULL,
@@ -58,36 +87,30 @@ export class PostgresAdapter extends BaseAdapter {
       )
     `);
 
-    const result = await this.pool.query('SELECT version FROM izi_migrations ORDER BY version');
+    const result = await client.query('SELECT version FROM izi_migrations ORDER BY version');
     const appliedVersions = new Set(result.rows.map(r => r.version));
 
     for (const migration of postgresMigrations) {
-      if (!appliedVersions.has(migration.version)) {
-        console.log(`[izi-queue] Applying migration ${migration.version}: ${migration.name}`);
+      if (appliedVersions.has(migration.version)) continue;
 
-        const client = await this.pool.connect();
-        try {
-          await client.query('BEGIN');
+      console.log(`[izi-queue] Applying migration ${migration.version}: ${migration.name}`);
 
-          const statements = migration.up.split(';').filter(s => s.trim());
-          for (const stmt of statements) {
-            if (stmt.trim()) {
-              await client.query(stmt);
-            }
-          }
+      try {
+        await client.query('BEGIN');
 
-          await client.query(
-            'INSERT INTO izi_migrations (version, name) VALUES ($1, $2)',
-            [migration.version, migration.name]
-          );
-
-          await client.query('COMMIT');
-        } catch (error) {
-          await client.query('ROLLBACK');
-          throw error;
-        } finally {
-          client.release();
+        for (const statement of migration.up) {
+          await client.query(statement);
         }
+
+        await client.query(
+          'INSERT INTO izi_migrations (version, name) VALUES ($1, $2)',
+          [migration.version, migration.name]
+        );
+
+        await client.query('COMMIT');
+      } catch (error) {
+        await client.query('ROLLBACK');
+        throw error;
       }
     }
   }
@@ -106,7 +129,9 @@ export class PostgresAdapter extends BaseAdapter {
         const client = await this.pool.connect();
         try {
           await client.query('BEGIN');
-          await client.query(migration.down);
+          for (const statement of migration.down) {
+            await client.query(statement);
+          }
           await client.query('DELETE FROM izi_migrations WHERE version = $1', [migration.version]);
           await client.query('COMMIT');
         } catch (error) {
@@ -142,7 +167,8 @@ export class PostgresAdapter extends BaseAdapter {
       job.attempt,
       job.maxAttempts,
       job.priority,
-      job.scheduledAt
+      job.scheduledAt,
+      job.uniqueKey ?? null
     ]);
     return rowToJob(result.rows[0]);
   }
@@ -221,45 +247,63 @@ export class PostgresAdapter extends BaseAdapter {
   }
 
   async checkUnique(options: UniqueOptions, job: Omit<Job, 'id' | 'insertedAt'>): Promise<Job | null> {
-    const fields = options.fields ?? ['worker', 'queue', 'args'];
-    const states = options.states ?? ['available', 'scheduled', 'executing', 'retryable'];
-    const period = options.period === 'infinity' ? 999999999 : (options.period ?? 60);
-
-    let sql = 'SELECT * FROM izi_jobs WHERE state = ANY($1)';
-    const params: unknown[] = [states];
-    let paramIndex = 2;
-
-    if (period !== 999999999) {
-      sql += ` AND inserted_at > NOW() - INTERVAL '1 second' * $${paramIndex++}`;
-      params.push(period);
-    }
-
-    if (fields.includes('worker')) {
-      sql += ` AND worker = $${paramIndex++}`;
-      params.push(job.worker);
-    }
-
-    if (fields.includes('queue')) {
-      sql += ` AND queue = $${paramIndex++}`;
-      params.push(job.queue);
-    }
-
-    if (fields.includes('args')) {
-      if (options.keys && options.keys.length > 0) {
-        for (const key of options.keys) {
-          sql += ` AND args->>'${key}' = $${paramIndex++}`;
-          params.push(String((job.args as Record<string, unknown>)[key] ?? ''));
-        }
-      } else {
-        sql += ` AND args = $${paramIndex++}`;
-        params.push(JSON.stringify(job.args));
-      }
-    }
-
-    sql += ' LIMIT 1';
-
-    const result = await this.pool.query(sql, params);
+    const { states, period } = this.uniqueLookup(options);
+    const uniqueKey = job.uniqueKey ?? computeUniqueKey(job, options);
+    const result = await this.pool.query(
+      uniqueLookupSql(period !== null),
+      period !== null ? [uniqueKey, states, period] : [uniqueKey, states]
+    );
     return result.rows[0] ? rowToJob(result.rows[0]) : null;
+  }
+
+  async insertUnique(
+    job: Omit<Job, 'id' | 'insertedAt'>,
+    options: UniqueOptions
+  ): Promise<{ job: Job; conflict: boolean }> {
+    const { states, period } = this.uniqueLookup(options);
+    const uniqueKey = job.uniqueKey ?? computeUniqueKey(job, options);
+
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+
+      // Held until commit, so a concurrent caller with the same unique key
+      // waits here and then sees the committed row rather than an empty result.
+      await client.query('SELECT pg_advisory_xact_lock($1)', [advisoryLockKey(uniqueKey)]);
+
+      const existing = await client.query(
+        uniqueLookupSql(period !== null),
+        period !== null ? [uniqueKey, states, period] : [uniqueKey, states]
+      );
+
+      if (existing.rows[0]) {
+        await client.query('COMMIT');
+        return { job: rowToJob(existing.rows[0]), conflict: true };
+      }
+
+      const inserted = await client.query(SQL.postgres.insertJob, [
+        job.state,
+        job.queue,
+        job.worker,
+        JSON.stringify(job.args),
+        JSON.stringify(job.meta),
+        job.tags,
+        JSON.stringify(job.errors),
+        job.attempt,
+        job.maxAttempts,
+        job.priority,
+        job.scheduledAt,
+        uniqueKey
+      ]);
+
+      await client.query('COMMIT');
+      return { job: rowToJob(inserted.rows[0]), conflict: false };
+    } catch (error) {
+      await client.query('ROLLBACK').catch(() => {});
+      throw error;
+    } finally {
+      client.release();
+    }
   }
 
   async listen(callback: (event: { queue: string }) => void): Promise<void> {

--- a/src/database/sqlite.ts
+++ b/src/database/sqlite.ts
@@ -1,6 +1,7 @@
 import type { Database } from 'better-sqlite3';
 import type { Job, JobState, UniqueOptions } from '../types.js';
 import { BaseAdapter, DEFAULT_NODE_TTL, rowToJob } from './adapter.js';
+import { computeUniqueKey } from '../core/unique.js';
 import { sqliteMigrations } from './migrations.js';
 
 export class SQLiteAdapter extends BaseAdapter {
@@ -24,11 +25,8 @@ export class SQLiteAdapter extends BaseAdapter {
     const appliedVersions = new Set((stmt.all() as { version: number }[]).map(r => r.version));
 
     const applyMigration = this.db.transaction((migration: typeof sqliteMigrations[0]) => {
-      const statements = migration.up.split(';').filter(s => s.trim());
-      for (const sql of statements) {
-        if (sql.trim()) {
-          this.db.exec(sql);
-        }
+      for (const statement of migration.up) {
+        this.db.exec(statement);
       }
 
       this.db.prepare('INSERT INTO izi_migrations (version, name) VALUES (?, ?)').run(
@@ -53,7 +51,9 @@ export class SQLiteAdapter extends BaseAdapter {
       const migration = sqliteMigrations.find(m => m.version === version);
       if (migration?.down) {
         console.log(`[izi-queue] Rolling back migration ${migration.version}: ${migration.name}`);
-        this.db.exec(migration.down);
+        for (const statement of migration.down) {
+          this.db.exec(statement);
+        }
         this.db.prepare('DELETE FROM izi_migrations WHERE version = ?').run(version);
       }
     });
@@ -76,8 +76,8 @@ export class SQLiteAdapter extends BaseAdapter {
 
   async insertJob(job: Omit<Job, 'id' | 'insertedAt'>): Promise<Job> {
     const stmt = this.db.prepare(`
-      INSERT INTO izi_jobs (state, queue, worker, args, meta, tags, errors, attempt, max_attempts, priority, scheduled_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO izi_jobs (state, queue, worker, args, meta, tags, errors, attempt, max_attempts, priority, scheduled_at, unique_key)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
 
     const result = stmt.run(
@@ -91,7 +91,8 @@ export class SQLiteAdapter extends BaseAdapter {
       job.attempt,
       job.maxAttempts,
       job.priority,
-      job.scheduledAt.toISOString()
+      job.scheduledAt.toISOString(),
+      job.uniqueKey ?? null
     );
 
     const getStmt = this.db.prepare('SELECT * FROM izi_jobs WHERE id = ?');
@@ -255,46 +256,72 @@ export class SQLiteAdapter extends BaseAdapter {
     this.db.prepare('DELETE FROM izi_nodes WHERE name = ?').run(node);
   }
 
-  async checkUnique(options: UniqueOptions, job: Omit<Job, 'id' | 'insertedAt'>): Promise<Job | null> {
-    const fields = options.fields ?? ['worker', 'queue', 'args'];
-    const states = options.states ?? ['available', 'scheduled', 'executing', 'retryable'];
-    const period = options.period === 'infinity' ? 999999999 : (options.period ?? 60);
+  private findUnique(uniqueKey: string, states: string[], period: number | null): Job | null {
+    const placeholders = states.map(() => '?').join(',');
+    const sql = `
+      SELECT * FROM izi_jobs
+      WHERE unique_key = ?
+        AND state IN (${placeholders})
+        ${period !== null ? `AND datetime(inserted_at) > datetime('now', '-' || ? || ' seconds')` : ''}
+      ORDER BY id ASC
+      LIMIT 1
+    `;
+    const params: unknown[] = [uniqueKey, ...states];
+    if (period !== null) params.push(period);
 
-    let sql = `SELECT * FROM izi_jobs WHERE state IN (${states.map(() => '?').join(',')})`;
-    const params: unknown[] = [...states];
-
-    if (period !== 999999999) {
-      sql += ` AND datetime(inserted_at) > datetime('now', '-' || ? || ' seconds')`;
-      params.push(period);
-    }
-
-    if (fields.includes('worker')) {
-      sql += ' AND worker = ?';
-      params.push(job.worker);
-    }
-
-    if (fields.includes('queue')) {
-      sql += ' AND queue = ?';
-      params.push(job.queue);
-    }
-
-    if (fields.includes('args')) {
-      if (options.keys && options.keys.length > 0) {
-        for (const key of options.keys) {
-          sql += ` AND json_extract(args, '$.${key}') = ?`;
-          params.push((job.args as Record<string, unknown>)[key] ?? null);
-        }
-      } else {
-        sql += ' AND args = ?';
-        params.push(JSON.stringify(job.args));
-      }
-    }
-
-    sql += ' LIMIT 1';
-
-    const stmt = this.db.prepare(sql);
-    const row = stmt.get(...params) as Record<string, unknown> | undefined;
+    const row = this.db.prepare(sql).get(...params) as Record<string, unknown> | undefined;
     return row ? rowToJob(row) : null;
+  }
+
+  async checkUnique(options: UniqueOptions, job: Omit<Job, 'id' | 'insertedAt'>): Promise<Job | null> {
+    const { states, period } = this.uniqueLookup(options);
+    return this.findUnique(job.uniqueKey ?? computeUniqueKey(job, options), states, period);
+  }
+
+  async insertUnique(
+    job: Omit<Job, 'id' | 'insertedAt'>,
+    options: UniqueOptions
+  ): Promise<{ job: Job; conflict: boolean }> {
+    const { states, period } = this.uniqueLookup(options);
+    const uniqueKey = job.uniqueKey ?? computeUniqueKey(job, options);
+
+    // `immediate` takes the write lock up front. A deferred transaction would
+    // start as a reader and only try to upgrade at the INSERT, which SQLite
+    // refuses outright rather than waiting when another writer got there first.
+    const run = this.db.transaction(() => {
+      const existing = this.findUnique(uniqueKey, states, period);
+      if (existing) return { job: existing, conflict: true };
+      return { job: this.insertJobSync({ ...job, uniqueKey }), conflict: false };
+    });
+
+    return run.immediate();
+  }
+
+  private insertJobSync(job: Omit<Job, 'id' | 'insertedAt'>): Job {
+    const result = this.db
+      .prepare(`
+        INSERT INTO izi_jobs (state, queue, worker, args, meta, tags, errors, attempt, max_attempts, priority, scheduled_at, unique_key)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `)
+      .run(
+        job.state,
+        job.queue,
+        job.worker,
+        JSON.stringify(job.args),
+        JSON.stringify(job.meta),
+        JSON.stringify(job.tags),
+        JSON.stringify(job.errors),
+        job.attempt,
+        job.maxAttempts,
+        job.priority,
+        job.scheduledAt.toISOString(),
+        job.uniqueKey ?? null
+      );
+
+    const row = this.db
+      .prepare('SELECT * FROM izi_jobs WHERE id = ?')
+      .get(result.lastInsertRowid) as Record<string, unknown>;
+    return rowToJob(row);
   }
 
   async close(): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,8 @@ export {
   defineWorker,
   WorkerResults,
   telemetry,
+  computeUniqueKey,
+  advisoryLockKey,
   initializeIsolatedWorkers,
   shutdownIsolatedWorkers,
   terminateIsolatedJob,

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,8 @@ export interface Job<T = Record<string, unknown>> {
   attemptedAt: Date | null;
   /** Name of the node that last fetched this job. Null for jobs never attempted. */
   attemptedBy: string | null;
+  /** Digest identifying this job for uniqueness. Null for non-unique jobs. */
+  uniqueKey: string | null;
   completedAt: Date | null;
   discardedAt: Date | null;
   cancelledAt: Date | null;
@@ -112,6 +114,7 @@ export interface SerializableJob<T = Record<string, unknown>> {
   scheduledAt: string;
   attemptedAt: string | null;
   attemptedBy: string | null;
+  uniqueKey: string | null;
   completedAt: string | null;
   discardedAt: string | null;
   cancelledAt: string | null;
@@ -158,7 +161,21 @@ export interface DatabaseAdapter {
   heartbeat?(node: string): Promise<void>;
   /** Removes a node's liveness record on graceful shutdown. */
   removeNode?(node: string): Promise<void>;
+  /**
+   * @deprecated Superseded by `insertUnique`, which is atomic. Retained so
+   * third-party adapters keep working; the check-then-insert it supports races
+   * between concurrent callers.
+   */
   checkUnique?(options: UniqueOptions, job: Omit<Job, 'id' | 'insertedAt'>): Promise<Job | null>;
+  /**
+   * Inserts a job unless an equivalent one already exists, atomically. Callers
+   * racing on the same unique job must all observe the same outcome: exactly
+   * one insert, and every caller receives the surviving job.
+   */
+  insertUnique?(
+    job: Omit<Job, 'id' | 'insertedAt'>,
+    options: UniqueOptions
+  ): Promise<{ job: Job; conflict: boolean }>;
   close(): Promise<void>;
   listen?(callback: (event: { queue: string }) => void): Promise<void>;
   notify?(queue: string): Promise<void>;

--- a/tests/isolation/executor.test.ts
+++ b/tests/isolation/executor.test.ts
@@ -28,6 +28,7 @@ function createMockJob(overrides: Partial<Job> = {}): Job {
     scheduledAt: new Date(),
     attemptedAt: new Date(),
     attemptedBy: null,
+    uniqueKey: null,
     completedAt: null,
     discardedAt: null,
     cancelledAt: null,

--- a/tests/isolation/thread-pool.test.ts
+++ b/tests/isolation/thread-pool.test.ts
@@ -22,6 +22,7 @@ function createSerializableJob(overrides: Partial<SerializableJob> = {}): Serial
     scheduledAt: now,
     attemptedAt: now,
     attemptedBy: null,
+    uniqueKey: null,
     completedAt: null,
     discardedAt: null,
     cancelledAt: null,

--- a/tests/mysql-adapter.test.ts
+++ b/tests/mysql-adapter.test.ts
@@ -28,6 +28,7 @@ function jobData(overrides: Partial<Omit<Job, 'id' | 'insertedAt'>> = {}): Omit<
     scheduledAt: new Date(),
     attemptedAt: null,
     attemptedBy: null,
+    uniqueKey: null,
     completedAt: null,
     discardedAt: null,
     cancelledAt: null,
@@ -205,14 +206,14 @@ describeMySQL('MySQLAdapter', () => {
     expect(await countByState()).toEqual({ available: 1, cancelled: 1, completed: 1 });
   });
 
-  it('detects a duplicate unique job', async () => {
+  it('does not unique-track jobs inserted without unique options', async () => {
+    // Deliberate: uniqueness is a property of how a job was enqueued, so a
+    // plain insert carries no key and cannot conflict with a later one.
     await adapter.insertJob(jobData({ args: { userId: 1 } }));
 
-    const conflict = await adapter.checkUnique({ period: 60 }, jobData({ args: { userId: 1 } }));
-    const distinct = await adapter.checkUnique({ period: 60 }, jobData({ args: { userId: 2 } }));
+    const result = await adapter.insertUnique(jobData({ args: { userId: 1 } }), { period: 60 });
 
-    expect(conflict).not.toBeNull();
-    expect(distinct).toBeNull();
+    expect(result.conflict).toBe(false);
   });
 
   it('prunes only terminal jobs past the age cutoff', async () => {
@@ -226,5 +227,78 @@ describeMySQL('MySQLAdapter', () => {
 
     expect(pruned).toBe(1);
     expect(await countByState()).toEqual({ available: 1 });
+  });
+
+  describe('unique jobs', () => {
+    const unique = { period: 60 };
+
+    it('inserts only one job when many nodes race on the same unique job', async () => {
+      const attempts = 15;
+      const results = await Promise.all(
+        Array.from({ length: attempts }, () =>
+          adapter.insertUnique(jobData({ args: { userId: 7 } }), unique)
+        )
+      );
+
+      expect(results.filter((r) => !r.conflict)).toHaveLength(1);
+      expect(results.filter((r) => r.conflict)).toHaveLength(attempts - 1);
+      expect(new Set(results.map((r) => r.job.id)).size).toBe(1);
+
+      const [rows] = await pool.query<mysql.RowDataPacket[]>('SELECT COUNT(*) AS c FROM izi_jobs');
+      expect(Number(rows[0].c)).toBe(1);
+    });
+
+    it('does not conflate distinct unique jobs inserted concurrently', async () => {
+      const results = await Promise.all(
+        Array.from({ length: 10 }, (_, i) =>
+          adapter.insertUnique(jobData({ args: { userId: i } }), unique)
+        )
+      );
+
+      expect(results.filter((r) => r.conflict)).toHaveLength(0);
+      const [rows] = await pool.query<mysql.RowDataPacket[]>('SELECT COUNT(*) AS c FROM izi_jobs');
+      expect(Number(rows[0].c)).toBe(10);
+    });
+
+    it('treats args differing only in key order as the same job', async () => {
+      const first = await adapter.insertUnique(jobData({ args: { a: 1, b: 2 } }), unique);
+      const second = await adapter.insertUnique(jobData({ args: { b: 2, a: 1 } }), unique);
+
+      expect(first.conflict).toBe(false);
+      expect(second.conflict).toBe(true);
+      expect(second.job.id).toBe(first.job.id);
+    });
+
+    it('ignores jobs outside the uniqueness period', async () => {
+      await adapter.insertUnique(jobData({ args: { userId: 1 } }), unique);
+      await pool.query('UPDATE izi_jobs SET inserted_at = NOW() - INTERVAL 1 HOUR');
+
+      const second = await adapter.insertUnique(jobData({ args: { userId: 1 } }), unique);
+
+      expect(second.conflict).toBe(false);
+    });
+  });
+
+  describe('concurrent migrations', () => {
+    it('lets several nodes migrate at once without failing', async () => {
+      await pool.query('DROP TABLE IF EXISTS izi_jobs, izi_nodes, izi_migrations');
+
+      const pools = Array.from({ length: 4 }, () =>
+        mysql.createPool({ uri: CONNECTION_STRING, timezone: 'Z' })
+      );
+      try {
+        const results = await Promise.allSettled(
+          pools.map((p) => createMySQLAdapter(p as never).migrate())
+        );
+
+        expect(results.filter((r) => r.status === 'rejected')).toHaveLength(0);
+
+        const [rows] = await pool.query<mysql.RowDataPacket[]>('SELECT version FROM izi_migrations');
+        const versions = rows.map((r) => Number(r.version));
+        expect(new Set(versions).size).toBe(versions.length);
+      } finally {
+        await Promise.all(pools.map((p) => p.end()));
+      }
+    });
   });
 });

--- a/tests/polling.test.ts
+++ b/tests/polling.test.ts
@@ -19,6 +19,7 @@ function createJobRow(id: number, overrides: Partial<Job> = {}): Job {
     scheduledAt: new Date(),
     attemptedAt: new Date(),
     attemptedBy: null,
+    uniqueKey: null,
     completedAt: null,
     discardedAt: null,
     cancelledAt: null,

--- a/tests/postgres-adapter.test.ts
+++ b/tests/postgres-adapter.test.ts
@@ -1,4 +1,5 @@
 import pg from 'pg';
+import { randomBytes } from 'crypto';
 import { createPostgresAdapter, PostgresAdapter } from '../src/database/postgres.js';
 import type { Job } from '../src/types.js';
 
@@ -28,6 +29,7 @@ function jobData(overrides: Partial<Omit<Job, 'id' | 'insertedAt'>> = {}): Omit<
     scheduledAt: new Date(),
     attemptedAt: null,
     attemptedBy: null,
+    uniqueKey: null,
     completedAt: null,
     discardedAt: null,
     cancelledAt: null,
@@ -144,5 +146,115 @@ describePostgres('PostgresAdapter', () => {
     await adapter.removeNode('node-a');
     const after = await pool.query('SELECT name FROM izi_nodes');
     expect(after.rows).toHaveLength(0);
+  });
+
+  describe('unique jobs', () => {
+    const unique = { period: 60 };
+
+    it('inserts only one job when many nodes race on the same unique job', async () => {
+      // The real failure mode: concurrent inserts on separate connections, each
+      // seeing "no conflict" before any of them has committed.
+      const attempts = 20;
+      const results = await Promise.all(
+        Array.from({ length: attempts }, () =>
+          adapter.insertUnique(jobData({ args: { userId: 7 } }), unique)
+        )
+      );
+
+      const inserted = results.filter((r) => !r.conflict);
+      const conflicted = results.filter((r) => r.conflict);
+
+      expect(inserted).toHaveLength(1);
+      expect(conflicted).toHaveLength(attempts - 1);
+
+      const { rows } = await pool.query('SELECT COUNT(*)::int AS count FROM izi_jobs');
+      expect(rows[0].count).toBe(1);
+
+      // Every caller gets a usable job back, and they all point at the same row.
+      const ids = new Set(results.map((r) => r.job.id));
+      expect(ids.size).toBe(1);
+    });
+
+    it('does not conflate distinct unique jobs inserted concurrently', async () => {
+      const results = await Promise.all(
+        Array.from({ length: 10 }, (_, i) =>
+          adapter.insertUnique(jobData({ args: { userId: i } }), unique)
+        )
+      );
+
+      expect(results.filter((r) => r.conflict)).toHaveLength(0);
+      const { rows } = await pool.query('SELECT COUNT(*)::int AS count FROM izi_jobs');
+      expect(rows[0].count).toBe(10);
+    });
+
+    it('treats args differing only in key order as the same job', async () => {
+      const first = await adapter.insertUnique(jobData({ args: { a: 1, b: 2 } }), unique);
+      const second = await adapter.insertUnique(jobData({ args: { b: 2, a: 1 } }), unique);
+
+      expect(first.conflict).toBe(false);
+      expect(second.conflict).toBe(true);
+      expect(second.job.id).toBe(first.job.id);
+    });
+
+    it('ignores jobs outside the uniqueness period', async () => {
+      const first = await adapter.insertUnique(jobData({ args: { userId: 1 } }), unique);
+      await pool.query(`UPDATE izi_jobs SET inserted_at = NOW() - INTERVAL '1 hour'`);
+
+      const second = await adapter.insertUnique(jobData({ args: { userId: 1 } }), unique);
+
+      expect(second.conflict).toBe(false);
+      expect(second.job.id).not.toBe(first.job.id);
+    });
+
+    it('ignores jobs in states outside the configured set', async () => {
+      await adapter.insertUnique(jobData({ args: { userId: 1 } }), unique);
+      await pool.query(`UPDATE izi_jobs SET state = 'completed'`);
+
+      const second = await adapter.insertUnique(jobData({ args: { userId: 1 } }), unique);
+
+      expect(second.conflict).toBe(false);
+    });
+
+    it('accepts payloads far larger than a btree index entry', async () => {
+      // Incompressible, so it cannot slip under the limit by being TOASTed.
+      const blob = randomBytes(4000).toString('base64');
+
+      const result = await adapter.insertUnique(jobData({ args: { blob } }), unique);
+
+      expect(result.conflict).toBe(false);
+      expect(((await adapter.getJob(result.job.id))?.args as { blob: string }).blob).toHaveLength(
+        blob.length
+      );
+    });
+
+    it('accepts a large payload on a plain insert too', async () => {
+      const blob = randomBytes(4000).toString('base64');
+
+      const job = await adapter.insertJob(jobData({ args: { blob } }));
+
+      expect(job.id).toBeGreaterThan(0);
+    });
+  });
+
+  describe('concurrent migrations', () => {
+    it('lets several nodes migrate at once without failing', async () => {
+      await pool.query('DROP TABLE IF EXISTS izi_jobs, izi_nodes, izi_migrations');
+
+      const pools = Array.from({ length: 4 }, () => new pg.Pool({ connectionString: CONNECTION_STRING }));
+      try {
+        const results = await Promise.allSettled(
+          pools.map((p) => createPostgresAdapter(p).migrate())
+        );
+
+        const rejected = results.filter((r) => r.status === 'rejected');
+        expect(rejected).toHaveLength(0);
+
+        const { rows } = await pool.query('SELECT version FROM izi_migrations ORDER BY version');
+        const versions = rows.map((r) => Number(r.version));
+        expect(new Set(versions).size).toBe(versions.length);
+      } finally {
+        await Promise.all(pools.map((p) => p.end()));
+      }
+    });
   });
 });

--- a/tests/queue.test.ts
+++ b/tests/queue.test.ts
@@ -50,6 +50,7 @@ describe('Queue Class', () => {
       scheduledAt: new Date(),
       attemptedAt: null,
       attemptedBy: null,
+    uniqueKey: null,
       completedAt: null,
       discardedAt: null,
       cancelledAt: null,

--- a/tests/rescue.test.ts
+++ b/tests/rescue.test.ts
@@ -17,6 +17,7 @@ function jobData(overrides: Partial<Job> = {}): Omit<Job, 'id' | 'insertedAt'> {
     scheduledAt: new Date(),
     attemptedAt: null,
     attemptedBy: null,
+    uniqueKey: null,
     completedAt: null,
     discardedAt: null,
     cancelledAt: null,

--- a/tests/sqlite-adapter.test.ts
+++ b/tests/sqlite-adapter.test.ts
@@ -1,6 +1,6 @@
 import Database from 'better-sqlite3';
 import { createSQLiteAdapter } from '../src/database/sqlite.js';
-import type { Job, JobState } from '../src/types.js';
+import type { Job, JobState, UniqueOptions } from '../src/types.js';
 
 describe('SQLiteAdapter', () => {
   let db: Database.Database;
@@ -31,6 +31,7 @@ describe('SQLiteAdapter', () => {
       scheduledAt: new Date(),
       attemptedAt: null,
       attemptedBy: null,
+    uniqueKey: null,
       completedAt: null,
       discardedAt: null,
       cancelledAt: null,
@@ -490,116 +491,101 @@ describe('SQLiteAdapter', () => {
     });
   });
 
-  describe('checkUnique', () => {
-    it('should find existing job with same args', async () => {
-      const inserted = await adapter.insertJob(createJobData({
-        worker: 'UniqueWorker',
-        args: { userId: 123 }
-      }));
+  describe('unique jobs', () => {
+    // Uniqueness is keyed on a digest stored at insert time, so a job only
+    // participates if it was itself inserted through insertUnique. A job
+    // enqueued without unique options is not unique-tracked.
+    const unique: UniqueOptions = { period: 60 };
 
-      const jobData = createJobData({
-        worker: 'UniqueWorker',
-        args: { userId: 123 }
-      });
+    async function insertUnique(
+      overrides: Partial<Omit<Job, 'id' | 'insertedAt'>> = {},
+      options: UniqueOptions = unique
+    ): Promise<{ job: Job; conflict: boolean }> {
+      return adapter.insertUnique(
+        createJobData({ worker: 'UniqueWorker', args: { userId: 123 }, ...overrides }),
+        options
+      );
+    }
 
-      const existing = await adapter.checkUnique({ period: 60 }, jobData);
+    it('conflicts with an equivalent unique job', async () => {
+      const first = await insertUnique();
+      const second = await insertUnique();
 
-      expect(existing).not.toBeNull();
-      expect(existing?.id).toBe(inserted.id);
+      expect(first.conflict).toBe(false);
+      expect(second.conflict).toBe(true);
+      expect(second.job.id).toBe(first.job.id);
     });
 
-    it('should not find job with different args', async () => {
-      await adapter.insertJob(createJobData({
-        worker: 'UniqueWorker',
-        args: { userId: 123 }
-      }));
+    it('does not conflict when args differ', async () => {
+      await insertUnique();
+      const other = await insertUnique({ args: { userId: 456 } });
 
-      const jobData = createJobData({
-        worker: 'UniqueWorker',
-        args: { userId: 456 }
-      });
-
-      const existing = await adapter.checkUnique({ period: 60 }, jobData);
-
-      expect(existing).toBeNull();
+      expect(other.conflict).toBe(false);
     });
 
-    it('should check only specified keys', async () => {
-      await adapter.insertJob(createJobData({
-        worker: 'UniqueWorker',
-        args: { userId: 123, timestamp: 1000 }
-      }));
+    it('ignores key order within args', async () => {
+      const first = await insertUnique({ args: { a: 1, b: 2 } });
+      const second = await insertUnique({ args: { b: 2, a: 1 } });
 
-      const jobData = createJobData({
-        worker: 'UniqueWorker',
-        args: { userId: 123, timestamp: 2000 }
-      });
+      expect(second.conflict).toBe(true);
+      expect(second.job.id).toBe(first.job.id);
+    });
 
-      const existing = await adapter.checkUnique(
-        { period: 60, keys: ['userId'] },
-        jobData
+    it('compares only the specified keys', async () => {
+      const options = { period: 60, keys: ['userId'] };
+      await insertUnique({ args: { userId: 1, extra: 'a' } }, options);
+      const second = await insertUnique({ args: { userId: 1, extra: 'b' } }, options);
+
+      expect(second.conflict).toBe(true);
+    });
+
+    it('does not track jobs inserted without unique options', async () => {
+      // Deliberate: uniqueness is a property of how a job was enqueued.
+      await adapter.insertJob(createJobData({ worker: 'UniqueWorker', args: { userId: 123 } }));
+
+      const result = await insertUnique();
+
+      expect(result.conflict).toBe(false);
+    });
+
+    it('respects the period', async () => {
+      const first = await insertUnique();
+      db.prepare(`UPDATE izi_jobs SET inserted_at = datetime('now', '-10 minutes') WHERE id = ?`).run(
+        first.job.id
       );
 
-      expect(existing).not.toBeNull();
+      expect((await insertUnique({}, { period: 300 })).conflict).toBe(false);
+
+      db.prepare('DELETE FROM izi_jobs WHERE id != ?').run(first.job.id);
+      expect((await insertUnique({}, { period: 900 })).conflict).toBe(true);
     });
 
-    it('should respect period constraint', async () => {
-      // Insert a job 10 minutes ago
-      db.prepare(`
-        INSERT INTO izi_jobs (state, queue, worker, args, inserted_at)
-        VALUES ('available', 'default', 'UniqueWorker', '{"userId":123}', datetime('now', '-10 minutes'))
-      `).run();
+    it('respects the configured states', async () => {
+      const first = await insertUnique();
+      db.prepare(`UPDATE izi_jobs SET state = 'completed' WHERE id = ?`).run(first.job.id);
 
-      const jobData = createJobData({
-        worker: 'UniqueWorker',
-        args: { userId: 123 }
-      });
+      expect((await insertUnique()).conflict).toBe(false);
 
-      // Check with 5 minute period - should not find
-      const existing5min = await adapter.checkUnique({ period: 300 }, jobData);
-      expect(existing5min).toBeNull();
-
-      // Check with 15 minute period - should find
-      const existing15min = await adapter.checkUnique({ period: 900 }, jobData);
-      expect(existing15min).not.toBeNull();
+      db.prepare('DELETE FROM izi_jobs WHERE id != ?').run(first.job.id);
+      expect((await insertUnique({}, { period: 60, states: ['completed'] })).conflict).toBe(true);
     });
 
-    it('should check specified states', async () => {
-      db.prepare(`
-        INSERT INTO izi_jobs (state, queue, worker, args)
-        VALUES ('completed', 'default', 'UniqueWorker', '{"userId":123}')
-      `).run();
-
-      const jobData = createJobData({
-        worker: 'UniqueWorker',
-        args: { userId: 123 }
-      });
-
-      // Default states don't include completed
-      const existingDefault = await adapter.checkUnique({ period: 60 }, jobData);
-      expect(existingDefault).toBeNull();
-
-      // Explicitly include completed
-      const existingWithCompleted = await adapter.checkUnique(
-        { period: 60, states: ['completed'] },
-        jobData
+    it('treats an infinite period as unbounded', async () => {
+      const first = await insertUnique();
+      db.prepare(`UPDATE izi_jobs SET inserted_at = datetime('now', '-365 days') WHERE id = ?`).run(
+        first.job.id
       );
-      expect(existingWithCompleted).not.toBeNull();
+
+      expect((await insertUnique({}, { period: 'infinity' })).conflict).toBe(true);
     });
 
-    it('should handle infinity period', async () => {
-      db.prepare(`
-        INSERT INTO izi_jobs (state, queue, worker, args, inserted_at)
-        VALUES ('available', 'default', 'UniqueWorker', '{"userId":123}', datetime('now', '-365 days'))
-      `).run();
+    it('accepts payloads far larger than a btree index entry', async () => {
+      const blob = 'x'.repeat(20000);
 
-      const jobData = createJobData({
-        worker: 'UniqueWorker',
-        args: { userId: 123 }
-      });
+      const result = await insertUnique({ args: { blob } });
 
-      const existing = await adapter.checkUnique({ period: 'infinity' }, jobData);
-      expect(existing).not.toBeNull();
+      expect(result.conflict).toBe(false);
+      expect(((await adapter.getJob(result.job.id))?.args as { blob: string }).blob).toHaveLength(20000);
     });
   });
 

--- a/tests/unique-key.test.ts
+++ b/tests/unique-key.test.ts
@@ -1,0 +1,148 @@
+import { computeUniqueKey, advisoryLockKey } from '../src/core/unique.js';
+import type { Job, UniqueOptions } from '../src/types.js';
+
+function job(overrides: Partial<Job> = {}): Omit<Job, 'id' | 'insertedAt'> {
+  return {
+    state: 'available',
+    queue: 'default',
+    worker: 'SendEmail',
+    args: {},
+    meta: {},
+    tags: [],
+    errors: [],
+    attempt: 0,
+    maxAttempts: 20,
+    priority: 0,
+    scheduledAt: new Date(),
+    attemptedAt: null,
+    attemptedBy: null,
+    completedAt: null,
+    discardedAt: null,
+    cancelledAt: null,
+    ...overrides,
+  } as Omit<Job, 'id' | 'insertedAt'>;
+}
+
+const DEFAULTS: UniqueOptions = {};
+
+describe('computeUniqueKey', () => {
+  it('is stable for identical jobs', () => {
+    const a = computeUniqueKey(job({ args: { userId: 1 } }), DEFAULTS);
+    const b = computeUniqueKey(job({ args: { userId: 1 } }), DEFAULTS);
+
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]+$/);
+  });
+
+  it('ignores key order in args', () => {
+    const a = computeUniqueKey(job({ args: { a: 1, b: 2 } }), DEFAULTS);
+    const b = computeUniqueKey(job({ args: { b: 2, a: 1 } }), DEFAULTS);
+
+    expect(a).toBe(b);
+  });
+
+  it('ignores key order in nested objects', () => {
+    const a = computeUniqueKey(job({ args: { o: { x: 1, y: 2 }, z: 3 } }), DEFAULTS);
+    const b = computeUniqueKey(job({ args: { z: 3, o: { y: 2, x: 1 } } }), DEFAULTS);
+
+    expect(a).toBe(b);
+  });
+
+  it('preserves array order, which is significant', () => {
+    const a = computeUniqueKey(job({ args: { items: [1, 2] } }), DEFAULTS);
+    const b = computeUniqueKey(job({ args: { items: [2, 1] } }), DEFAULTS);
+
+    expect(a).not.toBe(b);
+  });
+
+  it('distinguishes different args', () => {
+    const a = computeUniqueKey(job({ args: { userId: 1 } }), DEFAULTS);
+    const b = computeUniqueKey(job({ args: { userId: 2 } }), DEFAULTS);
+
+    expect(a).not.toBe(b);
+  });
+
+  it('distinguishes a numeric value from its string form', () => {
+    const a = computeUniqueKey(job({ args: { id: 1 } }), DEFAULTS);
+    const b = computeUniqueKey(job({ args: { id: '1' } }), DEFAULTS);
+
+    expect(a).not.toBe(b);
+  });
+
+  it('distinguishes workers and queues by default', () => {
+    const base = computeUniqueKey(job(), DEFAULTS);
+
+    expect(computeUniqueKey(job({ worker: 'Other' }), DEFAULTS)).not.toBe(base);
+    expect(computeUniqueKey(job({ queue: 'other' }), DEFAULTS)).not.toBe(base);
+  });
+
+  it('honours a narrowed field set', () => {
+    const opts: UniqueOptions = { fields: ['worker'] };
+
+    expect(computeUniqueKey(job({ queue: 'a', args: { x: 1 } }), opts)).toBe(
+      computeUniqueKey(job({ queue: 'b', args: { x: 2 } }), opts)
+    );
+  });
+
+  it('honours selected arg keys and ignores the rest', () => {
+    const opts: UniqueOptions = { keys: ['userId'] };
+
+    expect(computeUniqueKey(job({ args: { userId: 1, at: 'noon' } }), opts)).toBe(
+      computeUniqueKey(job({ args: { userId: 1, at: 'midnight' } }), opts)
+    );
+    expect(computeUniqueKey(job({ args: { userId: 1 } }), opts)).not.toBe(
+      computeUniqueKey(job({ args: { userId: 2 } }), opts)
+    );
+  });
+
+  it('treats a missing selected key as distinct from a present one', () => {
+    const opts: UniqueOptions = { keys: ['userId'] };
+
+    expect(computeUniqueKey(job({ args: {} }), opts)).not.toBe(
+      computeUniqueKey(job({ args: { userId: 1 } }), opts)
+    );
+  });
+
+  it('is not affected by the order selected keys are listed in', () => {
+    expect(computeUniqueKey(job({ args: { a: 1, b: 2 } }), { keys: ['a', 'b'] })).toBe(
+      computeUniqueKey(job({ args: { a: 1, b: 2 } }), { keys: ['b', 'a'] })
+    );
+  });
+
+  it('treats SQL metacharacters in key names as ordinary text', () => {
+    // Keys are hashed in JS and never reach SQL, so an injection payload is
+    // just another key name. It must not collide with the benign key either.
+    const evil = "x') OR 1=1 --";
+    const opts: UniqueOptions = { keys: [evil] };
+
+    const key = computeUniqueKey(job({ args: { [evil]: 'v' } }), opts);
+
+    expect(key).toMatch(/^[0-9a-f]+$/);
+    expect(key).not.toBe(computeUniqueKey(job({ args: { x: 'v' } }), { keys: ['x'] }));
+  });
+
+  it('produces a key short enough for a MySQL lock name', () => {
+    // GET_LOCK names are capped at 64 characters.
+    expect(computeUniqueKey(job(), DEFAULTS).length).toBeLessThanOrEqual(64);
+  });
+});
+
+describe('advisoryLockKey', () => {
+  it('maps a unique key onto a stable signed 64-bit integer', () => {
+    const key = computeUniqueKey(job({ args: { userId: 1 } }), DEFAULTS);
+
+    const a = advisoryLockKey(key);
+    const b = advisoryLockKey(key);
+
+    expect(a).toBe(b);
+    expect(BigInt(a)).toBeGreaterThanOrEqual(-(2n ** 63n));
+    expect(BigInt(a)).toBeLessThan(2n ** 63n);
+  });
+
+  it('separates different unique keys', () => {
+    const a = advisoryLockKey(computeUniqueKey(job({ args: { userId: 1 } }), DEFAULTS));
+    const b = advisoryLockKey(computeUniqueKey(job({ args: { userId: 2 } }), DEFAULTS));
+
+    expect(a).not.toBe(b);
+  });
+});

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -28,6 +28,7 @@ function createMockJob(overrides: Partial<Job> = {}): Job {
     scheduledAt: new Date(),
     attemptedAt: new Date(),
     attemptedBy: null,
+    uniqueKey: null,
     completedAt: null,
     discardedAt: null,
     cancelledAt: null,


### PR DESCRIPTION
Closes #18, #19, #20, #25, #45.

Five defects that all reduce to the same thing: inserts and migrations weren't safe when more than one thing runs at once.

## The central change

Unique keys are now derived **in JavaScript** from a canonicalized digest of the configured fields, instead of being assembled into SQL at query time. That one change addresses four issues at once.

### #18 — SQL injection via `unique.keys`

Key names were interpolated straight into the query in all three adapters (`args->>'${key}'`). They no longer reach SQL at all, so the vector is **removed** rather than parameterised.

### #45 — adapters disagreed on what a duplicate is

SQLite compared serialized JSON, so `{a:1,b:2}` and `{b:2,a:1}` were different jobs. PostgreSQL compared JSONB and considered them identical. Every adapter now agrees, because comparison happens on a canonical digest computed before the query.

### #20 — large payloads could not be inserted at all

A btree index covered the raw `args` column. Verified previously against PostgreSQL 16: ~5KB of incompressible data failed with `index row size 5376 exceeds btree version 4 maximum 2704`. The index now covers a fixed-width digest.

### #19 — unique jobs were not unique

The check and the insert were separate statements with no lock. I measured the old path against PostgreSQL before fixing it:

```
old check-then-insert : 3 rows from 20 concurrent inserts   <- RACE
new insertUnique      : 1 rows from 20 concurrent inserts   <- correct
```

Atomicity is per dialect: `pg_advisory_xact_lock` on PostgreSQL, `GET_LOCK` on MySQL, and an **immediate** transaction on SQLite — a deferred one starts as a reader and gets refused the upgrade rather than waiting.

## #25 — migrations

Concurrent boots both saw the same version missing, both applied it, and the second died on the primary key, so a rolling deploy could kill a fresh node. Migrations now hold an advisory lock. Verified:

```
6 nodes migrating simultaneously -> 0 failures
migrations applied: 1,2,3,4,5,6,7
```

Migration SQL is also declared as **arrays of statements** rather than split on `;`, which would have torn apart the first migration containing a function body, a trigger, or a semicolon inside a string literal.

## Breaking

**Uniqueness now only considers jobs that were themselves inserted with `unique` options.** A job enqueued without them carries no key and no longer blocks a later unique insert. Two unique inserts still deduplicate, and now do so atomically. This matches Oban, where uniqueness is a property of how a job was enqueued — I raised the trade-off explicitly before making the change, and the 7 SQLite tests encoding the old behaviour were rewritten rather than quietly adjusted.

Also: `Job.uniqueKey` is required on the `Job` interface (`uniqueKey: null` for non-unique jobs), and `Migration.up`/`down` are `string[]`. `DatabaseAdapter.insertUnique` is **optional**, so third-party adapters keep compiling and fall back to the previous non-atomic path.

## Verification

**314 tests** against SQLite, PostgreSQL 16 and MySQL 8.4 — up from 283. New coverage includes 20-way and 15-way concurrent unique inserts on PostgreSQL and MySQL, concurrent migrations on both, canonical-form equivalence, period and state windows, and oversized payloads.

The race and migration numbers above were produced by running the old code path against a real server, not inferred.