### PR TITLE
docs: bring README and CLAUDE.md in line with 0.5.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ src/
 │   ├── izi-queue.ts      # Main IziQueue class (orchestrator)
 │   ├── queue.ts          # Queue class (worker execution)
 │   ├── job.ts            # Job state machine & backoff
+│   ├── unique.ts         # Uniqueness digest & advisory lock keys
 │   ├── worker.ts         # Worker registry & execution
 │   ├── telemetry.ts      # Event system
 │   └── isolation/        # Worker thread pool
@@ -82,7 +83,11 @@ Abstract interface with concrete implementations per database.
 export interface DatabaseAdapter {
   migrate(): Promise<void>;
   insertJob(job: Omit<Job, 'id' | 'insertedAt'>): Promise<Job>;
-  fetchJobs(queue: string, limit: number): Promise<Job[]>;
+  fetchJobs(queue: string, limit: number, node?: string): Promise<Job[]>;
+  updateJob(id: number, updates: Partial<Job>, expectedStates?: JobState[]): Promise<Job | null>;
+  rescueStuckJobs(rescueAfter: number, nodeTtl?: number): Promise<number>;
+  insertUnique?(job, options): Promise<{ job: Job; conflict: boolean }>;
+  heartbeat?(node: string): Promise<void>;
   // ... more methods
 }
 
