### PR TITLE
Add CI and make the test suite deterministic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,125 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint and typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+      - run: npx tsc --noEmit
+
+  test:
+    name: Test (Node ${{ matrix.node }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [18, 20, 22, 24]
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_PASSWORD: izi
+          POSTGRES_DB: izi
+        ports: ['5432:5432']
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_ROOT_PASSWORD: izi
+          MYSQL_DATABASE: izi
+        ports: ['3306:3306']
+        options: >-
+          --health-cmd "mysqladmin ping -h 127.0.0.1 -uroot -pizi"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+
+      - run: npm ci
+
+      # The isolation tests load the compiled worker-thread entry point, so the
+      # build has to happen before the suite runs.
+      - run: npm run build
+
+      - name: Test (all three adapters)
+        run: npm test
+        env:
+          IZI_TEST_POSTGRES_URL: postgres://postgres:izi@localhost:5432/izi
+          IZI_TEST_MYSQL_URL: mysql://root:izi@localhost:3306/izi
+
+  peer-range:
+    name: better-sqlite3 ${{ matrix.better-sqlite3 }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Keeps the declared peerDependencies range honest. The dev dependency
+        # drifting past it is exactly how #50 shipped: every test ran against
+        # v12 while the package told users it needed ^9.
+        better-sqlite3: ['11', '12', '13']
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm install --no-save better-sqlite3@^${{ matrix.better-sqlite3 }}.0.0
+      - run: npm run build
+      - name: SQLite suites
+        run: npx jest tests/sqlite-adapter.test.ts tests/retry.test.ts tests/rescue.test.ts tests/lifecycle.test.ts
+
+  pack:
+    name: Package installs cleanly
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: npm pack --pack-destination /tmp
+
+      # Guards the failure mode from #50, where the published package could not
+      # be installed at all next to a current better-sqlite3.
+      - name: Install the tarball into a clean project
+        run: |
+          mkdir -p /tmp/consumer && cd /tmp/consumer
+          npm init -y > /dev/null
+          npm pkg set type=module > /dev/null
+          npm install /tmp/izi-queue-*.tgz better-sqlite3
+          node -e "import('izi-queue').then(m => {
+            if (typeof m.IziQueue !== 'function') { throw new Error('entry point did not resolve'); }
+            console.log('izi-queue resolves, exports', Object.keys(m).length, 'symbols');
+          })"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,38 @@ While the version is below 1.0.0, breaking changes are released as minor version
 
 ### Fixed
 
+- **`stop()` left its grace-period timer pending.** The shutdown races running
+  jobs against a timer, and when the jobs won -- the normal case -- the timer
+  was never cleared. A process that drained in a second still kept the event
+  loop alive for the full grace period, 15 seconds by default, before it could
+  exit. Found while removing `forceExit` from the test runner.
+
+### Added
+
+- **Continuous integration.** Build, lint and typecheck, plus the full suite on
+  Node 18, 20, 22 and 24 against real PostgreSQL and MySQL service containers,
+  a matrix over the supported `better-sqlite3` majors, and a job that packs the
+  tarball and installs it into a clean project. Nothing enforced any of this
+  before, which is how retries stayed broken across two releases, how MySQL
+  shipped untested, and how the peer range drifted out of date. ([#42])
+- `pretest` builds before running the suite, so `npm test` works on a clean
+  checkout. The isolation tests load the compiled worker thread and previously
+  failed with 16 opaque errors until someone thought to build first. ([#42])
+
+### Changed
+
+- **Tests wait on conditions instead of sleeping.** Fixed-duration sleeps were
+  betting that work finished inside a guessed window, which fails intermittently
+  on a loaded machine and makes every run pay the full duration regardless. The
+  retry and lifecycle suites went from about nine seconds to 1.6, and no longer
+  depend on wall-clock timing. ([#41])
+- `forceExit` is gone from the Jest config, so a leaked handle now fails loudly
+  instead of being papered over. Two were found and fixed in the process: the
+  grace-period timer above, and a test that abandoned a running job without
+  releasing it. ([#41])
+
+### Fixed
+
 - **Snoozing consumed a retry attempt.** The attempt is claimed at fetch time,
   and snoozing did not compensate, so a job that snoozed while waiting on an
   external condition was eventually discarded having never failed once. Snooze
@@ -215,6 +247,8 @@ production. Anyone running 0.3.0 or earlier should upgrade.
 [#20]: https://github.com/iagocavalcante/izi-queue/issues/20
 [#25]: https://github.com/iagocavalcante/izi-queue/issues/25
 [#28]: https://github.com/iagocavalcante/izi-queue/issues/28
+[#41]: https://github.com/iagocavalcante/izi-queue/issues/41
+[#42]: https://github.com/iagocavalcante/izi-queue/issues/42
 [#30]: https://github.com/iagocavalcante/izi-queue/issues/30
 [#33]: https://github.com/iagocavalcante/izi-queue/issues/33
 [#35]: https://github.com/iagocavalcante/izi-queue/issues/35

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,47 @@ While the version is below 1.0.0, breaking changes are released as minor version
 
 ### Fixed
 
+- **Snoozing consumed a retry attempt.** The attempt is claimed at fetch time,
+  and snoozing did not compensate, so a job that snoozed while waiting on an
+  external condition was eventually discarded having never failed once. Snooze
+  now raises `max_attempts` to match, as Oban does. ([#28])
+- **A finishing worker could resurrect a cancelled job.** Result writes went
+  straight to `updateJob` with no check on the job's current state, so a job
+  cancelled while executing was silently marked completed when its worker
+  returned. Transitions are now arbitrated by the database -- the update only
+  lands if the job is still in a state the transition is legal from, and a
+  refusal emits `job:transition_refused`. The state machine was already declared
+  and unit-tested; it was simply never consulted. ([#35])
+- **Jobs with an unregistered worker were retried for hours.** The outcome is
+  deterministic, so they are now discarded immediately with a
+  `job:unknown_worker` event instead of occupying fetch slots through 20
+  backoffs. ([#33])
+- **The pruner reported deleted rows as completed jobs.** It emitted
+  `job:complete` with no job attached, corrupting any metric counting
+  completions. It now emits `jobs:pruned`. ([#39])
+
+### Added
+
+- `cancelJob(id)` and `retryJob(id)`, plus `retryJobs(criteria)`. Retrying a job
+  that had exhausted its attempts raises `max_attempts` so it can actually run
+  rather than being discarded again on its next fetch. ([#30])
+- Bulk operations accept `ids` and require at least one criterion. `cancelJobs({})`
+  previously cancelled every non-terminal job in the database, which a handler
+  forwarding optional filters would do when called with none of them. Acting on
+  everything now requires an explicit `{ all: true }`. ([#30])
+- `updateJob` accepts an optional list of expected source states.
+- Telemetry: `job:retry`, `job:unknown_worker`, `job:transition_refused`,
+  `jobs:pruned`.
+
+### Breaking
+
+- `cancelJobs({})` now throws instead of cancelling every job. Pass
+  `{ all: true }` for the old behaviour.
+- The pruner no longer emits `job:complete`. Anything counting prune runs
+  through that event should move to `jobs:pruned`.
+
+### Fixed
+
 - **Unique job keys could alter the SQL they were looked up with.** `unique.keys`
   entries were interpolated straight into the query in all three adapters. Keys
   are now hashed in JavaScript and never reach a query, so the injection vector
@@ -173,7 +214,12 @@ production. Anyone running 0.3.0 or earlier should upgrade.
 [#19]: https://github.com/iagocavalcante/izi-queue/issues/19
 [#20]: https://github.com/iagocavalcante/izi-queue/issues/20
 [#25]: https://github.com/iagocavalcante/izi-queue/issues/25
+[#28]: https://github.com/iagocavalcante/izi-queue/issues/28
+[#30]: https://github.com/iagocavalcante/izi-queue/issues/30
+[#33]: https://github.com/iagocavalcante/izi-queue/issues/33
+[#35]: https://github.com/iagocavalcante/izi-queue/issues/35
 [#38]: https://github.com/iagocavalcante/izi-queue/issues/38
+[#39]: https://github.com/iagocavalcante/izi-queue/issues/39
 [#45]: https://github.com/iagocavalcante/izi-queue/issues/45
 [#47]: https://github.com/iagocavalcante/izi-queue/pull/47
 [#50]: https://github.com/iagocavalcante/izi-queue/issues/50

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -25,6 +25,5 @@ module.exports = {
   coverageDirectory: 'coverage',
   coverageReporters: ['text', 'lcov'],
   testTimeout: 10000,
-  forceExit: true,
   silent: true, // Suppress migration logs during tests
 };

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "test:coverage": "jest --coverage",
     "lint": "eslint src --ext .ts",
     "benchmark": "npx tsx benchmarks/benchmark.ts",
-    "prepublishOnly": "npm run build && npm test"
+    "prepublishOnly": "npm run build && npm test",
+    "pretest": "npm run build"
   },
   "keywords": [
     "job-queue",

--- a/src/core/izi-queue.ts
+++ b/src/core/izi-queue.ts
@@ -3,6 +3,7 @@ import type {
   IziQueueConfig,
   IsolationConfig,
   Job,
+  JobCriteria,
   JobInsertOptions,
   JobState,
   QueueConfig,
@@ -28,6 +29,27 @@ import { DEFAULT_NODE_TTL } from '../database/adapter.js';
 
 export interface IziQueueFullConfig extends IziQueueConfig {
   plugins?: Plugin[];
+}
+
+/**
+ * Bulk operations must be scoped. An HTTP handler that forwards optional
+ * filters would otherwise act on every job in the database when called with
+ * none of them.
+ */
+function assertScoped(criteria: JobCriteria, operation: string): void {
+  if (criteria.all) return;
+
+  const scoped =
+    (criteria.ids && criteria.ids.length > 0) ||
+    criteria.queue ||
+    criteria.worker ||
+    (criteria.state && criteria.state.length > 0);
+
+  if (!scoped) {
+    throw new Error(
+      `${operation} requires at least one criterion. Pass { all: true } to act on every job.`
+    );
+  }
 }
 
 export interface InsertResult<T = Record<string, unknown>> {
@@ -300,12 +322,39 @@ export class IziQueue {
     return this.config.database.getJob(id);
   }
 
-  async cancelJobs(criteria: {
-    queue?: string;
-    worker?: string;
-    state?: JobState[];
-  }): Promise<number> {
+  async cancelJobs(criteria: JobCriteria): Promise<number> {
+    assertScoped(criteria, 'cancelJobs');
     return this.config.database.cancelJobs(criteria);
+  }
+
+  /** Cancels one job. Returns false if it was already in a terminal state. */
+  async cancelJob(id: number): Promise<boolean> {
+    return (await this.config.database.cancelJobs({ ids: [id] })) > 0;
+  }
+
+  /**
+   * Returns discarded or cancelled jobs to the queue. Jobs that had exhausted
+   * their attempts are given headroom, otherwise they would be discarded again
+   * on the very next fetch.
+   */
+  async retryJobs(criteria: JobCriteria): Promise<number> {
+    assertScoped(criteria, 'retryJobs');
+
+    if (!this.config.database.retryJobs) {
+      throw new Error('The configured database adapter does not support retryJobs');
+    }
+
+    const count = await this.config.database.retryJobs(criteria);
+    if (count > 0) {
+      telemetry.emit('job:retry', { result: { count } });
+      this.queues.forEach(queue => queue.dispatch());
+    }
+    return count;
+  }
+
+  /** Retries one job. Returns false if it was not in a retryable state. */
+  async retryJob(id: number): Promise<boolean> {
+    return (await this.retryJobs({ ids: [id] })) > 0;
   }
 
   async pruneJobs(maxAgeSeconds = 86400 * 7): Promise<number> {

--- a/src/core/izi-queue.ts
+++ b/src/core/izi-queue.ts
@@ -5,7 +5,6 @@ import type {
   Job,
   JobCriteria,
   JobInsertOptions,
-  JobState,
   QueueConfig,
   TelemetryEvent,
   TelemetryHandler,

--- a/src/core/job.ts
+++ b/src/core/job.ts
@@ -16,6 +16,18 @@ export function isValidTransition(from: JobState, to: JobState): boolean {
   return STATE_TRANSITIONS[from].includes(to);
 }
 
+/**
+ * The states a job may legally be in for `to` to be reachable. Passed to
+ * `updateJob` so the database refuses an illegal transition, which is the only
+ * place the check can be made safely: the race is between nodes, not within
+ * this process.
+ */
+export function sourceStatesFor(to: JobState): JobState[] {
+  return (Object.keys(STATE_TRANSITIONS) as JobState[]).filter(from =>
+    STATE_TRANSITIONS[from].includes(to)
+  );
+}
+
 export function isTerminal(state: JobState): boolean {
   return TERMINAL_STATES.includes(state);
 }

--- a/src/core/queue.ts
+++ b/src/core/queue.ts
@@ -1,5 +1,5 @@
 import type { DatabaseAdapter, Job, QueueConfig } from '../types.js';
-import { formatError } from './job.js';
+import { formatError, sourceStatesFor } from './job.js';
 import { executeWorker, getBackoffDelay, hasWorker, getWorker, terminateIsolatedJob } from './worker.js';
 import { telemetry } from './telemetry.js';
 
@@ -192,8 +192,10 @@ export class Queue {
     telemetry.emit('job:start', { job, queue: this.name });
 
     if (!hasWorker(job.worker)) {
-      const error = new Error(`Worker "${job.worker}" not registered`);
-      await this.handleError(job, error, startTime);
+      // Deterministic: no number of retries will make the worker appear on this
+      // node, so retrying only occupies fetch slots for hours before the job is
+      // discarded anyway.
+      await this.handleUnknownWorker(job, startTime);
       return;
     }
 
@@ -237,11 +239,54 @@ export class Queue {
     }
   }
 
-  private async handleSuccess(job: Job, result: unknown, duration: number): Promise<void> {
-    await this.database.updateJob(job.id, {
-      state: 'completed',
-      completedAt: new Date()
+  /**
+   * Applies a terminal or scheduling update, letting the database refuse it if
+   * the job has moved on -- cancelled by an operator, or rescued onto another
+   * node. Returns whether the write landed.
+   */
+  private async transition(
+    job: Job,
+    to: Job['state'],
+    updates: Partial<Job>
+  ): Promise<boolean> {
+    const updated = await this.database.updateJob(
+      job.id,
+      { state: to, ...updates },
+      sourceStatesFor(to)
+    );
+
+    if (!updated) {
+      telemetry.emit('job:transition_refused', {
+        job,
+        queue: this.name,
+        result: { to }
+      });
+      return false;
+    }
+
+    return true;
+  }
+
+  private async handleUnknownWorker(job: Job, startTime: number): Promise<void> {
+    const error = new Error(`Worker "${job.worker}" not registered`);
+    const errors = [...job.errors, formatError(error, job.attempt)];
+
+    await this.transition(job, 'discarded', {
+      errors,
+      discardedAt: new Date()
     });
+
+    telemetry.emit('job:unknown_worker', {
+      job: { ...job, state: 'discarded', errors },
+      queue: this.name,
+      duration: Date.now() - startTime,
+      error
+    });
+  }
+
+  private async handleSuccess(job: Job, result: unknown, duration: number): Promise<void> {
+    const applied = await this.transition(job, 'completed', { completedAt: new Date() });
+    if (!applied) return;
 
     telemetry.emit('job:complete', {
       job: { ...job, state: 'completed' },
@@ -256,11 +301,11 @@ export class Queue {
     const newErrors = [...job.errors, formatError(error, job.attempt)];
 
     if (job.attempt >= job.maxAttempts) {
-      await this.database.updateJob(job.id, {
-        state: 'discarded',
+      const applied = await this.transition(job, 'discarded', {
         errors: newErrors,
         discardedAt: new Date()
       });
+      if (!applied) return;
 
       telemetry.emit('job:error', {
         job: { ...job, state: 'discarded', errors: newErrors },
@@ -272,11 +317,11 @@ export class Queue {
       const backoffMs = getBackoffDelay(job);
       const scheduledAt = new Date(Date.now() + backoffMs);
 
-      await this.database.updateJob(job.id, {
-        state: 'retryable',
+      const applied = await this.transition(job, 'retryable', {
         errors: newErrors,
         scheduledAt
       });
+      if (!applied) return;
 
       telemetry.emit('job:error', {
         job: { ...job, state: 'retryable', errors: newErrors },
@@ -290,11 +335,11 @@ export class Queue {
   private async handleCancel(job: Job, reason: string, duration: number): Promise<void> {
     const newErrors = [...job.errors, formatError(new Error(reason), job.attempt)];
 
-    await this.database.updateJob(job.id, {
-      state: 'cancelled',
+    const applied = await this.transition(job, 'cancelled', {
       errors: newErrors,
       cancelledAt: new Date()
     });
+    if (!applied) return;
 
     telemetry.emit('job:cancel', {
       job: { ...job, state: 'cancelled', errors: newErrors },
@@ -306,11 +351,15 @@ export class Queue {
   private async handleSnooze(job: Job, seconds: number, duration: number): Promise<void> {
     const scheduledAt = new Date(Date.now() + seconds * 1000);
 
-    await this.database.updateJob(job.id, {
-      state: 'scheduled',
+    // The attempt was already consumed by the fetch, but a snooze is not a
+    // failure: without compensating, a job that snoozes while waiting on some
+    // external condition is eventually discarded having never failed once.
+    const applied = await this.transition(job, 'scheduled', {
       scheduledAt,
+      maxAttempts: job.maxAttempts + 1,
       meta: { ...job.meta, snoozedAt: new Date().toISOString() }
     });
+    if (!applied) return;
 
     telemetry.emit('job:snooze', {
       job: { ...job, state: 'scheduled' },

--- a/src/core/queue.ts
+++ b/src/core/queue.ts
@@ -68,14 +68,23 @@ export class Queue {
     }
 
     if (this.running.size > 0) {
-      const timeout = new Promise<'timeout' | 'done'>((resolve) =>
-        setTimeout(() => resolve('timeout'), gracePeriod)
-      );
+      let graceTimer: ReturnType<typeof setTimeout> | undefined;
+      const timeout = new Promise<'timeout' | 'done'>((resolve) => {
+        graceTimer = setTimeout(() => resolve('timeout'), gracePeriod);
+      });
 
-      const result = await Promise.race([
-        Promise.all(this.running.values()).then(() => 'done' as const),
-        timeout
-      ]);
+      let result: 'timeout' | 'done';
+      try {
+        result = await Promise.race([
+          Promise.all(this.running.values()).then(() => 'done' as const),
+          timeout
+        ]);
+      } finally {
+        // The jobs usually win the race, and the losing timer would otherwise
+        // keep the event loop alive for the whole grace period -- so a process
+        // that drained in a second still takes 15 to exit.
+        if (graceTimer) clearTimeout(graceTimer);
+      }
 
       if (result === 'timeout' && this.isolatedJobs.size > 0) {
         const terminatePromises = Array.from(this.isolatedJobs).map(jobId =>

--- a/src/database/adapter.ts
+++ b/src/database/adapter.ts
@@ -312,6 +312,38 @@ export const SQL = {
   }
 };
 
+/**
+ * Builds the shared filter for bulk job operations. An empty criteria object is
+ * rejected by the caller rather than silently matching every job.
+ */
+export function criteriaClause(
+  criteria: import('../types.js').JobCriteria,
+  placeholder: (index: number) => string
+): { clause: string; params: unknown[] } {
+  const params: unknown[] = [];
+  let clause = '';
+  let index = 1;
+
+  if (criteria.ids && criteria.ids.length > 0) {
+    clause += ` AND id IN (${criteria.ids.map(() => placeholder(index++)).join(',')})`;
+    params.push(...criteria.ids);
+  }
+  if (criteria.queue) {
+    clause += ` AND queue = ${placeholder(index++)}`;
+    params.push(criteria.queue);
+  }
+  if (criteria.worker) {
+    clause += ` AND worker = ${placeholder(index++)}`;
+    params.push(criteria.worker);
+  }
+  if (criteria.state && criteria.state.length > 0) {
+    clause += ` AND state IN (${criteria.state.map(() => placeholder(index++)).join(',')})`;
+    params.push(...criteria.state);
+  }
+
+  return { clause, params };
+}
+
 export function rowToJob(row: Record<string, unknown>): Job {
   const parseJSON = (val: unknown): unknown => {
     if (typeof val === 'string') {
@@ -357,11 +389,11 @@ export abstract class BaseAdapter implements DatabaseAdapter {
   abstract migrate(): Promise<void>;
   abstract insertJob(job: Omit<Job, 'id' | 'insertedAt'>): Promise<Job>;
   abstract fetchJobs(queue: string, limit: number, node?: string): Promise<Job[]>;
-  abstract updateJob(id: number, updates: Partial<Job>): Promise<Job | null>;
+  abstract updateJob(id: number, updates: Partial<Job>, expectedStates?: JobState[]): Promise<Job | null>;
   abstract getJob(id: number): Promise<Job | null>;
   abstract pruneJobs(maxAge: number): Promise<number>;
   abstract stageJobs(): Promise<number>;
-  abstract cancelJobs(criteria: { queue?: string; worker?: string; state?: JobState[] }): Promise<number>;
+  abstract cancelJobs(criteria: import('../types.js').JobCriteria): Promise<number>;
   abstract rescueStuckJobs(rescueAfter: number, nodeTtl?: number): Promise<number>;
 
   /** Shared predicate for locating an existing unique job. */

--- a/src/database/mysql.ts
+++ b/src/database/mysql.ts
@@ -23,8 +23,8 @@ interface Pool {
   getConnection(): Promise<PoolConnection>;
   end(): Promise<void>;
 }
-import type { Job, JobState, UniqueOptions } from '../types.js';
-import { BaseAdapter, DEFAULT_NODE_TTL, SQL, rowToJob } from './adapter.js';
+import type { Job, JobCriteria, JobState, UniqueOptions } from '../types.js';
+import { BaseAdapter, DEFAULT_NODE_TTL, SQL, criteriaClause, rowToJob } from './adapter.js';
 import { computeUniqueKey } from '../core/unique.js';
 
 /** Arbitrary but fixed: all izi-queue instances must agree on this value. */
@@ -184,8 +184,12 @@ export class MySQLAdapter extends BaseAdapter {
     }
   }
 
-  async updateJob(id: number, updates: Partial<Job>): Promise<Job | null> {
-    await this.pool.query(SQL.mysql.updateJob, [
+  async updateJob(
+    id: number,
+    updates: Partial<Job>,
+    expectedStates?: JobState[]
+  ): Promise<Job | null> {
+    const params: unknown[] = [
       updates.state ?? null,
       updates.errors ? JSON.stringify(updates.errors) : null,
       updates.completedAt ?? null,
@@ -193,9 +197,35 @@ export class MySQLAdapter extends BaseAdapter {
       updates.cancelledAt ?? null,
       updates.scheduledAt ?? null,
       updates.meta ? JSON.stringify(updates.meta) : null,
+      updates.attempt ?? null,
+      updates.maxAttempts ?? null,
       id
-    ]);
+    ];
 
+    let guard = '';
+    if (expectedStates?.length) {
+      guard = ` AND state IN (${expectedStates.map(() => '?').join(',')})`;
+      params.push(...expectedStates);
+    }
+
+    const [result] = await this.pool.query<ResultSetHeader>(
+      `
+        UPDATE izi_jobs
+        SET state = COALESCE(?, state),
+            errors = COALESCE(?, errors),
+            completed_at = COALESCE(?, completed_at),
+            discarded_at = COALESCE(?, discarded_at),
+            cancelled_at = COALESCE(?, cancelled_at),
+            scheduled_at = COALESCE(?, scheduled_at),
+            meta = COALESCE(?, meta),
+            attempt = COALESCE(?, attempt),
+            max_attempts = COALESCE(?, max_attempts)
+        WHERE id = ?${guard}
+      `,
+      params
+    );
+
+    if (result.affectedRows === 0) return null;
     return this.getJob(id);
   }
 
@@ -214,24 +244,31 @@ export class MySQLAdapter extends BaseAdapter {
     return result.affectedRows;
   }
 
-  async cancelJobs(criteria: { queue?: string; worker?: string; state?: JobState[] }): Promise<number> {
-    let sql = SQL.mysql.cancelJobs;
-    const params: unknown[] = [];
+  async cancelJobs(criteria: JobCriteria): Promise<number> {
+    const { clause, params } = criteriaClause(criteria, () => '?');
+    const [result] = await this.pool.query<ResultSetHeader>(
+      `${SQL.mysql.cancelJobs}${clause}`,
+      params
+    );
+    return result.affectedRows;
+  }
 
-    if (criteria.queue) {
-      sql += ' AND queue = ?';
-      params.push(criteria.queue);
-    }
-    if (criteria.worker) {
-      sql += ' AND worker = ?';
-      params.push(criteria.worker);
-    }
-    if (criteria.state && criteria.state.length > 0) {
-      sql += ' AND state IN (?)';
-      params.push(criteria.state);
-    }
-
-    const [result] = await this.pool.query<ResultSetHeader>(sql, params);
+  async retryJobs(criteria: JobCriteria): Promise<number> {
+    const { clause, params } = criteriaClause(criteria, () => '?');
+    // Raising max_attempts matters for jobs discarded after exhausting them:
+    // without headroom the job is discarded again on its very next fetch.
+    const [result] = await this.pool.query<ResultSetHeader>(
+      `
+        UPDATE izi_jobs
+        SET state = 'available',
+            scheduled_at = NOW(6),
+            discarded_at = NULL,
+            cancelled_at = NULL,
+            max_attempts = CASE WHEN attempt >= max_attempts THEN attempt + 1 ELSE max_attempts END
+        WHERE state IN ('discarded', 'cancelled')${clause}
+      `,
+      params
+    );
     return result.affectedRows;
   }
 

--- a/src/database/postgres.ts
+++ b/src/database/postgres.ts
@@ -1,6 +1,6 @@
 import type { Pool, PoolClient } from 'pg';
-import type { Job, JobState, UniqueOptions } from '../types.js';
-import { BaseAdapter, DEFAULT_NODE_TTL, SQL, rowToJob } from './adapter.js';
+import type { Job, JobCriteria, JobState, UniqueOptions } from '../types.js';
+import { BaseAdapter, DEFAULT_NODE_TTL, SQL, criteriaClause, rowToJob } from './adapter.js';
 import { advisoryLockKey, computeUniqueKey } from '../core/unique.js';
 
 /** Arbitrary but fixed: all izi-queue instances must agree on this value. */
@@ -178,8 +178,12 @@ export class PostgresAdapter extends BaseAdapter {
     return result.rows.map(rowToJob);
   }
 
-  async updateJob(id: number, updates: Partial<Job>): Promise<Job | null> {
-    const result = await this.pool.query(SQL.postgres.updateJob, [
+  async updateJob(
+    id: number,
+    updates: Partial<Job>,
+    expectedStates?: JobState[]
+  ): Promise<Job | null> {
+    const params: unknown[] = [
       id,
       updates.state ?? null,
       updates.errors ? JSON.stringify(updates.errors) : null,
@@ -187,8 +191,35 @@ export class PostgresAdapter extends BaseAdapter {
       updates.discardedAt ?? null,
       updates.cancelledAt ?? null,
       updates.scheduledAt ?? null,
-      updates.meta ? JSON.stringify(updates.meta) : null
-    ]);
+      updates.meta ? JSON.stringify(updates.meta) : null,
+      updates.attempt ?? null,
+      updates.maxAttempts ?? null
+    ];
+
+    let guard = '';
+    if (expectedStates?.length) {
+      params.push(expectedStates);
+      guard = ` AND state = ANY($${params.length})`;
+    }
+
+    const result = await this.pool.query(
+      `
+        UPDATE izi_jobs
+        SET state = COALESCE($2, state),
+            errors = COALESCE($3, errors),
+            completed_at = COALESCE($4, completed_at),
+            discarded_at = COALESCE($5, discarded_at),
+            cancelled_at = COALESCE($6, cancelled_at),
+            scheduled_at = COALESCE($7, scheduled_at),
+            meta = COALESCE($8, meta),
+            attempt = COALESCE($9, attempt),
+            max_attempts = COALESCE($10, max_attempts)
+        WHERE id = $1${guard}
+        RETURNING *
+      `,
+      params
+    );
+
     return result.rows[0] ? rowToJob(result.rows[0]) : null;
   }
 
@@ -207,25 +238,31 @@ export class PostgresAdapter extends BaseAdapter {
     return result.rowCount ?? 0;
   }
 
-  async cancelJobs(criteria: { queue?: string; worker?: string; state?: JobState[] }): Promise<number> {
-    let sql = SQL.postgres.cancelJobs;
-    const params: unknown[] = [];
-    let paramIndex = 1;
+  async cancelJobs(criteria: JobCriteria): Promise<number> {
+    const { clause, params } = criteriaClause(criteria, i => `$${i}`);
+    const result = await this.pool.query(
+      `${SQL.postgres.cancelJobs}${clause}`,
+      params
+    );
+    return result.rowCount ?? 0;
+  }
 
-    if (criteria.queue) {
-      sql += ` AND queue = $${paramIndex++}`;
-      params.push(criteria.queue);
-    }
-    if (criteria.worker) {
-      sql += ` AND worker = $${paramIndex++}`;
-      params.push(criteria.worker);
-    }
-    if (criteria.state && criteria.state.length > 0) {
-      sql += ` AND state = ANY($${paramIndex++})`;
-      params.push(criteria.state);
-    }
-
-    const result = await this.pool.query(sql, params);
+  async retryJobs(criteria: JobCriteria): Promise<number> {
+    const { clause, params } = criteriaClause(criteria, i => `$${i}`);
+    // Raising max_attempts matters for jobs discarded after exhausting them:
+    // without headroom the job is discarded again on its very next fetch.
+    const result = await this.pool.query(
+      `
+        UPDATE izi_jobs
+        SET state = 'available',
+            scheduled_at = NOW(),
+            discarded_at = NULL,
+            cancelled_at = NULL,
+            max_attempts = CASE WHEN attempt >= max_attempts THEN attempt + 1 ELSE max_attempts END
+        WHERE state IN ('discarded', 'cancelled')${clause}
+      `,
+      params
+    );
     return result.rowCount ?? 0;
   }
 

--- a/src/database/sqlite.ts
+++ b/src/database/sqlite.ts
@@ -1,6 +1,6 @@
 import type { Database } from 'better-sqlite3';
-import type { Job, JobState, UniqueOptions } from '../types.js';
-import { BaseAdapter, DEFAULT_NODE_TTL, rowToJob } from './adapter.js';
+import type { Job, JobCriteria, JobState, UniqueOptions } from '../types.js';
+import { BaseAdapter, DEFAULT_NODE_TTL, criteriaClause, rowToJob } from './adapter.js';
 import { computeUniqueKey } from '../core/unique.js';
 import { sqliteMigrations } from './migrations.js';
 
@@ -134,7 +134,15 @@ export class SQLiteAdapter extends BaseAdapter {
     return rows.map(rowToJob);
   }
 
-  async updateJob(id: number, updates: Partial<Job>): Promise<Job | null> {
+  async updateJob(
+    id: number,
+    updates: Partial<Job>,
+    expectedStates?: JobState[]
+  ): Promise<Job | null> {
+    const guard = expectedStates?.length
+      ? ` AND state IN (${expectedStates.map(() => '?').join(',')})`
+      : '';
+
     const stmt = this.db.prepare(`
       UPDATE izi_jobs
       SET state = COALESCE(?, state),
@@ -143,11 +151,13 @@ export class SQLiteAdapter extends BaseAdapter {
           discarded_at = COALESCE(?, discarded_at),
           cancelled_at = COALESCE(?, cancelled_at),
           scheduled_at = COALESCE(?, scheduled_at),
-          meta = COALESCE(?, meta)
-      WHERE id = ?
+          meta = COALESCE(?, meta),
+          attempt = COALESCE(?, attempt),
+          max_attempts = COALESCE(?, max_attempts)
+      WHERE id = ?${guard}
     `);
 
-    stmt.run(
+    const result = stmt.run(
       updates.state ?? null,
       updates.errors ? JSON.stringify(updates.errors) : null,
       updates.completedAt?.toISOString() ?? null,
@@ -155,11 +165,17 @@ export class SQLiteAdapter extends BaseAdapter {
       updates.cancelledAt?.toISOString() ?? null,
       updates.scheduledAt?.toISOString() ?? null,
       updates.meta ? JSON.stringify(updates.meta) : null,
-      id
+      updates.attempt ?? null,
+      updates.maxAttempts ?? null,
+      id,
+      ...(expectedStates ?? [])
     );
 
-    const getStmt = this.db.prepare('SELECT * FROM izi_jobs WHERE id = ?');
-    const row = getStmt.get(id) as Record<string, unknown> | undefined;
+    if (result.changes === 0) return null;
+
+    const row = this.db.prepare('SELECT * FROM izi_jobs WHERE id = ?').get(id) as
+      | Record<string, unknown>
+      | undefined;
     return row ? rowToJob(row) : null;
   }
 
@@ -189,30 +205,31 @@ export class SQLiteAdapter extends BaseAdapter {
     return result.changes;
   }
 
-  async cancelJobs(criteria: { queue?: string; worker?: string; state?: JobState[] }): Promise<number> {
-    let sql = `
+  async cancelJobs(criteria: JobCriteria): Promise<number> {
+    const { clause, params } = criteriaClause(criteria, () => '?');
+    const stmt = this.db.prepare(`
       UPDATE izi_jobs
       SET state = 'cancelled', cancelled_at = datetime('now')
-      WHERE state NOT IN ('completed', 'discarded', 'cancelled')
-    `;
-    const params: unknown[] = [];
+      WHERE state NOT IN ('completed', 'discarded', 'cancelled')${clause}
+    `);
+    return stmt.run(...params).changes;
+  }
 
-    if (criteria.queue) {
-      sql += ' AND queue = ?';
-      params.push(criteria.queue);
-    }
-    if (criteria.worker) {
-      sql += ' AND worker = ?';
-      params.push(criteria.worker);
-    }
-    if (criteria.state && criteria.state.length > 0) {
-      sql += ` AND state IN (${criteria.state.map(() => '?').join(',')})`;
-      params.push(...criteria.state);
-    }
-
-    const stmt = this.db.prepare(sql);
-    const result = stmt.run(...params);
-    return result.changes;
+  async retryJobs(criteria: JobCriteria): Promise<number> {
+    const { clause, params } = criteriaClause(criteria, () => '?');
+    // Raising max_attempts matters for jobs that were discarded after
+    // exhausting them: without headroom the job would be discarded again on
+    // its very next fetch.
+    const stmt = this.db.prepare(`
+      UPDATE izi_jobs
+      SET state = 'available',
+          scheduled_at = datetime('now'),
+          discarded_at = NULL,
+          cancelled_at = NULL,
+          max_attempts = CASE WHEN attempt >= max_attempts THEN attempt + 1 ELSE max_attempts END
+      WHERE state IN ('discarded', 'cancelled')${clause}
+    `);
+    return stmt.run(...params).changes;
   }
 
   async rescueStuckJobs(rescueAfter: number, nodeTtl = DEFAULT_NODE_TTL): Promise<number> {

--- a/src/plugins/pruner.ts
+++ b/src/plugins/pruner.ts
@@ -40,9 +40,11 @@ export class PrunerPlugin extends BasePlugin {
       const pruned = await this.context.database.pruneJobs(this.config.maxAge);
 
       if (pruned > 0) {
-        telemetry.emit('job:complete', {
+        // Deliberately not `job:complete`: pruning is maintenance, and counting
+        // deleted rows as completed jobs corrupts any metric built on that event.
+        telemetry.emit('jobs:pruned', {
           result: { pruned, maxAge: this.config.maxAge },
-          queue: 'pruner'
+          queue: this.name
         });
       }
     } catch (error) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,18 @@ export interface UniqueOptions {
   states?: JobState[];
 }
 
+export interface JobCriteria {
+  ids?: number[];
+  queue?: string;
+  worker?: string;
+  state?: JobState[];
+  /**
+   * Required to act on every job. Without it an empty criteria object is
+   * rejected, so a handler forwarding optional filters cannot wipe the queue.
+   */
+  all?: boolean;
+}
+
 export interface JobInsertOptions<T = Record<string, unknown>> {
   args: T;
   queue?: string;
@@ -146,11 +158,19 @@ export interface DatabaseAdapter {
    * abandoned by a dead node from one still running on a live node.
    */
   fetchJobs(queue: string, limit: number, node?: string): Promise<Job[]>;
-  updateJob(id: number, updates: Partial<Job>): Promise<Job | null>;
+  /**
+   * Applies `updates` to a job. When `expectedStates` is given the database
+   * arbitrates the transition: the write only lands if the job is still in one
+   * of those states, and `null` is returned otherwise. That check has to happen
+   * in the database, because the race is between nodes.
+   */
+  updateJob(id: number, updates: Partial<Job>, expectedStates?: JobState[]): Promise<Job | null>;
   getJob(id: number): Promise<Job | null>;
   pruneJobs(maxAge: number): Promise<number>;
   stageJobs(): Promise<number>;
-  cancelJobs(criteria: { queue?: string; worker?: string; state?: JobState[] }): Promise<number>;
+  cancelJobs(criteria: JobCriteria): Promise<number>;
+  /** Returns discarded or cancelled jobs to the queue. */
+  retryJobs?(criteria: JobCriteria): Promise<number>;
   /**
    * Returns jobs abandoned by dead nodes to the queue (or discards them when
    * their attempts are exhausted). `nodeTtl` is how many seconds a node may go
@@ -210,6 +230,10 @@ export type TelemetryEvent =
   | 'job:cancel'
   | 'job:snooze'
   | 'job:rescue'
+  | 'job:retry'
+  | 'job:unknown_worker'
+  | 'job:transition_refused'
+  | 'jobs:pruned'
   | 'job:unique_conflict'
   | 'job:isolated:start'
   | 'job:isolated:timeout'

--- a/tests/helpers/wait.ts
+++ b/tests/helpers/wait.ts
@@ -1,0 +1,73 @@
+import { telemetry } from '../../src/core/telemetry.js';
+import type { TelemetryEvent, TelemetryPayload } from '../../src/types.js';
+
+export interface WaitOptions {
+  timeout?: number;
+  interval?: number;
+  describe?: string;
+}
+
+/**
+ * Polls until `predicate` returns something truthy.
+ *
+ * Tests that instead sleep for a fixed duration are betting that the work
+ * finishes inside a window they guessed. That bet fails intermittently on a
+ * loaded machine, and it makes every run pay the full duration even when the
+ * work took 20ms. Waiting on the actual condition is both faster and stable.
+ */
+export async function waitFor<T>(
+  predicate: () => T | Promise<T>,
+  { timeout = 10000, interval = 10, describe = 'condition' }: WaitOptions = {}
+): Promise<T> {
+  const deadline = Date.now() + timeout;
+  let last: T | undefined;
+
+  for (;;) {
+    last = await predicate();
+    if (last) return last;
+
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `Timed out after ${timeout}ms waiting for ${describe} (last value: ${JSON.stringify(last)})`
+      );
+    }
+
+    await new Promise(resolve => setTimeout(resolve, interval));
+  }
+}
+
+/** Resolves once a telemetry event fires, or rejects on timeout. */
+export function waitForEvent(
+  event: TelemetryEvent,
+  { timeout = 10000 }: { timeout?: number } = {}
+): Promise<TelemetryPayload> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      unsubscribe();
+      reject(new Error(`Timed out after ${timeout}ms waiting for "${event}"`));
+    }, timeout);
+
+    const unsubscribe = telemetry.on(event, payload => {
+      clearTimeout(timer);
+      unsubscribe();
+      resolve(payload);
+    });
+  });
+}
+
+/**
+ * Asserts something stays false for a window. Only for genuinely negative
+ * assertions ("this must NOT happen"), where there is no event to wait on.
+ */
+export async function stayFalse(
+  predicate: () => boolean | Promise<boolean>,
+  { duration = 300, interval = 25 }: { duration?: number; interval?: number } = {}
+): Promise<void> {
+  const deadline = Date.now() + duration;
+  while (Date.now() < deadline) {
+    if (await predicate()) {
+      throw new Error('Condition became true when it should not have');
+    }
+    await new Promise(resolve => setTimeout(resolve, interval));
+  }
+}

--- a/tests/lifecycle.test.ts
+++ b/tests/lifecycle.test.ts
@@ -1,0 +1,229 @@
+import Database from 'better-sqlite3';
+import { IziQueue } from '../src/core/izi-queue.js';
+import { defineWorker, WorkerResults, clearWorkers } from '../src/core/worker.js';
+import { createSQLiteAdapter, SQLiteAdapter } from '../src/database/sqlite.js';
+import { telemetry } from '../src/core/telemetry.js';
+import type { Job, TelemetryEvent } from '../src/types.js';
+
+describe('job lifecycle', () => {
+  let db: Database.Database;
+  let adapter: SQLiteAdapter;
+
+  beforeEach(async () => {
+    db = new Database(':memory:');
+    adapter = createSQLiteAdapter(db);
+    await adapter.migrate();
+    clearWorkers();
+    telemetry.off();
+  });
+
+  afterEach(async () => {
+    telemetry.off();
+    await adapter.close();
+  });
+
+  function queueWith(...workers: Parameters<IziQueue['register']>[0][]): IziQueue {
+    const queue = new IziQueue({
+      database: adapter,
+      queues: { default: 5 },
+      stageInterval: 50,
+      pollInterval: 50,
+    });
+    workers.forEach((w) => queue.register(w));
+    return queue;
+  }
+
+  function events(): TelemetryEvent[] {
+    const seen: TelemetryEvent[] = [];
+    telemetry.on('*', ({ event }) => seen.push(event));
+    return seen;
+  }
+
+  describe('snooze', () => {
+    it('does not consume a retry attempt', async () => {
+      let calls = 0;
+      const queue = queueWith(
+        defineWorker('snoozer', async () => {
+          calls++;
+          if (calls <= 3) return WorkerResults.snooze(0);
+          return WorkerResults.ok();
+        })
+      );
+
+      await queue.start();
+      const job = await queue.insert('snoozer', { args: {}, maxAttempts: 2 });
+      await new Promise((r) => setTimeout(r, 1500));
+      const final = await queue.getJob(job.id);
+      await queue.stop();
+
+      // Snoozing three times with maxAttempts: 2 must not exhaust the job.
+      expect(calls).toBe(4);
+      expect(final?.state).toBe('completed');
+    }, 20000);
+
+    it('leaves the effective retry budget intact after snoozing', async () => {
+      const queue = queueWith(
+        defineWorker('snooze_once', async () => WorkerResults.snooze(60))
+      );
+
+      await queue.start();
+      const job = await queue.insert('snooze_once', { args: {}, maxAttempts: 5 });
+      await new Promise((r) => setTimeout(r, 400));
+      const snoozed = await queue.getJob(job.id);
+      await queue.stop();
+
+      expect(snoozed?.state).toBe('scheduled');
+      // One attempt was consumed by the fetch, so the budget is raised to
+      // compensate: the job still has its original five real attempts.
+      expect(snoozed!.maxAttempts - snoozed!.attempt).toBe(5);
+    }, 20000);
+  });
+
+  describe('unknown workers', () => {
+    it('discards the job immediately instead of retrying it', async () => {
+      const queue = queueWith();
+      const seen = events();
+
+      await queue.start();
+      const job = await queue.insert('NeverRegistered', { args: {} });
+      await new Promise((r) => setTimeout(r, 400));
+      const final = await queue.getJob(job.id);
+      await queue.stop();
+
+      expect(final?.state).toBe('discarded');
+      expect(final?.errors).toHaveLength(1);
+      expect(final?.errors[0].error).toContain('NeverRegistered');
+      expect(seen).toContain('job:unknown_worker');
+    }, 20000);
+  });
+
+  describe('state transitions', () => {
+    it('does not let a finishing worker resurrect a cancelled job', async () => {
+      let release: (() => void) | undefined;
+      const gate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+
+      const queue = queueWith(
+        defineWorker('slow', async () => {
+          await gate;
+          return WorkerResults.ok();
+        })
+      );
+
+      await queue.start();
+      const job = await queue.insert('slow', { args: {} });
+      await new Promise((r) => setTimeout(r, 300)); // let it start executing
+
+      expect((await queue.getJob(job.id))?.state).toBe('executing');
+      await queue.cancelJobs({ queue: 'default' });
+      expect((await queue.getJob(job.id))?.state).toBe('cancelled');
+
+      release!();
+      await new Promise((r) => setTimeout(r, 300));
+      const final = await queue.getJob(job.id);
+      await queue.stop();
+
+      // The worker succeeded, but the job was already cancelled. Completing it
+      // now would silently undo the cancellation.
+      expect(final?.state).toBe('cancelled');
+    }, 20000);
+
+    it('refuses an update whose source state does not allow it', async () => {
+      const job = await adapter.insertJob({
+        state: 'completed',
+        queue: 'default',
+        worker: 'W',
+        args: {},
+        meta: {},
+        tags: [],
+        errors: [],
+        attempt: 1,
+        maxAttempts: 20,
+        priority: 0,
+        scheduledAt: new Date(),
+        attemptedAt: null,
+        attemptedBy: null,
+        uniqueKey: null,
+        completedAt: null,
+        discardedAt: null,
+        cancelledAt: null,
+      } as Omit<Job, 'id' | 'insertedAt'>);
+
+      const refused = await adapter.updateJob(job.id, { state: 'executing' }, ['available']);
+
+      expect(refused).toBeNull();
+      expect((await adapter.getJob(job.id))?.state).toBe('completed');
+    });
+  });
+
+  describe('cancel and retry', () => {
+    it('cancels a single job by id', async () => {
+      const queue = queueWith();
+      const keep = await queue.insert('W', { args: { n: 1 } });
+      const drop = await queue.insert('W', { args: { n: 2 } });
+
+      const cancelled = await queue.cancelJob(drop.id);
+
+      expect(cancelled).toBe(true);
+      expect((await queue.getJob(drop.id))?.state).toBe('cancelled');
+      expect((await queue.getJob(keep.id))?.state).toBe('available');
+    });
+
+    it('refuses to cancel everything unless asked explicitly', async () => {
+      const queue = queueWith();
+      const job = await queue.insert('W', { args: {} });
+
+      await expect(queue.cancelJobs({})).rejects.toThrow(/criteri/i);
+      // The rejected call must not have touched anything.
+      expect((await queue.getJob(job.id))?.state).toBe('available');
+
+      const cancelled = await queue.cancelJobs({ all: true });
+      expect(cancelled).toBe(1);
+      expect((await queue.getJob(job.id))?.state).toBe('cancelled');
+    });
+
+    it('returns a discarded job to the queue', async () => {
+      const queue = queueWith();
+      const job = await queue.insert('W', { args: {}, maxAttempts: 1 });
+      await adapter.updateJob(job.id, { state: 'discarded', discardedAt: new Date() });
+
+      const retried = await queue.retryJob(job.id);
+
+      expect(retried).toBe(true);
+      const after = await queue.getJob(job.id);
+      expect(after?.state).toBe('available');
+      // A job that exhausted its attempts needs headroom to run again.
+      expect(after!.maxAttempts).toBeGreaterThan(after!.attempt);
+    });
+
+    it('does not retry a job that is still runnable', async () => {
+      const queue = queueWith();
+      const job = await queue.insert('W', { args: {} });
+
+      expect(await queue.retryJob(job.id)).toBe(false);
+      expect((await queue.getJob(job.id))?.state).toBe('available');
+    });
+  });
+
+  describe('pruner telemetry', () => {
+    it('does not report pruned rows as completed jobs', async () => {
+      const { PrunerPlugin } = await import('../src/plugins/pruner.js');
+      const seen = events();
+
+      db.prepare(
+        `INSERT INTO izi_jobs (state, queue, worker, args, completed_at)
+         VALUES ('completed', 'default', 'W', '{}', datetime('now', '-2 days'))`
+      ).run();
+
+      const pruner = new PrunerPlugin({ interval: 60000, maxAge: 3600 });
+      await pruner.start({ database: adapter, node: 'node-1', queues: ['default'] });
+      await new Promise((r) => setTimeout(r, 50));
+      await (pruner as unknown as { prune(): Promise<void> }).prune();
+      await pruner.stop();
+
+      expect(seen).not.toContain('job:complete');
+      expect(seen).toContain('jobs:pruned');
+    }, 20000);
+  });
+});

--- a/tests/lifecycle.test.ts
+++ b/tests/lifecycle.test.ts
@@ -4,6 +4,7 @@ import { defineWorker, WorkerResults, clearWorkers } from '../src/core/worker.js
 import { createSQLiteAdapter, SQLiteAdapter } from '../src/database/sqlite.js';
 import { telemetry } from '../src/core/telemetry.js';
 import type { Job, TelemetryEvent } from '../src/types.js';
+import { waitFor, waitForEvent } from './helpers/wait.js';
 
 describe('job lifecycle', () => {
   let db: Database.Database;
@@ -52,8 +53,14 @@ describe('job lifecycle', () => {
 
       await queue.start();
       const job = await queue.insert('snoozer', { args: {}, maxAttempts: 2 });
-      await new Promise((r) => setTimeout(r, 1500));
-      const final = await queue.getJob(job.id);
+
+      const final = await waitFor(
+        async () => {
+          const current = await queue.getJob(job.id);
+          return current?.state === 'completed' ? current : null;
+        },
+        { describe: 'the job to complete after snoozing three times' }
+      );
       await queue.stop();
 
       // Snoozing three times with maxAttempts: 2 must not exhaust the job.
@@ -68,8 +75,14 @@ describe('job lifecycle', () => {
 
       await queue.start();
       const job = await queue.insert('snooze_once', { args: {}, maxAttempts: 5 });
-      await new Promise((r) => setTimeout(r, 400));
-      const snoozed = await queue.getJob(job.id);
+
+      const snoozed = await waitFor(
+        async () => {
+          const current = await queue.getJob(job.id);
+          return current?.state === 'scheduled' ? current : null;
+        },
+        { describe: 'the job to be snoozed' }
+      );
       await queue.stop();
 
       expect(snoozed?.state).toBe('scheduled');
@@ -86,8 +99,14 @@ describe('job lifecycle', () => {
 
       await queue.start();
       const job = await queue.insert('NeverRegistered', { args: {} });
-      await new Promise((r) => setTimeout(r, 400));
-      const final = await queue.getJob(job.id);
+
+      const final = await waitFor(
+        async () => {
+          const current = await queue.getJob(job.id);
+          return current?.state === 'discarded' ? current : null;
+        },
+        { describe: 'the job to be discarded for having no worker' }
+      );
       await queue.stop();
 
       expect(final?.state).toBe('discarded');
@@ -113,14 +132,20 @@ describe('job lifecycle', () => {
 
       await queue.start();
       const job = await queue.insert('slow', { args: {} });
-      await new Promise((r) => setTimeout(r, 300)); // let it start executing
 
-      expect((await queue.getJob(job.id))?.state).toBe('executing');
+      await waitFor(
+        async () => (await queue.getJob(job.id))?.state === 'executing',
+        { describe: 'the job to start executing' }
+      );
       await queue.cancelJobs({ queue: 'default' });
       expect((await queue.getJob(job.id))?.state).toBe('cancelled');
 
+      // The worker now succeeds, and the write it attempts must be refused.
+      // Waiting on that event is exact; sleeping would only be a guess.
+      const refused = waitForEvent('job:transition_refused');
       release!();
-      await new Promise((r) => setTimeout(r, 300));
+      await refused;
+
       const final = await queue.getJob(job.id);
       await queue.stop();
 
@@ -218,7 +243,6 @@ describe('job lifecycle', () => {
 
       const pruner = new PrunerPlugin({ interval: 60000, maxAge: 3600 });
       await pruner.start({ database: adapter, node: 'node-1', queues: ['default'] });
-      await new Promise((r) => setTimeout(r, 50));
       await (pruner as unknown as { prune(): Promise<void> }).prune();
       await pruner.stop();
 

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -386,12 +386,16 @@ describe('Plugins', () => {
         await plugin.stop();
       });
 
-      it('should emit job:complete event when pruning jobs', async () => {
+      it('should emit jobs:pruned event when pruning jobs', async () => {
         const events: any[] = [];
-        const unsubscribe = telemetry.on('job:complete', (payload) => {
-          if (payload.queue === 'pruner') {
-            events.push(payload);
-          }
+        // Maintenance gets its own event: counting deleted rows as completed
+        // jobs would corrupt any metric built on job:complete.
+        const unsubscribe = telemetry.on('jobs:pruned', (payload) => {
+          events.push(payload);
+        });
+        const completed: any[] = [];
+        const unsubscribeCompleted = telemetry.on('job:complete', (payload) => {
+          completed.push(payload);
         });
 
         // Insert old completed job
@@ -412,8 +416,10 @@ describe('Plugins', () => {
 
         expect(events.length).toBeGreaterThan(0);
         expect(events[0].result.pruned).toBe(1);
+        expect(completed).toHaveLength(0);
 
         unsubscribe();
+        unsubscribeCompleted();
         await plugin.stop();
       });
     });

--- a/tests/polling.test.ts
+++ b/tests/polling.test.ts
@@ -1,6 +1,7 @@
 import { Queue } from '../src/core/queue.js';
 import { defineWorker, registerWorker, clearWorkers, WorkerResults } from '../src/core/worker.js';
 import type { DatabaseAdapter, Job } from '../src/types.js';
+import { waitFor } from './helpers/wait.js';
 
 function createJobRow(id: number, overrides: Partial<Job> = {}): Job {
   return {
@@ -146,6 +147,63 @@ describe('queue polling', () => {
     expect(rejections).toHaveLength(0);
     // The queue is still healthy and polling.
     expect(queue.currentState).toBe('stopped');
+  }, 15000);
+
+  it('clears the grace-period timer when jobs finish before it fires', async () => {
+    // stop() races the running jobs against a grace-period timer. When the jobs
+    // win, that timer must still be cleared: otherwise every graceful shutdown
+    // keeps the event loop alive for the full grace period (15s by default),
+    // delaying process exit long after the queue has drained.
+    const GRACE = 15000;
+    const realSetTimeout = global.setTimeout;
+    const realClearTimeout = global.clearTimeout;
+    const graceTimers: unknown[] = [];
+    const cleared = new Set<unknown>();
+
+    (global as unknown as { setTimeout: unknown }).setTimeout = ((
+      fn: () => void,
+      ms?: number,
+      ...rest: unknown[]
+    ) => {
+      const id = (realSetTimeout as unknown as (...a: unknown[]) => unknown)(fn, ms, ...rest);
+      if (ms === GRACE) graceTimers.push(id);
+      return id;
+    }) as unknown as typeof global.setTimeout;
+
+    (global as unknown as { clearTimeout: unknown }).clearTimeout = ((id: unknown) => {
+      cleared.add(id);
+      return (realClearTimeout as unknown as (a: unknown) => unknown)(id);
+    }) as unknown as typeof global.clearTimeout;
+
+    try {
+      registerWorker(
+        defineWorker('blocker', async () => {
+          await new Promise((r) => realSetTimeout(r, 30));
+          return WorkerResults.ok();
+        })
+      );
+
+      let handed = false;
+      const db = {
+        fetchJobs: async () => {
+          if (handed) return [];
+          handed = true;
+          return [createJobRow(1)];
+        },
+        updateJob: async () => null,
+      } as unknown as DatabaseAdapter;
+
+      const queue = new Queue({ name: 'default', limit: 1, pollInterval: 10 }, db, 'node-1');
+      await queue.start();
+      await waitFor(() => queue.runningCount > 0, { describe: 'a job to start' });
+      await queue.stop(GRACE);
+
+      expect(graceTimers).toHaveLength(1);
+      expect(cleared.has(graceTimers[0])).toBe(true);
+    } finally {
+      global.setTimeout = realSetTimeout;
+      global.clearTimeout = realClearTimeout;
+    }
   }, 15000);
 
   it('never runs more jobs concurrently than the queue limit', async () => {

--- a/tests/queue.test.ts
+++ b/tests/queue.test.ts
@@ -8,6 +8,7 @@ import {
   clearWorkers
 } from '../src/index.js';
 import { telemetry } from '../src/core/telemetry.js';
+import { waitFor } from './helpers/wait.js';
 import type { QueueConfig, Job } from '../src/types.js';
 
 describe('Queue Class', () => {
@@ -609,11 +610,20 @@ describe('Queue Class', () => {
 
     it('should timeout if jobs take too long during stop', async () => {
       let jobCompleted = false;
+      // The job is deliberately abandoned by the short grace period. It still
+      // has to be released before the suite ends: leaving it suspended keeps
+      // both its own timer and executeWorker's timeout race pending, which
+      // holds the process open long after the tests finish.
+      let jobTimer: ReturnType<typeof setTimeout> | undefined;
+      let releaseJob: (() => void) | undefined;
 
       registerWorker({
         name: 'VeryLongWorker',
         perform: async () => {
-          await new Promise(resolve => setTimeout(resolve, 2000));
+          await new Promise<void>(resolve => {
+            releaseJob = resolve;
+            jobTimer = setTimeout(resolve, 2000);
+          });
           jobCompleted = true;
           return WorkerResults.ok();
         }
@@ -625,13 +635,17 @@ describe('Queue Class', () => {
       await adapter.insertJob(createJobData({ worker: 'VeryLongWorker' }));
 
       await queue.start();
-      await new Promise(resolve => setTimeout(resolve, 50)); // Let job start
+      await waitFor(() => queue.runningCount > 0, { describe: 'the job to start' });
 
       // Stop with short grace period
       await queue.stop(100);
 
       // Job should not have completed due to timeout
       expect(jobCompleted).toBe(false);
+
+      if (jobTimer) clearTimeout(jobTimer);
+      releaseJob?.();
+      await waitFor(() => jobCompleted, { describe: 'the abandoned job to settle' });
     });
   });
 });

--- a/tests/retry.test.ts
+++ b/tests/retry.test.ts
@@ -2,6 +2,7 @@ import Database from 'better-sqlite3';
 import { IziQueue } from '../src/core/izi-queue.js';
 import { defineWorker, WorkerResults, clearWorkers } from '../src/core/worker.js';
 import { createSQLiteAdapter, SQLiteAdapter } from '../src/database/sqlite.js';
+import { waitFor } from './helpers/wait.js';
 
 describe('retry lifecycle', () => {
   let db: Database.Database;
@@ -73,9 +74,14 @@ describe('retry lifecycle', () => {
       await queue.start();
 
       const job = await queue.insert('flaky', { args: { x: 1 } });
-      await new Promise((r) => setTimeout(r, 2000));
 
-      const final = await queue.getJob(job.id);
+      const final = await waitFor(
+        async () => {
+          const current = await queue.getJob(job.id);
+          return current?.state === 'completed' ? current : null;
+        },
+        { describe: 'the job to complete after retrying' }
+      );
       await queue.stop();
 
       expect(attempts).toBe(2);
@@ -104,9 +110,14 @@ describe('retry lifecycle', () => {
       await queue.start();
 
       const job = await queue.insert('always_fails', { args: {}, maxAttempts: 3 });
-      await new Promise((r) => setTimeout(r, 2500));
 
-      const final = await queue.getJob(job.id);
+      const final = await waitFor(
+        async () => {
+          const current = await queue.getJob(job.id);
+          return current?.state === 'discarded' ? current : null;
+        },
+        { describe: 'the job to be discarded once attempts run out' }
+      );
       await queue.stop();
 
       expect(attempts).toBe(3);


### PR DESCRIPTION
Closes #41, #42.

> **Stacked on #54**, which is stacked on #53. Merge those first and this retargets automatically.

Nothing has been enforcing build, lint or tests on this repo. That absence is the common cause behind a lot of what we've been fixing by hand:

| Bug | What CI would have caught |
|---|---|
| #15 retries never ran | An integration test asserting a retry — but there was no gate requiring one to exist or pass |
| #50 package uninstallable | The pack-and-install job below |
| MySQL untested | Adapter suites now run against real service containers instead of skipping |
| peer range drift | A matrix over supported `better-sqlite3` majors |

The irony was immediate: writing this PR, `npm run lint` failed on an unused import I'd introduced two commits earlier and nothing had told me.

## The workflow

- **lint** — eslint + `tsc --noEmit`
- **test** — full suite on Node **18, 20, 22, 24**, with PostgreSQL 16 and MySQL 8 service containers, so `IZI_TEST_*_URL` is set and the adapter suites actually execute rather than skipping
- **peer-range** — SQLite suites against `better-sqlite3` 11, 12 and 13, so the declared range stays honest
- **pack** — builds the tarball, installs it into a clean project alongside a current `better-sqlite3`, and imports the entry point. This is exactly the check that would have caught #50

## Determinism

Tests waited by sleeping for a guessed duration. That bets the work finishes inside the window — it fails intermittently under load (**one such failure appeared during the 0.4.1 release and I could not reproduce it afterwards**) and makes every run pay the full window even when the work took 20ms.

They now wait on the actual condition, or on a telemetry event where one exists:

```
retry + lifecycle suites: ~9s -> 1.6s, and no longer wall-clock dependent
```

## Removing forceExit found a real product bug

`forceExit: true` was papering over leaked handles. Removing it surfaced two immediately:

**`Queue.stop()` never cleared its grace-period timer.** Shutdown races the running jobs against a timer; when the jobs win — the normal case — the timer stayed pending. **A process that drained in one second still kept the event loop alive for the full grace period, 15 seconds by default, before it could exit.** Every graceful shutdown, every deploy. That is a product bug, not a test artefact, and it is fixed here with a regression test that asserts the specific timer is cleared.

The second was test hygiene: a test abandoned a running job without releasing it, so both its own timer and `executeWorker`'s timeout race outlived the suite.

## Also

`pretest` builds first, so `npm test` works on a clean checkout instead of failing with 16 opaque errors until someone thinks to run `npm run build` (#42).

**325 tests, exiting cleanly with no forced teardown.**

## Not verified yet

I cannot run GitHub Actions locally, so **the workflow itself is unproven until this PR runs it**. Node 18 in particular is untested here — everything local ran on Node 24. If a matrix leg fails I'll fix it on this branch.