### PR TITLE
Enforce job state transitions and correct lifecycle semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,47 @@ While the version is below 1.0.0, breaking changes are released as minor version
 
 ### Fixed
 
+- **Snoozing consumed a retry attempt.** The attempt is claimed at fetch time,
+  and snoozing did not compensate, so a job that snoozed while waiting on an
+  external condition was eventually discarded having never failed once. Snooze
+  now raises `max_attempts` to match, as Oban does. ([#28])
+- **A finishing worker could resurrect a cancelled job.** Result writes went
+  straight to `updateJob` with no check on the job's current state, so a job
+  cancelled while executing was silently marked completed when its worker
+  returned. Transitions are now arbitrated by the database -- the update only
+  lands if the job is still in a state the transition is legal from, and a
+  refusal emits `job:transition_refused`. The state machine was already declared
+  and unit-tested; it was simply never consulted. ([#35])
+- **Jobs with an unregistered worker were retried for hours.** The outcome is
+  deterministic, so they are now discarded immediately with a
+  `job:unknown_worker` event instead of occupying fetch slots through 20
+  backoffs. ([#33])
+- **The pruner reported deleted rows as completed jobs.** It emitted
+  `job:complete` with no job attached, corrupting any metric counting
+  completions. It now emits `jobs:pruned`. ([#39])
+
+### Added
+
+- `cancelJob(id)` and `retryJob(id)`, plus `retryJobs(criteria)`. Retrying a job
+  that had exhausted its attempts raises `max_attempts` so it can actually run
+  rather than being discarded again on its next fetch. ([#30])
+- Bulk operations accept `ids` and require at least one criterion. `cancelJobs({})`
+  previously cancelled every non-terminal job in the database, which a handler
+  forwarding optional filters would do when called with none of them. Acting on
+  everything now requires an explicit `{ all: true }`. ([#30])
+- `updateJob` accepts an optional list of expected source states.
+- Telemetry: `job:retry`, `job:unknown_worker`, `job:transition_refused`,
+  `jobs:pruned`.
+
+### Breaking
+
+- `cancelJobs({})` now throws instead of cancelling every job. Pass
+  `{ all: true }` for the old behaviour.
+- The pruner no longer emits `job:complete`. Anything counting prune runs
+  through that event should move to `jobs:pruned`.
+
+### Fixed
+
 - **Unique job keys could alter the SQL they were looked up with.** `unique.keys`
   entries were interpolated straight into the query in all three adapters. Keys
   are now hashed in JavaScript and never reach a query, so the injection vector
@@ -173,7 +214,12 @@ production. Anyone running 0.3.0 or earlier should upgrade.
 [#19]: https://github.com/iagocavalcante/izi-queue/issues/19
 [#20]: https://github.com/iagocavalcante/izi-queue/issues/20
 [#25]: https://github.com/iagocavalcante/izi-queue/issues/25
+[#28]: https://github.com/iagocavalcante/izi-queue/issues/28
+[#30]: https://github.com/iagocavalcante/izi-queue/issues/30
+[#33]: https://github.com/iagocavalcante/izi-queue/issues/33
+[#35]: https://github.com/iagocavalcante/izi-queue/issues/35
 [#38]: https://github.com/iagocavalcante/izi-queue/issues/38
+[#39]: https://github.com/iagocavalcante/izi-queue/issues/39
 [#45]: https://github.com/iagocavalcante/izi-queue/issues/45
 [#47]: https://github.com/iagocavalcante/izi-queue/pull/47
 [#50]: https://github.com/iagocavalcante/izi-queue/issues/50

--- a/src/core/izi-queue.ts
+++ b/src/core/izi-queue.ts
@@ -3,6 +3,7 @@ import type {
   IziQueueConfig,
   IsolationConfig,
   Job,
+  JobCriteria,
   JobInsertOptions,
   JobState,
   QueueConfig,
@@ -28,6 +29,27 @@ import { DEFAULT_NODE_TTL } from '../database/adapter.js';
 
 export interface IziQueueFullConfig extends IziQueueConfig {
   plugins?: Plugin[];
+}
+
+/**
+ * Bulk operations must be scoped. An HTTP handler that forwards optional
+ * filters would otherwise act on every job in the database when called with
+ * none of them.
+ */
+function assertScoped(criteria: JobCriteria, operation: string): void {
+  if (criteria.all) return;
+
+  const scoped =
+    (criteria.ids && criteria.ids.length > 0) ||
+    criteria.queue ||
+    criteria.worker ||
+    (criteria.state && criteria.state.length > 0);
+
+  if (!scoped) {
+    throw new Error(
+      `${operation} requires at least one criterion. Pass { all: true } to act on every job.`
+    );
+  }
 }
 
 export interface InsertResult<T = Record<string, unknown>> {
@@ -300,12 +322,39 @@ export class IziQueue {
     return this.config.database.getJob(id);
   }
 
-  async cancelJobs(criteria: {
-    queue?: string;
-    worker?: string;
-    state?: JobState[];
-  }): Promise<number> {
+  async cancelJobs(criteria: JobCriteria): Promise<number> {
+    assertScoped(criteria, 'cancelJobs');
     return this.config.database.cancelJobs(criteria);
+  }
+
+  /** Cancels one job. Returns false if it was already in a terminal state. */
+  async cancelJob(id: number): Promise<boolean> {
+    return (await this.config.database.cancelJobs({ ids: [id] })) > 0;
+  }
+
+  /**
+   * Returns discarded or cancelled jobs to the queue. Jobs that had exhausted
+   * their attempts are given headroom, otherwise they would be discarded again
+   * on the very next fetch.
+   */
+  async retryJobs(criteria: JobCriteria): Promise<number> {
+    assertScoped(criteria, 'retryJobs');
+
+    if (!this.config.database.retryJobs) {
+      throw new Error('The configured database adapter does not support retryJobs');
+    }
+
+    const count = await this.config.database.retryJobs(criteria);
+    if (count > 0) {
+      telemetry.emit('job:retry', { result: { count } });
+      this.queues.forEach(queue => queue.dispatch());
+    }
+    return count;
+  }
+
+  /** Retries one job. Returns false if it was not in a retryable state. */
+  async retryJob(id: number): Promise<boolean> {
+    return (await this.retryJobs({ ids: [id] })) > 0;
   }
 
   async pruneJobs(maxAgeSeconds = 86400 * 7): Promise<number> {

--- a/src/core/job.ts
+++ b/src/core/job.ts
@@ -16,6 +16,18 @@ export function isValidTransition(from: JobState, to: JobState): boolean {
   return STATE_TRANSITIONS[from].includes(to);
 }
 
+/**
+ * The states a job may legally be in for `to` to be reachable. Passed to
+ * `updateJob` so the database refuses an illegal transition, which is the only
+ * place the check can be made safely: the race is between nodes, not within
+ * this process.
+ */
+export function sourceStatesFor(to: JobState): JobState[] {
+  return (Object.keys(STATE_TRANSITIONS) as JobState[]).filter(from =>
+    STATE_TRANSITIONS[from].includes(to)
+  );
+}
+
 export function isTerminal(state: JobState): boolean {
   return TERMINAL_STATES.includes(state);
 }

--- a/src/core/queue.ts
+++ b/src/core/queue.ts
@@ -1,5 +1,5 @@
 import type { DatabaseAdapter, Job, QueueConfig } from '../types.js';
-import { formatError } from './job.js';
+import { formatError, sourceStatesFor } from './job.js';
 import { executeWorker, getBackoffDelay, hasWorker, getWorker, terminateIsolatedJob } from './worker.js';
 import { telemetry } from './telemetry.js';
 
@@ -192,8 +192,10 @@ export class Queue {
     telemetry.emit('job:start', { job, queue: this.name });
 
     if (!hasWorker(job.worker)) {
-      const error = new Error(`Worker "${job.worker}" not registered`);
-      await this.handleError(job, error, startTime);
+      // Deterministic: no number of retries will make the worker appear on this
+      // node, so retrying only occupies fetch slots for hours before the job is
+      // discarded anyway.
+      await this.handleUnknownWorker(job, startTime);
       return;
     }
 
@@ -237,11 +239,54 @@ export class Queue {
     }
   }
 
-  private async handleSuccess(job: Job, result: unknown, duration: number): Promise<void> {
-    await this.database.updateJob(job.id, {
-      state: 'completed',
-      completedAt: new Date()
+  /**
+   * Applies a terminal or scheduling update, letting the database refuse it if
+   * the job has moved on -- cancelled by an operator, or rescued onto another
+   * node. Returns whether the write landed.
+   */
+  private async transition(
+    job: Job,
+    to: Job['state'],
+    updates: Partial<Job>
+  ): Promise<boolean> {
+    const updated = await this.database.updateJob(
+      job.id,
+      { state: to, ...updates },
+      sourceStatesFor(to)
+    );
+
+    if (!updated) {
+      telemetry.emit('job:transition_refused', {
+        job,
+        queue: this.name,
+        result: { to }
+      });
+      return false;
+    }
+
+    return true;
+  }
+
+  private async handleUnknownWorker(job: Job, startTime: number): Promise<void> {
+    const error = new Error(`Worker "${job.worker}" not registered`);
+    const errors = [...job.errors, formatError(error, job.attempt)];
+
+    await this.transition(job, 'discarded', {
+      errors,
+      discardedAt: new Date()
     });
+
+    telemetry.emit('job:unknown_worker', {
+      job: { ...job, state: 'discarded', errors },
+      queue: this.name,
+      duration: Date.now() - startTime,
+      error
+    });
+  }
+
+  private async handleSuccess(job: Job, result: unknown, duration: number): Promise<void> {
+    const applied = await this.transition(job, 'completed', { completedAt: new Date() });
+    if (!applied) return;
 
     telemetry.emit('job:complete', {
       job: { ...job, state: 'completed' },
@@ -256,11 +301,11 @@ export class Queue {
     const newErrors = [...job.errors, formatError(error, job.attempt)];
 
     if (job.attempt >= job.maxAttempts) {
-      await this.database.updateJob(job.id, {
-        state: 'discarded',
+      const applied = await this.transition(job, 'discarded', {
         errors: newErrors,
         discardedAt: new Date()
       });
+      if (!applied) return;
 
       telemetry.emit('job:error', {
         job: { ...job, state: 'discarded', errors: newErrors },
@@ -272,11 +317,11 @@ export class Queue {
       const backoffMs = getBackoffDelay(job);
       const scheduledAt = new Date(Date.now() + backoffMs);
 
-      await this.database.updateJob(job.id, {
-        state: 'retryable',
+      const applied = await this.transition(job, 'retryable', {
         errors: newErrors,
         scheduledAt
       });
+      if (!applied) return;
 
       telemetry.emit('job:error', {
         job: { ...job, state: 'retryable', errors: newErrors },
@@ -290,11 +335,11 @@ export class Queue {
   private async handleCancel(job: Job, reason: string, duration: number): Promise<void> {
     const newErrors = [...job.errors, formatError(new Error(reason), job.attempt)];
 
-    await this.database.updateJob(job.id, {
-      state: 'cancelled',
+    const applied = await this.transition(job, 'cancelled', {
       errors: newErrors,
       cancelledAt: new Date()
     });
+    if (!applied) return;
 
     telemetry.emit('job:cancel', {
       job: { ...job, state: 'cancelled', errors: newErrors },
@@ -306,11 +351,15 @@ export class Queue {
   private async handleSnooze(job: Job, seconds: number, duration: number): Promise<void> {
     const scheduledAt = new Date(Date.now() + seconds * 1000);
 
-    await this.database.updateJob(job.id, {
-      state: 'scheduled',
+    // The attempt was already consumed by the fetch, but a snooze is not a
+    // failure: without compensating, a job that snoozes while waiting on some
+    // external condition is eventually discarded having never failed once.
+    const applied = await this.transition(job, 'scheduled', {
       scheduledAt,
+      maxAttempts: job.maxAttempts + 1,
       meta: { ...job.meta, snoozedAt: new Date().toISOString() }
     });
+    if (!applied) return;
 
     telemetry.emit('job:snooze', {
       job: { ...job, state: 'scheduled' },

--- a/src/database/adapter.ts
+++ b/src/database/adapter.ts
@@ -312,6 +312,38 @@ export const SQL = {
   }
 };
 
+/**
+ * Builds the shared filter for bulk job operations. An empty criteria object is
+ * rejected by the caller rather than silently matching every job.
+ */
+export function criteriaClause(
+  criteria: import('../types.js').JobCriteria,
+  placeholder: (index: number) => string
+): { clause: string; params: unknown[] } {
+  const params: unknown[] = [];
+  let clause = '';
+  let index = 1;
+
+  if (criteria.ids && criteria.ids.length > 0) {
+    clause += ` AND id IN (${criteria.ids.map(() => placeholder(index++)).join(',')})`;
+    params.push(...criteria.ids);
+  }
+  if (criteria.queue) {
+    clause += ` AND queue = ${placeholder(index++)}`;
+    params.push(criteria.queue);
+  }
+  if (criteria.worker) {
+    clause += ` AND worker = ${placeholder(index++)}`;
+    params.push(criteria.worker);
+  }
+  if (criteria.state && criteria.state.length > 0) {
+    clause += ` AND state IN (${criteria.state.map(() => placeholder(index++)).join(',')})`;
+    params.push(...criteria.state);
+  }
+
+  return { clause, params };
+}
+
 export function rowToJob(row: Record<string, unknown>): Job {
   const parseJSON = (val: unknown): unknown => {
     if (typeof val === 'string') {
@@ -357,11 +389,11 @@ export abstract class BaseAdapter implements DatabaseAdapter {
   abstract migrate(): Promise<void>;
   abstract insertJob(job: Omit<Job, 'id' | 'insertedAt'>): Promise<Job>;
   abstract fetchJobs(queue: string, limit: number, node?: string): Promise<Job[]>;
-  abstract updateJob(id: number, updates: Partial<Job>): Promise<Job | null>;
+  abstract updateJob(id: number, updates: Partial<Job>, expectedStates?: JobState[]): Promise<Job | null>;
   abstract getJob(id: number): Promise<Job | null>;
   abstract pruneJobs(maxAge: number): Promise<number>;
   abstract stageJobs(): Promise<number>;
-  abstract cancelJobs(criteria: { queue?: string; worker?: string; state?: JobState[] }): Promise<number>;
+  abstract cancelJobs(criteria: import('../types.js').JobCriteria): Promise<number>;
   abstract rescueStuckJobs(rescueAfter: number, nodeTtl?: number): Promise<number>;
 
   /** Shared predicate for locating an existing unique job. */

--- a/src/database/mysql.ts
+++ b/src/database/mysql.ts
@@ -23,8 +23,8 @@ interface Pool {
   getConnection(): Promise<PoolConnection>;
   end(): Promise<void>;
 }
-import type { Job, JobState, UniqueOptions } from '../types.js';
-import { BaseAdapter, DEFAULT_NODE_TTL, SQL, rowToJob } from './adapter.js';
+import type { Job, JobCriteria, JobState, UniqueOptions } from '../types.js';
+import { BaseAdapter, DEFAULT_NODE_TTL, SQL, criteriaClause, rowToJob } from './adapter.js';
 import { computeUniqueKey } from '../core/unique.js';
 
 /** Arbitrary but fixed: all izi-queue instances must agree on this value. */
@@ -184,8 +184,12 @@ export class MySQLAdapter extends BaseAdapter {
     }
   }
 
-  async updateJob(id: number, updates: Partial<Job>): Promise<Job | null> {
-    await this.pool.query(SQL.mysql.updateJob, [
+  async updateJob(
+    id: number,
+    updates: Partial<Job>,
+    expectedStates?: JobState[]
+  ): Promise<Job | null> {
+    const params: unknown[] = [
       updates.state ?? null,
       updates.errors ? JSON.stringify(updates.errors) : null,
       updates.completedAt ?? null,
@@ -193,9 +197,35 @@ export class MySQLAdapter extends BaseAdapter {
       updates.cancelledAt ?? null,
       updates.scheduledAt ?? null,
       updates.meta ? JSON.stringify(updates.meta) : null,
+      updates.attempt ?? null,
+      updates.maxAttempts ?? null,
       id
-    ]);
+    ];
 
+    let guard = '';
+    if (expectedStates?.length) {
+      guard = ` AND state IN (${expectedStates.map(() => '?').join(',')})`;
+      params.push(...expectedStates);
+    }
+
+    const [result] = await this.pool.query<ResultSetHeader>(
+      `
+        UPDATE izi_jobs
+        SET state = COALESCE(?, state),
+            errors = COALESCE(?, errors),
+            completed_at = COALESCE(?, completed_at),
+            discarded_at = COALESCE(?, discarded_at),
+            cancelled_at = COALESCE(?, cancelled_at),
+            scheduled_at = COALESCE(?, scheduled_at),
+            meta = COALESCE(?, meta),
+            attempt = COALESCE(?, attempt),
+            max_attempts = COALESCE(?, max_attempts)
+        WHERE id = ?${guard}
+      `,
+      params
+    );
+
+    if (result.affectedRows === 0) return null;
     return this.getJob(id);
   }
 
@@ -214,24 +244,31 @@ export class MySQLAdapter extends BaseAdapter {
     return result.affectedRows;
   }
 
-  async cancelJobs(criteria: { queue?: string; worker?: string; state?: JobState[] }): Promise<number> {
-    let sql = SQL.mysql.cancelJobs;
-    const params: unknown[] = [];
+  async cancelJobs(criteria: JobCriteria): Promise<number> {
+    const { clause, params } = criteriaClause(criteria, () => '?');
+    const [result] = await this.pool.query<ResultSetHeader>(
+      `${SQL.mysql.cancelJobs}${clause}`,
+      params
+    );
+    return result.affectedRows;
+  }
 
-    if (criteria.queue) {
-      sql += ' AND queue = ?';
-      params.push(criteria.queue);
-    }
-    if (criteria.worker) {
-      sql += ' AND worker = ?';
-      params.push(criteria.worker);
-    }
-    if (criteria.state && criteria.state.length > 0) {
-      sql += ' AND state IN (?)';
-      params.push(criteria.state);
-    }
-
-    const [result] = await this.pool.query<ResultSetHeader>(sql, params);
+  async retryJobs(criteria: JobCriteria): Promise<number> {
+    const { clause, params } = criteriaClause(criteria, () => '?');
+    // Raising max_attempts matters for jobs discarded after exhausting them:
+    // without headroom the job is discarded again on its very next fetch.
+    const [result] = await this.pool.query<ResultSetHeader>(
+      `
+        UPDATE izi_jobs
+        SET state = 'available',
+            scheduled_at = NOW(6),
+            discarded_at = NULL,
+            cancelled_at = NULL,
+            max_attempts = CASE WHEN attempt >= max_attempts THEN attempt + 1 ELSE max_attempts END
+        WHERE state IN ('discarded', 'cancelled')${clause}
+      `,
+      params
+    );
     return result.affectedRows;
   }
 

--- a/src/database/postgres.ts
+++ b/src/database/postgres.ts
@@ -1,6 +1,6 @@
 import type { Pool, PoolClient } from 'pg';
-import type { Job, JobState, UniqueOptions } from '../types.js';
-import { BaseAdapter, DEFAULT_NODE_TTL, SQL, rowToJob } from './adapter.js';
+import type { Job, JobCriteria, JobState, UniqueOptions } from '../types.js';
+import { BaseAdapter, DEFAULT_NODE_TTL, SQL, criteriaClause, rowToJob } from './adapter.js';
 import { advisoryLockKey, computeUniqueKey } from '../core/unique.js';
 
 /** Arbitrary but fixed: all izi-queue instances must agree on this value. */
@@ -178,8 +178,12 @@ export class PostgresAdapter extends BaseAdapter {
     return result.rows.map(rowToJob);
   }
 
-  async updateJob(id: number, updates: Partial<Job>): Promise<Job | null> {
-    const result = await this.pool.query(SQL.postgres.updateJob, [
+  async updateJob(
+    id: number,
+    updates: Partial<Job>,
+    expectedStates?: JobState[]
+  ): Promise<Job | null> {
+    const params: unknown[] = [
       id,
       updates.state ?? null,
       updates.errors ? JSON.stringify(updates.errors) : null,
@@ -187,8 +191,35 @@ export class PostgresAdapter extends BaseAdapter {
       updates.discardedAt ?? null,
       updates.cancelledAt ?? null,
       updates.scheduledAt ?? null,
-      updates.meta ? JSON.stringify(updates.meta) : null
-    ]);
+      updates.meta ? JSON.stringify(updates.meta) : null,
+      updates.attempt ?? null,
+      updates.maxAttempts ?? null
+    ];
+
+    let guard = '';
+    if (expectedStates?.length) {
+      params.push(expectedStates);
+      guard = ` AND state = ANY($${params.length})`;
+    }
+
+    const result = await this.pool.query(
+      `
+        UPDATE izi_jobs
+        SET state = COALESCE($2, state),
+            errors = COALESCE($3, errors),
+            completed_at = COALESCE($4, completed_at),
+            discarded_at = COALESCE($5, discarded_at),
+            cancelled_at = COALESCE($6, cancelled_at),
+            scheduled_at = COALESCE($7, scheduled_at),
+            meta = COALESCE($8, meta),
+            attempt = COALESCE($9, attempt),
+            max_attempts = COALESCE($10, max_attempts)
+        WHERE id = $1${guard}
+        RETURNING *
+      `,
+      params
+    );
+
     return result.rows[0] ? rowToJob(result.rows[0]) : null;
   }
 
@@ -207,25 +238,31 @@ export class PostgresAdapter extends BaseAdapter {
     return result.rowCount ?? 0;
   }
 
-  async cancelJobs(criteria: { queue?: string; worker?: string; state?: JobState[] }): Promise<number> {
-    let sql = SQL.postgres.cancelJobs;
-    const params: unknown[] = [];
-    let paramIndex = 1;
+  async cancelJobs(criteria: JobCriteria): Promise<number> {
+    const { clause, params } = criteriaClause(criteria, i => `$${i}`);
+    const result = await this.pool.query(
+      `${SQL.postgres.cancelJobs}${clause}`,
+      params
+    );
+    return result.rowCount ?? 0;
+  }
 
-    if (criteria.queue) {
-      sql += ` AND queue = $${paramIndex++}`;
-      params.push(criteria.queue);
-    }
-    if (criteria.worker) {
-      sql += ` AND worker = $${paramIndex++}`;
-      params.push(criteria.worker);
-    }
-    if (criteria.state && criteria.state.length > 0) {
-      sql += ` AND state = ANY($${paramIndex++})`;
-      params.push(criteria.state);
-    }
-
-    const result = await this.pool.query(sql, params);
+  async retryJobs(criteria: JobCriteria): Promise<number> {
+    const { clause, params } = criteriaClause(criteria, i => `$${i}`);
+    // Raising max_attempts matters for jobs discarded after exhausting them:
+    // without headroom the job is discarded again on its very next fetch.
+    const result = await this.pool.query(
+      `
+        UPDATE izi_jobs
+        SET state = 'available',
+            scheduled_at = NOW(),
+            discarded_at = NULL,
+            cancelled_at = NULL,
+            max_attempts = CASE WHEN attempt >= max_attempts THEN attempt + 1 ELSE max_attempts END
+        WHERE state IN ('discarded', 'cancelled')${clause}
+      `,
+      params
+    );
     return result.rowCount ?? 0;
   }
 

--- a/src/database/sqlite.ts
+++ b/src/database/sqlite.ts
@@ -1,6 +1,6 @@
 import type { Database } from 'better-sqlite3';
-import type { Job, JobState, UniqueOptions } from '../types.js';
-import { BaseAdapter, DEFAULT_NODE_TTL, rowToJob } from './adapter.js';
+import type { Job, JobCriteria, JobState, UniqueOptions } from '../types.js';
+import { BaseAdapter, DEFAULT_NODE_TTL, criteriaClause, rowToJob } from './adapter.js';
 import { computeUniqueKey } from '../core/unique.js';
 import { sqliteMigrations } from './migrations.js';
 
@@ -134,7 +134,15 @@ export class SQLiteAdapter extends BaseAdapter {
     return rows.map(rowToJob);
   }
 
-  async updateJob(id: number, updates: Partial<Job>): Promise<Job | null> {
+  async updateJob(
+    id: number,
+    updates: Partial<Job>,
+    expectedStates?: JobState[]
+  ): Promise<Job | null> {
+    const guard = expectedStates?.length
+      ? ` AND state IN (${expectedStates.map(() => '?').join(',')})`
+      : '';
+
     const stmt = this.db.prepare(`
       UPDATE izi_jobs
       SET state = COALESCE(?, state),
@@ -143,11 +151,13 @@ export class SQLiteAdapter extends BaseAdapter {
           discarded_at = COALESCE(?, discarded_at),
           cancelled_at = COALESCE(?, cancelled_at),
           scheduled_at = COALESCE(?, scheduled_at),
-          meta = COALESCE(?, meta)
-      WHERE id = ?
+          meta = COALESCE(?, meta),
+          attempt = COALESCE(?, attempt),
+          max_attempts = COALESCE(?, max_attempts)
+      WHERE id = ?${guard}
     `);
 
-    stmt.run(
+    const result = stmt.run(
       updates.state ?? null,
       updates.errors ? JSON.stringify(updates.errors) : null,
       updates.completedAt?.toISOString() ?? null,
@@ -155,11 +165,17 @@ export class SQLiteAdapter extends BaseAdapter {
       updates.cancelledAt?.toISOString() ?? null,
       updates.scheduledAt?.toISOString() ?? null,
       updates.meta ? JSON.stringify(updates.meta) : null,
-      id
+      updates.attempt ?? null,
+      updates.maxAttempts ?? null,
+      id,
+      ...(expectedStates ?? [])
     );
 
-    const getStmt = this.db.prepare('SELECT * FROM izi_jobs WHERE id = ?');
-    const row = getStmt.get(id) as Record<string, unknown> | undefined;
+    if (result.changes === 0) return null;
+
+    const row = this.db.prepare('SELECT * FROM izi_jobs WHERE id = ?').get(id) as
+      | Record<string, unknown>
+      | undefined;
     return row ? rowToJob(row) : null;
   }
 
@@ -189,30 +205,31 @@ export class SQLiteAdapter extends BaseAdapter {
     return result.changes;
   }
 
-  async cancelJobs(criteria: { queue?: string; worker?: string; state?: JobState[] }): Promise<number> {
-    let sql = `
+  async cancelJobs(criteria: JobCriteria): Promise<number> {
+    const { clause, params } = criteriaClause(criteria, () => '?');
+    const stmt = this.db.prepare(`
       UPDATE izi_jobs
       SET state = 'cancelled', cancelled_at = datetime('now')
-      WHERE state NOT IN ('completed', 'discarded', 'cancelled')
-    `;
-    const params: unknown[] = [];
+      WHERE state NOT IN ('completed', 'discarded', 'cancelled')${clause}
+    `);
+    return stmt.run(...params).changes;
+  }
 
-    if (criteria.queue) {
-      sql += ' AND queue = ?';
-      params.push(criteria.queue);
-    }
-    if (criteria.worker) {
-      sql += ' AND worker = ?';
-      params.push(criteria.worker);
-    }
-    if (criteria.state && criteria.state.length > 0) {
-      sql += ` AND state IN (${criteria.state.map(() => '?').join(',')})`;
-      params.push(...criteria.state);
-    }
-
-    const stmt = this.db.prepare(sql);
-    const result = stmt.run(...params);
-    return result.changes;
+  async retryJobs(criteria: JobCriteria): Promise<number> {
+    const { clause, params } = criteriaClause(criteria, () => '?');
+    // Raising max_attempts matters for jobs that were discarded after
+    // exhausting them: without headroom the job would be discarded again on
+    // its very next fetch.
+    const stmt = this.db.prepare(`
+      UPDATE izi_jobs
+      SET state = 'available',
+          scheduled_at = datetime('now'),
+          discarded_at = NULL,
+          cancelled_at = NULL,
+          max_attempts = CASE WHEN attempt >= max_attempts THEN attempt + 1 ELSE max_attempts END
+      WHERE state IN ('discarded', 'cancelled')${clause}
+    `);
+    return stmt.run(...params).changes;
   }
 
   async rescueStuckJobs(rescueAfter: number, nodeTtl = DEFAULT_NODE_TTL): Promise<number> {

--- a/src/plugins/pruner.ts
+++ b/src/plugins/pruner.ts
@@ -40,9 +40,11 @@ export class PrunerPlugin extends BasePlugin {
       const pruned = await this.context.database.pruneJobs(this.config.maxAge);
 
       if (pruned > 0) {
-        telemetry.emit('job:complete', {
+        // Deliberately not `job:complete`: pruning is maintenance, and counting
+        // deleted rows as completed jobs corrupts any metric built on that event.
+        telemetry.emit('jobs:pruned', {
           result: { pruned, maxAge: this.config.maxAge },
-          queue: 'pruner'
+          queue: this.name
         });
       }
     } catch (error) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,18 @@ export interface UniqueOptions {
   states?: JobState[];
 }
 
+export interface JobCriteria {
+  ids?: number[];
+  queue?: string;
+  worker?: string;
+  state?: JobState[];
+  /**
+   * Required to act on every job. Without it an empty criteria object is
+   * rejected, so a handler forwarding optional filters cannot wipe the queue.
+   */
+  all?: boolean;
+}
+
 export interface JobInsertOptions<T = Record<string, unknown>> {
   args: T;
   queue?: string;
@@ -146,11 +158,19 @@ export interface DatabaseAdapter {
    * abandoned by a dead node from one still running on a live node.
    */
   fetchJobs(queue: string, limit: number, node?: string): Promise<Job[]>;
-  updateJob(id: number, updates: Partial<Job>): Promise<Job | null>;
+  /**
+   * Applies `updates` to a job. When `expectedStates` is given the database
+   * arbitrates the transition: the write only lands if the job is still in one
+   * of those states, and `null` is returned otherwise. That check has to happen
+   * in the database, because the race is between nodes.
+   */
+  updateJob(id: number, updates: Partial<Job>, expectedStates?: JobState[]): Promise<Job | null>;
   getJob(id: number): Promise<Job | null>;
   pruneJobs(maxAge: number): Promise<number>;
   stageJobs(): Promise<number>;
-  cancelJobs(criteria: { queue?: string; worker?: string; state?: JobState[] }): Promise<number>;
+  cancelJobs(criteria: JobCriteria): Promise<number>;
+  /** Returns discarded or cancelled jobs to the queue. */
+  retryJobs?(criteria: JobCriteria): Promise<number>;
   /**
    * Returns jobs abandoned by dead nodes to the queue (or discards them when
    * their attempts are exhausted). `nodeTtl` is how many seconds a node may go
@@ -210,6 +230,10 @@ export type TelemetryEvent =
   | 'job:cancel'
   | 'job:snooze'
   | 'job:rescue'
+  | 'job:retry'
+  | 'job:unknown_worker'
+  | 'job:transition_refused'
+  | 'jobs:pruned'
   | 'job:unique_conflict'
   | 'job:isolated:start'
   | 'job:isolated:timeout'

--- a/tests/lifecycle.test.ts
+++ b/tests/lifecycle.test.ts
@@ -1,0 +1,229 @@
+import Database from 'better-sqlite3';
+import { IziQueue } from '../src/core/izi-queue.js';
+import { defineWorker, WorkerResults, clearWorkers } from '../src/core/worker.js';
+import { createSQLiteAdapter, SQLiteAdapter } from '../src/database/sqlite.js';
+import { telemetry } from '../src/core/telemetry.js';
+import type { Job, TelemetryEvent } from '../src/types.js';
+
+describe('job lifecycle', () => {
+  let db: Database.Database;
+  let adapter: SQLiteAdapter;
+
+  beforeEach(async () => {
+    db = new Database(':memory:');
+    adapter = createSQLiteAdapter(db);
+    await adapter.migrate();
+    clearWorkers();
+    telemetry.off();
+  });
+
+  afterEach(async () => {
+    telemetry.off();
+    await adapter.close();
+  });
+
+  function queueWith(...workers: Parameters<IziQueue['register']>[0][]): IziQueue {
+    const queue = new IziQueue({
+      database: adapter,
+      queues: { default: 5 },
+      stageInterval: 50,
+      pollInterval: 50,
+    });
+    workers.forEach((w) => queue.register(w));
+    return queue;
+  }
+
+  function events(): TelemetryEvent[] {
+    const seen: TelemetryEvent[] = [];
+    telemetry.on('*', ({ event }) => seen.push(event));
+    return seen;
+  }
+
+  describe('snooze', () => {
+    it('does not consume a retry attempt', async () => {
+      let calls = 0;
+      const queue = queueWith(
+        defineWorker('snoozer', async () => {
+          calls++;
+          if (calls <= 3) return WorkerResults.snooze(0);
+          return WorkerResults.ok();
+        })
+      );
+
+      await queue.start();
+      const job = await queue.insert('snoozer', { args: {}, maxAttempts: 2 });
+      await new Promise((r) => setTimeout(r, 1500));
+      const final = await queue.getJob(job.id);
+      await queue.stop();
+
+      // Snoozing three times with maxAttempts: 2 must not exhaust the job.
+      expect(calls).toBe(4);
+      expect(final?.state).toBe('completed');
+    }, 20000);
+
+    it('leaves the effective retry budget intact after snoozing', async () => {
+      const queue = queueWith(
+        defineWorker('snooze_once', async () => WorkerResults.snooze(60))
+      );
+
+      await queue.start();
+      const job = await queue.insert('snooze_once', { args: {}, maxAttempts: 5 });
+      await new Promise((r) => setTimeout(r, 400));
+      const snoozed = await queue.getJob(job.id);
+      await queue.stop();
+
+      expect(snoozed?.state).toBe('scheduled');
+      // One attempt was consumed by the fetch, so the budget is raised to
+      // compensate: the job still has its original five real attempts.
+      expect(snoozed!.maxAttempts - snoozed!.attempt).toBe(5);
+    }, 20000);
+  });
+
+  describe('unknown workers', () => {
+    it('discards the job immediately instead of retrying it', async () => {
+      const queue = queueWith();
+      const seen = events();
+
+      await queue.start();
+      const job = await queue.insert('NeverRegistered', { args: {} });
+      await new Promise((r) => setTimeout(r, 400));
+      const final = await queue.getJob(job.id);
+      await queue.stop();
+
+      expect(final?.state).toBe('discarded');
+      expect(final?.errors).toHaveLength(1);
+      expect(final?.errors[0].error).toContain('NeverRegistered');
+      expect(seen).toContain('job:unknown_worker');
+    }, 20000);
+  });
+
+  describe('state transitions', () => {
+    it('does not let a finishing worker resurrect a cancelled job', async () => {
+      let release: (() => void) | undefined;
+      const gate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+
+      const queue = queueWith(
+        defineWorker('slow', async () => {
+          await gate;
+          return WorkerResults.ok();
+        })
+      );
+
+      await queue.start();
+      const job = await queue.insert('slow', { args: {} });
+      await new Promise((r) => setTimeout(r, 300)); // let it start executing
+
+      expect((await queue.getJob(job.id))?.state).toBe('executing');
+      await queue.cancelJobs({ queue: 'default' });
+      expect((await queue.getJob(job.id))?.state).toBe('cancelled');
+
+      release!();
+      await new Promise((r) => setTimeout(r, 300));
+      const final = await queue.getJob(job.id);
+      await queue.stop();
+
+      // The worker succeeded, but the job was already cancelled. Completing it
+      // now would silently undo the cancellation.
+      expect(final?.state).toBe('cancelled');
+    }, 20000);
+
+    it('refuses an update whose source state does not allow it', async () => {
+      const job = await adapter.insertJob({
+        state: 'completed',
+        queue: 'default',
+        worker: 'W',
+        args: {},
+        meta: {},
+        tags: [],
+        errors: [],
+        attempt: 1,
+        maxAttempts: 20,
+        priority: 0,
+        scheduledAt: new Date(),
+        attemptedAt: null,
+        attemptedBy: null,
+        uniqueKey: null,
+        completedAt: null,
+        discardedAt: null,
+        cancelledAt: null,
+      } as Omit<Job, 'id' | 'insertedAt'>);
+
+      const refused = await adapter.updateJob(job.id, { state: 'executing' }, ['available']);
+
+      expect(refused).toBeNull();
+      expect((await adapter.getJob(job.id))?.state).toBe('completed');
+    });
+  });
+
+  describe('cancel and retry', () => {
+    it('cancels a single job by id', async () => {
+      const queue = queueWith();
+      const keep = await queue.insert('W', { args: { n: 1 } });
+      const drop = await queue.insert('W', { args: { n: 2 } });
+
+      const cancelled = await queue.cancelJob(drop.id);
+
+      expect(cancelled).toBe(true);
+      expect((await queue.getJob(drop.id))?.state).toBe('cancelled');
+      expect((await queue.getJob(keep.id))?.state).toBe('available');
+    });
+
+    it('refuses to cancel everything unless asked explicitly', async () => {
+      const queue = queueWith();
+      const job = await queue.insert('W', { args: {} });
+
+      await expect(queue.cancelJobs({})).rejects.toThrow(/criteri/i);
+      // The rejected call must not have touched anything.
+      expect((await queue.getJob(job.id))?.state).toBe('available');
+
+      const cancelled = await queue.cancelJobs({ all: true });
+      expect(cancelled).toBe(1);
+      expect((await queue.getJob(job.id))?.state).toBe('cancelled');
+    });
+
+    it('returns a discarded job to the queue', async () => {
+      const queue = queueWith();
+      const job = await queue.insert('W', { args: {}, maxAttempts: 1 });
+      await adapter.updateJob(job.id, { state: 'discarded', discardedAt: new Date() });
+
+      const retried = await queue.retryJob(job.id);
+
+      expect(retried).toBe(true);
+      const after = await queue.getJob(job.id);
+      expect(after?.state).toBe('available');
+      // A job that exhausted its attempts needs headroom to run again.
+      expect(after!.maxAttempts).toBeGreaterThan(after!.attempt);
+    });
+
+    it('does not retry a job that is still runnable', async () => {
+      const queue = queueWith();
+      const job = await queue.insert('W', { args: {} });
+
+      expect(await queue.retryJob(job.id)).toBe(false);
+      expect((await queue.getJob(job.id))?.state).toBe('available');
+    });
+  });
+
+  describe('pruner telemetry', () => {
+    it('does not report pruned rows as completed jobs', async () => {
+      const { PrunerPlugin } = await import('../src/plugins/pruner.js');
+      const seen = events();
+
+      db.prepare(
+        `INSERT INTO izi_jobs (state, queue, worker, args, completed_at)
+         VALUES ('completed', 'default', 'W', '{}', datetime('now', '-2 days'))`
+      ).run();
+
+      const pruner = new PrunerPlugin({ interval: 60000, maxAge: 3600 });
+      await pruner.start({ database: adapter, node: 'node-1', queues: ['default'] });
+      await new Promise((r) => setTimeout(r, 50));
+      await (pruner as unknown as { prune(): Promise<void> }).prune();
+      await pruner.stop();
+
+      expect(seen).not.toContain('job:complete');
+      expect(seen).toContain('jobs:pruned');
+    }, 20000);
+  });
+});

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -386,12 +386,16 @@ describe('Plugins', () => {
         await plugin.stop();
       });
 
-      it('should emit job:complete event when pruning jobs', async () => {
+      it('should emit jobs:pruned event when pruning jobs', async () => {
         const events: any[] = [];
-        const unsubscribe = telemetry.on('job:complete', (payload) => {
-          if (payload.queue === 'pruner') {
-            events.push(payload);
-          }
+        // Maintenance gets its own event: counting deleted rows as completed
+        // jobs would corrupt any metric built on job:complete.
+        const unsubscribe = telemetry.on('jobs:pruned', (payload) => {
+          events.push(payload);
+        });
+        const completed: any[] = [];
+        const unsubscribeCompleted = telemetry.on('job:complete', (payload) => {
+          completed.push(payload);
         });
 
         // Insert old completed job
@@ -412,8 +416,10 @@ describe('Plugins', () => {
 
         expect(events.length).toBeGreaterThan(0);
         expect(events[0].result.pruned).toBe(1);
+        expect(completed).toHaveLength(0);
 
         unsubscribe();
+        unsubscribeCompleted();
         await plugin.stop();
       });
     });


### PR DESCRIPTION
Closes #28, #33, #35, #39. Advances #30 without closing it.

> **Stacked on #53** — the base is that branch, not `main`, because both batches touch the same files. Merge #53 first and this retargets to `main` automatically.

## #35 — a finishing worker could resurrect a cancelled job

Result writes went straight to `updateJob` with no check on the job's current state. So an operator cancels a job that is mid-flight, the worker returns a moment later, and the job is silently marked **completed** — the cancellation quietly undone.

The state machine was already declared, exported, and unit-tested. It was simply never consulted by anything. Transitions are now arbitrated by the database, which is the only place the check is safe since the race is between nodes:

```sql
UPDATE izi_jobs SET state = 'completed' ... WHERE id = $1 AND state = ANY($n)
```

Zero rows means the transition was refused, which emits `job:transition_refused` rather than silently winning. Verified against PostgreSQL 16:

```
cancelled job -> complete : refused=true  state=cancelled
unguarded update          : applied=true  state=completed   (still backwards compatible)
```

## #28 — snoozing consumed a retry attempt

The attempt is claimed at fetch time and snooze never compensated, so a job snoozing while it waits on an external condition — the entire point of snooze — was eventually **discarded having never failed once**. With `maxAttempts: 2`, three snoozes killed it. Snooze now raises `max_attempts` to match, as Oban does.

## #33 — unregistered workers were retried for hours

No number of retries makes a worker appear on a node. Those jobs now discard immediately with a `job:unknown_worker` event instead of occupying fetch slots through 20 backoffs.

## #39 — the pruner reported deleted rows as completed jobs

It emitted `job:complete` with no job attached. The README's own telemetry example (`queue.on('*', ...)`) would count prune runs as completed jobs with `worker: undefined`. Now `jobs:pruned`.

## Job control (#30, partial)

- `cancelJob(id)`, `retryJob(id)`, `retryJobs(criteria)`
- Retrying an exhausted job raises `max_attempts`, otherwise it is discarded again on its very next fetch — verified: `state=available attempt=3 maxAttempts=4 runnable=true`
- **`cancelJobs({})` now throws.** It previously cancelled every non-terminal job in the database, which is exactly what an HTTP handler forwarding optional query filters does when called with none of them. Acting on everything needs `{ all: true }`.

**What #30 still wants:** cancelling does not interrupt a job mid-flight. The worker runs to completion and its result is then refused — better than before, but real interruption needs an `AbortSignal` threaded through `perform`. #30 stays open for that.

## Breaking

- `cancelJobs({})` throws instead of cancelling everything. Pass `{ all: true }` for the old behaviour.
- The pruner no longer emits `job:complete`; move to `jobs:pruned`.

## Verification

**324 tests** against SQLite, PostgreSQL 16 and MySQL 8.4. Two existing tests encoded the buggy behaviour and were rewritten rather than quietly adjusted — the pruner's `job:complete` assertion, which was asserting the defect itself.

One boundary worth naming: the empty-criteria guard lives in `IziQueue`, not the adapters. `adapter.cancelJobs({})` is still an unguarded primitive, which seems right for a lower-level interface, but anyone driving an adapter directly does not get the safety net.