@@ -143,7 +148,17 @@ export const STATE_TRANSITIONS: Record<JobState, JobState[]> = {
 export function isValidTransition(from: JobState, to: JobState): boolean {
   return STATE_TRANSITIONS[from].includes(to);
 }
+
+// The set of states `to` is reachable from, passed to updateJob so the
+// database refuses an illegal transition.
+export function sourceStatesFor(to: JobState): JobState[];
 ```
+
+**Transitions are enforced in SQL, not in process.** `Queue` passes
+`sourceStatesFor(target)` to `updateJob`, which appends `AND state IN (...)`.
+Zero rows means the job moved on -- cancelled by an operator, or rescued onto
+another node -- and the write is refused rather than silently winning. The check
+cannot live in JavaScript because the race is between nodes.
 
 ### 5. Result Objects (Worker Results)
 
@@ -277,7 +292,7 @@ Each adapter handles dialect-specific syntax:
 
 ```sql
 CREATE TABLE izi_jobs (
-  id SERIAL PRIMARY KEY,
+  id BIGSERIAL PRIMARY KEY,
   state VARCHAR(20) NOT NULL DEFAULT 'available',
   queue VARCHAR(255) NOT NULL DEFAULT 'default',
   worker VARCHAR(255) NOT NULL,
@@ -288,29 +303,64 @@ CREATE TABLE izi_jobs (
   attempt INTEGER NOT NULL DEFAULT 0,
   max_attempts INTEGER NOT NULL DEFAULT 20,
   priority INTEGER NOT NULL DEFAULT 0,
-  inserted_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  scheduled_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  attempted_at TIMESTAMP,
-  completed_at TIMESTAMP,
-  discarded_at TIMESTAMP,
-  cancelled_at TIMESTAMP
+  inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  scheduled_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  attempted_at TIMESTAMPTZ,
+  attempted_by VARCHAR(255),   -- node that claimed the job
+  unique_key VARCHAR(64),      -- uniqueness digest, null for non-unique jobs
+  completed_at TIMESTAMPTZ,
+  discarded_at TIMESTAMPTZ,
+  cancelled_at TIMESTAMPTZ
+);
+
+-- Node liveness, used to tell an orphaned job from a slow one
+CREATE TABLE izi_nodes (
+  name VARCHAR(255) PRIMARY KEY,
+  started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  heartbeat_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
 -- Critical indexes
-CREATE INDEX idx_izi_jobs_queue_state ON izi_jobs (queue, state);
-CREATE INDEX idx_izi_jobs_scheduled_at ON izi_jobs (scheduled_at);
+CREATE INDEX izi_jobs_queue_state_idx ON izi_jobs (queue, state);
+CREATE INDEX izi_jobs_stageable_idx ON izi_jobs (scheduled_at)
+  WHERE state IN ('scheduled', 'retryable');
+CREATE INDEX izi_jobs_unique_key_idx ON izi_jobs (unique_key) WHERE unique_key IS NOT NULL;
 ```
+
+**Never index `args` directly.** A btree entry is capped at ~2704 bytes and a
+JSONB value that does not compress below it fails the insert outright. That is
+why uniqueness is keyed on a digest.
 
 ### Concurrency Control
 
 PostgreSQL uses `FOR UPDATE SKIP LOCKED` for non-blocking job fetching:
 
 ```sql
-SELECT * FROM izi_jobs
-WHERE queue = $1 AND state = 'available'
-ORDER BY priority ASC, scheduled_at ASC
-LIMIT $2
-FOR UPDATE SKIP LOCKED
+WITH claimed AS (
+  UPDATE izi_jobs
+  SET state = 'executing', attempted_at = NOW(), attempt = attempt + 1, attempted_by = $3
+  WHERE id IN (
+    SELECT id FROM izi_jobs
+    WHERE queue = $1 AND state = 'available'
+    ORDER BY priority ASC, scheduled_at ASC, id ASC
+    LIMIT $2
+    FOR UPDATE SKIP LOCKED
+  )
+  RETURNING *
+)
+SELECT * FROM claimed ORDER BY priority ASC, scheduled_at ASC, id ASC
+```
+
+The outer `ORDER BY` is not redundant: `RETURNING` follows physical update order,
+not the subquery's ordering, so without it a high-priority job could be handed to
+the executor after a low-priority one from the same batch.
+
+**Staging** promotes both `scheduled` and `retryable` jobs once due. Omitting
+`retryable` means no job is ever retried:
+
+```sql
+UPDATE izi_jobs SET state = 'available'
+WHERE state IN ('scheduled', 'retryable') AND scheduled_at <= NOW()
 ```
 
 ## Testing Patterns
@@ -354,6 +404,8 @@ function createMockJob(overrides: Partial<Job> = {}): Job {
     insertedAt: new Date(),
     scheduledAt: new Date(),
     attemptedAt: null,
+    attemptedBy: null,
+    uniqueKey: null,
     completedAt: null,
     discardedAt: null,
     cancelledAt: null,
@@ -361,6 +413,41 @@ function createMockJob(overrides: Partial<Job> = {}): Job {
   };
 }
 ```
+
+### Waiting in tests
+
+Never sleep for a guessed duration. Wait on the condition, or on the telemetry
+event that marks it:
+
+```typescript
+import { waitFor, waitForEvent } from './helpers/wait.js';
+
+const done = await waitFor(async () => {
+  const job = await queue.getJob(id);
+  return job?.state === 'completed' ? job : null;
+}, { describe: 'the job to complete' });
+
+const refused = waitForEvent('job:transition_refused');
+```
+
+A fixed sleep bets the work finishes inside a window you guessed. That bet fails
+intermittently under load and makes every run pay the full duration regardless.
+
+### Running against real databases
+
+SQLite alone will not catch dialect bugs -- the priority-ordering and btree index
+defects were both invisible to it. The PostgreSQL and MySQL suites skip unless
+their connection strings are set:
+
+```bash
+docker run -d --rm -e POSTGRES_PASSWORD=izi -e POSTGRES_DB=izi -p 55432:5432 postgres:16-alpine
+docker run -d --rm -e MYSQL_ROOT_PASSWORD=izi -e MYSQL_DATABASE=izi -p 33306:3306 mysql:8
+
+IZI_TEST_POSTGRES_URL=postgres://postgres:izi@localhost:55432/izi \
+IZI_TEST_MYSQL_URL=mysql://root:izi@localhost:33306/izi npm test
+```
+
+CI runs both on every push, so a change that only works on SQLite fails there.
 
 ## Key Formulas
 
@@ -379,6 +466,18 @@ Lower priority value = higher priority (0 is highest).
 Jobs ordered by: `priority ASC, scheduled_at ASC`
 
 ## Common Tasks
+
+### Adding a Migration
+
+1. Append to the relevant array in `src/database/migrations.ts`, using the next
+   version for that dialect -- version numbers are tracked per database, so the
+   three arrays are free to diverge.
+2. `up` and `down` are **arrays of statements**, one statement per entry. They
+   are not split on `;`, which would tear apart a function body or a semicolon
+   inside a string literal.
+3. Migrations run under an advisory lock, so several nodes may boot at once.
+4. On PostgreSQL, DDL is transactional and a failure rolls back. On MySQL it is
+   not: a failure part-way leaves the schema changed and the version unrecorded.
 
 ### Adding a New Database Adapter
 
@@ -407,7 +506,13 @@ Jobs ordered by: `priority ASC, scheduled_at ASC`
 ## Performance Considerations
 
 - **Poll interval**: Default 1000ms, configurable per queue
+- **One poll loop per queue**: `dispatch()` moves the pending timer rather than
+  starting another. Starting a second loop per notification makes the query rate
+  grow with every insert until the database saturates.
 - **Batch fetching**: Fetch up to `limit` jobs per poll
 - **Skip locked**: PostgreSQL doesn't block on contested rows
 - **Worker threads**: Optional isolation for CPU-intensive work
 - **Connection pooling**: Use pg-pool for PostgreSQL
+- **Clear every timer you create**: the timeout race in `executeWorker` and the
+  grace-period race in `Queue.stop()` both leaked until fixed, each holding the
+  event loop open long after its work was done.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,8 +53,15 @@ npm test
 # Build the project
 npm run build
 
-# Run tests
+# Run tests (SQLite only; PostgreSQL and MySQL suites skip)
 npm test
+
+# Run everything, including the PostgreSQL and MySQL adapter suites
+docker run -d --rm -e POSTGRES_PASSWORD=izi -e POSTGRES_DB=izi -p 55432:5432 postgres:16-alpine
+docker run -d --rm -e MYSQL_ROOT_PASSWORD=izi -e MYSQL_DATABASE=izi -p 33306:3306 mysql:8
+
+IZI_TEST_POSTGRES_URL=postgres://postgres:izi@localhost:55432/izi \
+IZI_TEST_MYSQL_URL=mysql://root:izi@localhost:33306/izi npm test
 
 # Run tests with coverage
 npm run test:coverage

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # izi-queue
 
+[![CI](https://github.com/iagocavalcante/izi-queue/actions/workflows/ci.yml/badge.svg)](https://github.com/iagocavalcante/izi-queue/actions/workflows/ci.yml)
 [![npm version](https://img.shields.io/npm/v/izi-queue.svg)](https://www.npmjs.com/package/izi-queue)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js Version](https://img.shields.io/node/v/izi-queue.svg)](https://nodejs.org)
@@ -10,10 +11,14 @@ A minimal, reliable, database-backed job queue for Node.js inspired by [Oban](ht
 ## Why izi-queue?
 
 - **No extra infrastructure** - Use your existing PostgreSQL, SQLite, or MySQL database
-- **ACID guarantees** - Jobs are inserted transactionally with your business data
+- **Durable** - Jobs live in your database, survive restarts, and are recovered when a node dies
 - **Simple API** - Define workers, insert jobs, done
 - **TypeScript-first** - Full type safety and excellent DX
 - **Battle-tested patterns** - Inspired by Oban's proven design
+
+> **Not yet supported:** inserting a job inside your own transaction. Every insert
+> currently commits on its own connection, so a job can outlive a rolled-back
+> business write. Tracked in [#21](https://github.com/iagocavalcante/izi-queue/issues/21).
 
 ## Table of Contents
 
@@ -27,6 +32,9 @@ A minimal, reliable, database-backed job queue for Node.js inspired by [Oban](ht
   - [Worker Isolation](#worker-isolation)
   - [Plugins](#plugins)
   - [Telemetry](#telemetry)
+- [Managing Jobs](#managing-jobs)
+- [Migrations](#migrations)
+- [Running Multiple Nodes](#running-multiple-nodes)
 - [Worker Results](#worker-results)
 - [Database Support](#database-support)
 - [Examples](#examples)
@@ -72,14 +80,28 @@ const queue = new IziQueue({
   queues: { default: 10 }, // queue name: concurrency limit
 });
 
-// 3. Register worker and start
-queue.registerWorker(sendEmailWorker);
+// 3. Register worker, run migrations, and start
+queue.register(sendEmailWorker);
+await queue.migrate();
 await queue.start();
 
-// 4. Insert jobs
+// 4. Insert jobs. Job arguments go under `args`.
 await queue.insert('send_email', {
-  to: 'user@example.com',
-  subject: 'Welcome!',
+  args: { to: 'user@example.com', subject: 'Welcome!' },
+});
+```
+
+`insert` takes the worker name (or definition) and a single options object.
+Everything other than `args` is optional:
+
+```typescript
+await queue.insert('send_email', {
+  args: { to: 'user@example.com' },
+  queue: 'emails',
+  priority: 0,
+  maxAttempts: 5,
+  scheduledAt: new Date(Date.now() + 3600000),
+  tags: ['welcome'],
 });
 ```
 
@@ -89,10 +111,11 @@ await queue.insert('send_email', {
 
 ```typescript
 // Run immediately
-await queue.insert('send_email', args);
+await queue.insert('send_email', { args });
 
 // Schedule for later
-await queue.insert('send_email', args, {
+await queue.insert('send_email', {
+  args,
   scheduledAt: new Date(Date.now() + 3600000), // 1 hour from now
 });
 ```
@@ -119,8 +142,8 @@ const customBackoffWorker = defineWorker('custom_worker', async (job) => {
 ### Priority Queues
 
 ```typescript
-await queue.insert('urgent_task', args, { priority: 0 }); // High priority (lower = higher)
-await queue.insert('background_task', args, { priority: 10 }); // Low priority
+await queue.insert('urgent_task', { args, priority: 0 });      // High priority (lower = higher)
+await queue.insert('background_task', { args, priority: 10 }); // Low priority
 ```
 
 ### Unique Jobs
@@ -128,14 +151,35 @@ await queue.insert('background_task', args, { priority: 10 }); // Low priority
 Prevent duplicate jobs from being enqueued:
 
 ```typescript
-await queue.insert('send_digest', args, {
+await queue.insert('send_digest', {
+  args,
   unique: {
     fields: ['worker', 'args'], // Uniqueness based on these fields
-    period: 3600, // Only one per hour (in seconds)
-    states: ['scheduled', 'available', 'executing'], // Check these states
+    keys: ['userId'],           // Or compare only these keys within args
+    period: 3600,               // Only one per hour (in seconds), or 'infinity'
+    states: ['scheduled', 'available', 'executing'],
   },
 });
 ```
+
+Use `insertWithResult` when you need to know whether a duplicate was found:
+
+```typescript
+const { job, conflict } = await queue.insertWithResult('send_digest', {
+  args,
+  unique: { period: 3600 },
+});
+```
+
+Insertion is atomic, so concurrent callers across multiple nodes produce exactly
+one job. Two notes on the semantics:
+
+- **Only jobs inserted with `unique` participate.** A job enqueued without
+  `unique` options carries no uniqueness key and will not block a later unique
+  insert. This matches Oban, where uniqueness is a property of how a job was
+  enqueued.
+- **Argument order does not matter.** `{ a: 1, b: 2 }` and `{ b: 2, a: 1 }` are
+  the same job on every adapter.
 
 ### Worker Isolation
 
@@ -149,14 +193,29 @@ const isolatedWorker = defineWorker('heavy_computation', async (job) => {
   isolation: {
     isolated: true,
     workerPath: './workers/heavy-computation.js',
-    resourceLimits: {
-      maxOldGenerationSizeMb: 128,
-      maxYoungGenerationSizeMb: 32,
-    },
   },
   timeout: 30000, // 30 seconds
 });
 ```
+
+Configure the thread pool on the queue:
+
+```typescript
+const queue = new IziQueue({
+  database: createSQLiteAdapter(db),
+  queues: { default: 4 },
+  isolation: { minThreads: 0, maxThreads: 4, idleTimeoutMs: 30000 },
+});
+```
+
+> **Keep a queue's concurrency at or below `maxThreads`.** A job that finds the
+> pool saturated currently fails with `No available worker threads` and consumes
+> a retry attempt rather than waiting. Tracked in
+> [#22](https://github.com/iagocavalcante/izi-queue/issues/22).
+>
+> `resourceLimits` is accepted by the type but **not currently applied** to
+> worker threads, so isolated workers run without a memory cap. Tracked in
+> [#23](https://github.com/iagocavalcante/izi-queue/issues/23).
 
 ### Plugins
 
@@ -169,11 +228,23 @@ const queue = new IziQueue({
   database: createSQLiteAdapter(db),
   queues: { default: 10 },
   plugins: [
-    new LifelinePlugin({ rescueAfter: 300 }), // Rescue stuck jobs after 5 min
-    new PrunerPlugin({ maxAge: 86400 }), // Prune completed jobs older than 24h
+    new LifelinePlugin({ rescueAfter: 300 }), // Rescue orphaned jobs after 5 min
+    new PrunerPlugin({ maxAge: 86400 }),      // Prune finished jobs older than 24h
   ],
 });
 ```
+
+**Lifeline** returns jobs abandoned by a node that stopped heartbeating. It will
+not touch a job that is still running on a live node, so `rescueAfter` does not
+have to exceed your worker timeouts.
+
+**Pruner** deletes finished jobs. It currently deletes in one unbounded
+statement, so the first run against a large backlog is a long-running delete
+([#29](https://github.com/iagocavalcante/izi-queue/issues/29)).
+
+> Every node runs every plugin: there is no leader election yet
+> ([#26](https://github.com/iagocavalcante/izi-queue/issues/26)). With several
+> nodes this duplicates maintenance work against the same rows.
 
 ### Telemetry
 
@@ -195,11 +266,83 @@ queue.on('*', ({ event, job }) => {
 ```
 
 **Available events:**
-- `job:start`, `job:complete`, `job:error`, `job:cancel`, `job:snooze`, `job:rescue`
+- `job:start`, `job:complete`, `job:error`, `job:cancel`, `job:snooze`
+- `job:retry`, `job:rescue`, `job:unknown_worker`, `job:transition_refused`
 - `job:unique_conflict`, `job:isolated:start`, `job:isolated:timeout`
+- `jobs:pruned`
 - `queue:start`, `queue:stop`, `queue:pause`, `queue:resume`
 - `thread:spawn`, `thread:exit`
 - `plugin:start`, `plugin:stop`, `plugin:error`
+
+`job:transition_refused` fires when a result could not be written because the
+job had already moved on — cancelled by an operator, or rescued onto another
+node. `jobs:pruned` and `job:rescue` carry `result`, not `job`.
+
+## Managing Jobs
+
+```typescript
+const job = await queue.getJob(id);
+
+// Cancel one job, or a scoped set
+await queue.cancelJob(id);
+await queue.cancelJobs({ queue: 'emails' });
+await queue.cancelJobs({ worker: 'SendEmail', state: ['available', 'scheduled'] });
+
+// Return discarded or cancelled jobs to the queue
+await queue.retryJob(id);
+await queue.retryJobs({ worker: 'SendEmail' });
+```
+
+Bulk operations require at least one criterion. `cancelJobs({})` throws rather
+than cancelling everything, so a handler that forwards optional filters cannot
+wipe the queue when called with none of them. To act on every job, be explicit:
+
+```typescript
+await queue.cancelJobs({ all: true });
+```
+
+Cancelling a job that is currently executing marks it cancelled and causes its
+result to be discarded when the worker finishes. It does **not** interrupt the
+worker mid-run ([#30](https://github.com/iagocavalcante/izi-queue/issues/30)).
+
+## Migrations
+
+`migrate()` creates and upgrades the schema, and is safe to call from every node
+at boot — it holds an advisory lock, so concurrent starts do not collide.
+
+```typescript
+await queue.migrate();
+```
+
+It applies DDL against `izi_jobs`, so on a large table review what a release
+adds before deploying. Each version's migrations are listed in
+[CHANGELOG.md](CHANGELOG.md).
+
+## Running Multiple Nodes
+
+Jobs are claimed with `FOR UPDATE SKIP LOCKED` on PostgreSQL and MySQL, so any
+number of nodes can share a queue without handing out the same job twice.
+
+Each node records a heartbeat. When one stops heartbeating, the Lifeline plugin
+returns its in-flight jobs to the queue — and only its jobs, so a slow job on a
+healthy node is never restarted underneath you.
+
+```typescript
+const queue = new IziQueue({
+  database: adapter,
+  queues: { default: 10 },
+  node: 'worker-1',        // defaults to a random id
+  heartbeatInterval: 15000,
+});
+```
+
+Two caveats when scaling out:
+
+- Concurrency limits are **per node**. Five nodes with `{ default: 10 }` run up
+  to 50 jobs at once ([#37](https://github.com/iagocavalcante/izi-queue/issues/37)).
+- Every node runs every plugin ([#26](https://github.com/iagocavalcante/izi-queue/issues/26)).
+- A worker that blocks the event loop for longer than the node TTL stops the
+  heartbeat and may be treated as dead. Use isolated workers for CPU-bound work.
 
 ## Worker Results
 
@@ -209,13 +352,13 @@ async perform(job) {
   return WorkerResults.ok();
   return WorkerResults.ok({ processed: 100 }); // With metadata
 
-  // Retry later - job will be retried with backoff
+  // Retry later - job moves to `retryable` and is retried with backoff
   return WorkerResults.error('Temporary failure');
 
-  // Discard - don't retry, job is invalid
+  // Cancel - job moves to `cancelled` and is not retried
   return WorkerResults.cancel('Invalid data');
 
-  // Snooze - reschedule for later
+  // Snooze - reschedule without consuming a retry attempt
   return WorkerResults.snooze(60); // Try again in 60 seconds
 }
 ```


### PR DESCRIPTION
Closes #43, #44.

Answering the question honestly: the docs were **not** updated alongside the code. This fixes that.

## The README was wrong in a way that breaks the Quick Start

Every `insert` example used a signature that does not exist, and had since before 0.1.0:

```typescript
// README said                        // reality
queue.insert('send_email', args)      queue.insert('send_email', { args })
queue.insert('w', args, { priority }) queue.insert('w', { args, priority })
queue.registerWorker(worker)          queue.register(worker)
```

Anyone copy-pasting the Quick Start enqueued a job with `args: undefined`. That mattered less when the package could not be installed at all; 0.5.0 is the first release where it can.

**Both README examples now run verbatim against the published 0.5.0:**

```
Sending email to user@example.com: Welcome!
QUICK START OK

features OK  | insertWithResult conflict: false | cancelJobs({}) guarded: true
```

## Two claims removed rather than softened

**"ACID guarantees — jobs are inserted transactionally with your business data"** was the second bullet in the README. It is not implemented: there is no way to enqueue inside a caller's transaction, so a job can outlive a rolled-back business write. That is the single biggest reason someone picks this over a Redis queue, so advertising it while it does not work is the worst kind of documentation bug. Replaced with an explicit statement of the limitation pointing at #21.

**`resourceLimits`** was shown in the isolation example with a 128MB cap. It is typed, documented, and never passed to `new Worker()` — isolated workers run with no memory cap at all, which is the entire reason someone would reach for isolation. Removed from the example, gap noted against #23.

## Documented for the first time

Shipped in 0.4.x/0.5.0 with no docs at all: job control (`cancelJob`, `retryJob`, `retryJobs`, the `{ all: true }` guard), migrations and that they are safe to run from every node concurrently, multi-node behaviour (per-node concurrency, heartbeat, node TTL), and the new telemetry events.

Known gaps are now stated where a user would hit them rather than left to be discovered: thread-pool saturation (#22), unbounded pruning (#29), no leader election (#26), per-node concurrency (#37), and that cancelling does not interrupt a running job (#30).

## CLAUDE.md described the pre-0.4 architecture

No `attempted_by`, no `unique_key`, no `izi_nodes`, old adapter signatures, and a fetch query missing the outer `ORDER BY` that keeps priority meaningful.

It now also records the reasoning behind constraints that were learned the hard way, so the next person does not rediscover them: why `args` must never be indexed, why staging has to include `retryable`, why transitions are enforced in SQL rather than in process, why every timer needs clearing, and why tests wait on conditions instead of sleeping.

## CONTRIBUTING.md

Adds the commands to run the PostgreSQL and MySQL suites locally. They skip silently without connection strings, which is how MySQL reached "production ready" in the README with zero tests ever executed against it.