### PR TITLE
Insert jobs inside the caller's transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,41 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 While the version is below 1.0.0, breaking changes are released as minor versions.
 
+## [Unreleased]
+
+### Added
+
+- **Transactional inserts.** Pass your open transaction as `tx` and the job is
+  committed or discarded atomically with your business write:
+
+  ```typescript
+  await client.query('BEGIN');
+  const { rows } = await client.query('INSERT INTO orders ... RETURNING id');
+  await queue.insert('send_receipt', { args: { orderId: rows[0].id }, tx: client });
+  await client.query('COMMIT');
+  ```
+
+  This closes the gap that made the README's original "ACID guarantees" claim
+  false: every insert previously committed on its own connection, so a job could
+  outlive a rolled-back write, or become visible to a worker before the row it
+  referred to. ([#21])
+
+  On PostgreSQL the wake-up notification is issued on the caller's connection,
+  so `NOTIFY` inherits the transaction's fate -- deferred until commit, dropped
+  on rollback. Unique inserts also participate: the advisory lock is
+  transaction-scoped, so it is held until the caller commits.
+
+  MySQL **refuses** `unique` inside a caller-managed transaction rather than
+  silently weakening it. `GET_LOCK` is connection-scoped and cannot be held
+  across the caller's commit, which would reopen the duplicate-insert race that
+  atomic insertion exists to close.
+
+### Changed
+
+- `DatabaseAdapter.insertJob`, `insertUnique` and `notify` accept an optional
+  transaction handle. All three parameters are optional, so existing adapters
+  continue to compile.
+
 ## [0.5.0] - 2026-08-04
 
 ### Fixed
@@ -231,6 +266,7 @@ production. Anyone running 0.3.0 or earlier should upgrade.
 [#19]: https://github.com/iagocavalcante/izi-queue/issues/19
 [#20]: https://github.com/iagocavalcante/izi-queue/issues/20
 [#25]: https://github.com/iagocavalcante/izi-queue/issues/25
+[#21]: https://github.com/iagocavalcante/izi-queue/issues/21
 [#28]: https://github.com/iagocavalcante/izi-queue/issues/28
 [#41]: https://github.com/iagocavalcante/izi-queue/issues/41
 [#42]: https://github.com/iagocavalcante/izi-queue/issues/42

--- a/README.md
+++ b/README.md
@@ -11,14 +11,11 @@ A minimal, reliable, database-backed job queue for Node.js inspired by [Oban](ht
 ## Why izi-queue?
 
 - **No extra infrastructure** - Use your existing PostgreSQL, SQLite, or MySQL database
+- **Transactional** - Enqueue inside your own transaction, so a job never outlives the write it belongs to
 - **Durable** - Jobs live in your database, survive restarts, and are recovered when a node dies
 - **Simple API** - Define workers, insert jobs, done
 - **TypeScript-first** - Full type safety and excellent DX
 - **Battle-tested patterns** - Inspired by Oban's proven design
-
-> **Not yet supported:** inserting a job inside your own transaction. Every insert
-> currently commits on its own connection, so a job can outlive a rolled-back
-> business write. Tracked in [#21](https://github.com/iagocavalcante/izi-queue/issues/21).
 
 ## Table of Contents
 
@@ -33,6 +30,7 @@ A minimal, reliable, database-backed job queue for Node.js inspired by [Oban](ht
   - [Plugins](#plugins)
   - [Telemetry](#telemetry)
 - [Managing Jobs](#managing-jobs)
+- [Transactional Inserts](#transactional-inserts)
 - [Migrations](#migrations)
 - [Running Multiple Nodes](#running-multiple-nodes)
 - [Worker Results](#worker-results)
@@ -304,6 +302,59 @@ await queue.cancelJobs({ all: true });
 Cancelling a job that is currently executing marks it cancelled and causes its
 result to be discarded when the worker finishes. It does **not** interrupt the
 worker mid-run ([#30](https://github.com/iagocavalcante/izi-queue/issues/30)).
+
+## Transactional Inserts
+
+Pass your open transaction as `tx` and the job is committed or discarded with
+the rest of your work. No job for an order that was never placed, and no job
+that becomes visible before the row it refers to.
+
+```typescript
+const client = await pool.connect();
+try {
+  await client.query('BEGIN');
+
+  const { rows } = await client.query(
+    'INSERT INTO orders (total) VALUES ($1) RETURNING id',
+    [total]
+  );
+
+  await queue.insert('send_receipt', {
+    args: { orderId: rows[0].id },
+    tx: client,          // same connection, same transaction
+  });
+
+  await client.query('COMMIT');
+} catch (error) {
+  await client.query('ROLLBACK');   // the job goes with it
+  throw error;
+} finally {
+  client.release();
+}
+```
+
+The handle is whatever your driver uses for a transaction:
+
+| Adapter | Pass as `tx` | Transaction opened with |
+| --- | --- | --- |
+| PostgreSQL | `PoolClient` | `client.query('BEGIN')` |
+| MySQL | `PoolConnection` | `connection.beginTransaction()` |
+| SQLite | the `Database` | `db.exec('BEGIN')` |
+
+On PostgreSQL the wake-up notification is issued on your connection too, so a
+worker is never nudged toward a row that has not committed yet, and is not
+nudged at all if you roll back.
+
+**SQLite** has a single connection, so any insert while a transaction is open is
+already part of it; passing `tx` makes that explicit and catches the mistake of
+handing over a different database. Use `db.exec('BEGIN')` rather than
+`db.transaction()`, which is synchronous and cannot await.
+
+**MySQL** cannot combine `unique` with a caller-managed transaction and will
+throw if you try. Its advisory lock is connection-scoped and cannot be held
+across your commit, which would leave a window for a concurrent node to insert a
+duplicate. Insert unique jobs outside the transaction, or use PostgreSQL, where
+the lock is transaction-scoped.
 
 ## Migrations
 

--- a/src/core/izi-queue.ts
+++ b/src/core/izi-queue.ts
@@ -5,6 +5,7 @@ import type {
   Job,
   JobCriteria,
   JobInsertOptions,
+  TransactionHandle,
   QueueConfig,
   TelemetryEvent,
   TelemetryHandler,
@@ -269,28 +270,40 @@ export class IziQueue {
       } as Omit<Job, 'id' | 'insertedAt'>;
 
       const result = this.config.database.insertUnique
-        ? await this.config.database.insertUnique(data, options.unique)
-        : await this.insertUniqueUnsafely(data, options.unique);
+        ? await this.config.database.insertUnique(data, options.unique, options.tx)
+        : await this.insertUniqueUnsafely(data, options.unique, options.tx);
 
       if (result.conflict) {
         telemetry.emit('job:unique_conflict', {
           job: result.job,
           queue: result.job.queue
         });
-      } else if (this.started && this.config.database.notify) {
-        await this.config.database.notify(result.job.queue);
+      } else {
+        await this.wake(result.job.queue, options.tx);
       }
 
       return { job: result.job as Job<T>, conflict: result.conflict };
     }
 
-    const job = await this.config.database.insertJob(jobData as Omit<Job, 'id' | 'insertedAt'>);
+    const job = await this.config.database.insertJob(
+      jobData as Omit<Job, 'id' | 'insertedAt'>,
+      options.tx
+    );
 
-    if (this.started && this.config.database.notify) {
-      await this.config.database.notify(job.queue);
-    }
+    await this.wake(job.queue, options.tx);
 
     return { job: job as Job<T>, conflict: false };
+  }
+
+  /**
+   * Nudges a queue to poll now rather than at its next interval. Passing the
+   * transaction through matters: the notification must not be observable
+   * before the caller commits, or a worker looks for a row that is not there
+   * yet -- and must never fire at all if they roll back.
+   */
+  private async wake(queue: string, tx?: TransactionHandle): Promise<void> {
+    if (!this.started || !this.config.database.notify) return;
+    await this.config.database.notify(queue, tx);
   }
 
   /**
@@ -300,14 +313,15 @@ export class IziQueue {
    */
   private async insertUniqueUnsafely(
     data: Omit<Job, 'id' | 'insertedAt'>,
-    unique: NonNullable<JobInsertOptions['unique']>
+    unique: NonNullable<JobInsertOptions['unique']>,
+    tx?: TransactionHandle
   ): Promise<{ job: Job; conflict: boolean }> {
     if (this.config.database.checkUnique) {
       const existing = await this.config.database.checkUnique(unique, data);
       if (existing) return { job: existing, conflict: true };
     }
 
-    return { job: await this.config.database.insertJob(data), conflict: false };
+    return { job: await this.config.database.insertJob(data, tx), conflict: false };
   }
 
   async insertAll<T = Record<string, unknown>>(

--- a/src/database/mysql.ts
+++ b/src/database/mysql.ts
@@ -23,7 +23,7 @@ interface Pool {
   getConnection(): Promise<PoolConnection>;
   end(): Promise<void>;
 }
-import type { Job, JobCriteria, JobState, UniqueOptions } from '../types.js';
+import type { Job, JobCriteria, JobState, TransactionHandle, UniqueOptions } from '../types.js';
 import { BaseAdapter, DEFAULT_NODE_TTL, SQL, criteriaClause, rowToJob } from './adapter.js';
 import { computeUniqueKey } from '../core/unique.js';
 
@@ -123,8 +123,24 @@ export class MySQLAdapter extends BaseAdapter {
     }));
   }
 
-  async insertJob(job: Omit<Job, 'id' | 'insertedAt'>): Promise<Job> {
-    const [result] = await this.pool.query<ResultSetHeader>(SQL.mysql.insertJob, [
+  /**
+   * Resolves where a statement should run. With a caller transaction the work
+   * has to go through their connection -- the pool would hand back a different
+   * one, which commits independently of them.
+   */
+  private executor(tx?: TransactionHandle): Pool | PoolConnection {
+    if (tx === undefined) return this.pool;
+
+    if (typeof (tx as PoolConnection)?.query !== 'function') {
+      throw new Error('izi-queue: the transaction handle must be a mysql2 PoolConnection');
+    }
+
+    return tx as PoolConnection;
+  }
+
+  async insertJob(job: Omit<Job, 'id' | 'insertedAt'>, tx?: TransactionHandle): Promise<Job> {
+    const executor = this.executor(tx);
+    const [result] = await executor.query<ResultSetHeader>(SQL.mysql.insertJob, [
       job.state,
       job.queue,
       job.worker,
@@ -139,11 +155,13 @@ export class MySQLAdapter extends BaseAdapter {
       job.uniqueKey ?? null
     ]);
 
-    const insertedJob = await this.getJob(result.insertId);
-    if (!insertedJob) {
+    // Read back through the same executor: an uncommitted row is invisible to
+    // any other connection, so going via the pool would find nothing.
+    const [rows] = await executor.query<RowDataPacket[]>(SQL.mysql.getJob, [result.insertId]);
+    if (!rows[0]) {
       throw new Error('Failed to retrieve inserted job');
     }
-    return insertedJob;
+    return rowToJob(rows[0] as Record<string, unknown>);
   }
 
   async fetchJobs(queue: string, limit: number, node?: string): Promise<Job[]> {
@@ -314,8 +332,22 @@ export class MySQLAdapter extends BaseAdapter {
 
   async insertUnique(
     job: Omit<Job, 'id' | 'insertedAt'>,
-    options: UniqueOptions
+    options: UniqueOptions,
+    tx?: TransactionHandle
   ): Promise<{ job: Job; conflict: boolean }> {
+    if (tx !== undefined) {
+      // MySQL's GET_LOCK is connection-scoped and not transactional, so it
+      // cannot be held across the caller's commit. Releasing it at insert time
+      // would leave a window for a concurrent node to insert a duplicate --
+      // reintroducing the exact race that atomic insertion exists to close.
+      // Degrading silently would be worse than refusing.
+      throw new Error(
+        'izi-queue: unique jobs cannot be inserted inside a caller-managed transaction on MySQL, ' +
+          'because the advisory lock cannot span the commit. Insert unique jobs outside the ' +
+          'transaction, or use PostgreSQL, where the lock is transaction-scoped.'
+      );
+    }
+
     const { states, period } = this.uniqueLookup(options);
     const uniqueKey = job.uniqueKey ?? computeUniqueKey(job, options);
     // GET_LOCK names are capped at 64 characters; the digest is 32.

--- a/src/database/postgres.ts
+++ b/src/database/postgres.ts
@@ -1,5 +1,5 @@
 import type { Pool, PoolClient } from 'pg';
-import type { Job, JobCriteria, JobState, UniqueOptions } from '../types.js';
+import type { Job, JobCriteria, JobState, TransactionHandle, UniqueOptions } from '../types.js';
 import { BaseAdapter, DEFAULT_NODE_TTL, SQL, criteriaClause, rowToJob } from './adapter.js';
 import { advisoryLockKey, computeUniqueKey } from '../core/unique.js';
 
@@ -155,8 +155,23 @@ export class PostgresAdapter extends BaseAdapter {
     }));
   }
 
-  async insertJob(job: Omit<Job, 'id' | 'insertedAt'>): Promise<Job> {
-    const result = await this.pool.query(SQL.postgres.insertJob, [
+  /**
+   * Resolves where a statement should run. With a caller transaction the work
+   * has to go through their client -- the pool would hand back a different
+   * connection, which commits independently of them.
+   */
+  private executor(tx?: TransactionHandle): Pool | PoolClient {
+    if (tx === undefined) return this.pool;
+
+    if (typeof (tx as PoolClient)?.query !== 'function') {
+      throw new Error('izi-queue: the transaction handle must be a pg PoolClient or Client');
+    }
+
+    return tx as PoolClient;
+  }
+
+  async insertJob(job: Omit<Job, 'id' | 'insertedAt'>, tx?: TransactionHandle): Promise<Job> {
+    const result = await this.executor(tx).query(SQL.postgres.insertJob, [
       job.state,
       job.queue,
       job.worker,
@@ -295,17 +310,15 @@ export class PostgresAdapter extends BaseAdapter {
 
   async insertUnique(
     job: Omit<Job, 'id' | 'insertedAt'>,
-    options: UniqueOptions
+    options: UniqueOptions,
+    tx?: TransactionHandle
   ): Promise<{ job: Job; conflict: boolean }> {
     const { states, period } = this.uniqueLookup(options);
     const uniqueKey = job.uniqueKey ?? computeUniqueKey(job, options);
 
-    const client = await this.pool.connect();
-    try {
-      await client.query('BEGIN');
-
-      // Held until commit, so a concurrent caller with the same unique key
-      // waits here and then sees the committed row rather than an empty result.
+    const claim = async (client: Pool | PoolClient): Promise<{ job: Job; conflict: boolean }> => {
+      // Transaction-scoped, so it is held until whoever owns the transaction
+      // commits -- the caller when they supplied one, otherwise us.
       await client.query('SELECT pg_advisory_xact_lock($1)', [advisoryLockKey(uniqueKey)]);
 
       const existing = await client.query(
@@ -314,7 +327,6 @@ export class PostgresAdapter extends BaseAdapter {
       );
 
       if (existing.rows[0]) {
-        await client.query('COMMIT');
         return { job: rowToJob(existing.rows[0]), conflict: true };
       }
 
@@ -333,8 +345,21 @@ export class PostgresAdapter extends BaseAdapter {
         uniqueKey
       ]);
 
-      await client.query('COMMIT');
       return { job: rowToJob(inserted.rows[0]), conflict: false };
+    };
+
+    // Inside the caller's transaction: their BEGIN/COMMIT governs atomicity,
+    // and issuing our own would end their transaction early.
+    if (tx !== undefined) {
+      return claim(this.executor(tx));
+    }
+
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+      const result = await claim(client);
+      await client.query('COMMIT');
+      return result;
     } catch (error) {
       await client.query('ROLLBACK').catch(() => {});
       throw error;
@@ -362,9 +387,12 @@ export class PostgresAdapter extends BaseAdapter {
     });
   }
 
-  async notify(queue: string): Promise<void> {
+  async notify(queue: string, tx?: TransactionHandle): Promise<void> {
     const payload = JSON.stringify({ queue });
-    await this.pool.query('SELECT pg_notify($1, $2)', ['izi_jobs_insert', payload]);
+    // Issued on the caller's connection when there is one. PostgreSQL defers
+    // NOTIFY until commit and discards it on rollback, so the wake-up inherits
+    // the transaction's fate for free.
+    await this.executor(tx).query('SELECT pg_notify($1, $2)', ['izi_jobs_insert', payload]);
   }
 
   async close(): Promise<void> {

--- a/src/database/sqlite.ts
+++ b/src/database/sqlite.ts
@@ -1,5 +1,5 @@
 import type { Database } from 'better-sqlite3';
-import type { Job, JobCriteria, JobState, UniqueOptions } from '../types.js';
+import type { Job, JobCriteria, JobState, TransactionHandle, UniqueOptions } from '../types.js';
 import { BaseAdapter, DEFAULT_NODE_TTL, criteriaClause, rowToJob } from './adapter.js';
 import { computeUniqueKey } from '../core/unique.js';
 import { sqliteMigrations } from './migrations.js';
@@ -74,7 +74,22 @@ export class SQLiteAdapter extends BaseAdapter {
     }));
   }
 
-  async insertJob(job: Omit<Job, 'id' | 'insertedAt'>): Promise<Job> {
+  /**
+   * better-sqlite3 has a single connection, so any statement issued while a
+   * transaction is open is already part of it. The handle exists to make that
+   * explicit at the call site and to catch the mistake of passing a different
+   * database, which would silently commit outside the caller's transaction.
+   */
+  private resolveTx(tx?: TransactionHandle): void {
+    if (tx !== undefined && tx !== this.db) {
+      throw new Error(
+        'izi-queue: the transaction handle must be the same database the adapter was created with'
+      );
+    }
+  }
+
+  async insertJob(job: Omit<Job, 'id' | 'insertedAt'>, tx?: TransactionHandle): Promise<Job> {
+    this.resolveTx(tx);
     const stmt = this.db.prepare(`
       INSERT INTO izi_jobs (state, queue, worker, args, meta, tags, errors, attempt, max_attempts, priority, scheduled_at, unique_key)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -297,21 +312,30 @@ export class SQLiteAdapter extends BaseAdapter {
 
   async insertUnique(
     job: Omit<Job, 'id' | 'insertedAt'>,
-    options: UniqueOptions
+    options: UniqueOptions,
+    tx?: TransactionHandle
   ): Promise<{ job: Job; conflict: boolean }> {
+    this.resolveTx(tx);
+
     const { states, period } = this.uniqueLookup(options);
     const uniqueKey = job.uniqueKey ?? computeUniqueKey(job, options);
+
+    const claim = (): { job: Job; conflict: boolean } => {
+      const existing = this.findUnique(uniqueKey, states, period);
+      if (existing) return { job: existing, conflict: true };
+      return { job: this.insertJobSync({ ...job, uniqueKey }), conflict: false };
+    };
+
+    // Already inside the caller's transaction: opening another would fail, and
+    // their transaction is what makes the check-and-insert atomic.
+    if (tx !== undefined || this.db.inTransaction) {
+      return claim();
+    }
 
     // `immediate` takes the write lock up front. A deferred transaction would
     // start as a reader and only try to upgrade at the INSERT, which SQLite
     // refuses outright rather than waiting when another writer got there first.
-    const run = this.db.transaction(() => {
-      const existing = this.findUnique(uniqueKey, states, period);
-      if (existing) return { job: existing, conflict: true };
-      return { job: this.insertJobSync({ ...job, uniqueKey }), conflict: false };
-    });
-
-    return run.immediate();
+    return this.db.transaction(claim).immediate();
   }
 
   private insertJobSync(job: Omit<Job, 'id' | 'insertedAt'>): Job {

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,17 @@ export interface JobCriteria {
   all?: boolean;
 }
 
+/**
+ * A caller-managed transaction handle, passed straight through to the adapter.
+ * Adapter-specific by nature, so the shared type stays open and each adapter
+ * validates what it is given:
+ *
+ * - PostgreSQL: a `PoolClient` with `BEGIN` already issued
+ * - MySQL: a `PoolConnection` with `beginTransaction()` already called
+ * - SQLite: the `Database`, with `BEGIN` issued manually
+ */
+export type TransactionHandle = unknown;
+
 export interface JobInsertOptions<T = Record<string, unknown>> {
   args: T;
   queue?: string;
@@ -66,6 +77,11 @@ export interface JobInsertOptions<T = Record<string, unknown>> {
   meta?: Record<string, unknown>;
   tags?: string[];
   unique?: UniqueOptions;
+  /**
+   * Insert as part of the caller's transaction, so the job is committed or
+   * discarded atomically with their business write.
+   */
+  tx?: TransactionHandle;
 }
 
 export type WorkerResult =
@@ -151,7 +167,7 @@ export interface WorkerThreadMessage {
 
 export interface DatabaseAdapter {
   migrate(): Promise<void>;
-  insertJob(job: Omit<Job, 'id' | 'insertedAt'>): Promise<Job>;
+  insertJob(job: Omit<Job, 'id' | 'insertedAt'>, tx?: TransactionHandle): Promise<Job>;
   /**
    * Claims up to `limit` available jobs for `queue`, marking them executing.
    * `node` is recorded on each claimed job so orphan rescue can tell a job
@@ -194,11 +210,16 @@ export interface DatabaseAdapter {
    */
   insertUnique?(
     job: Omit<Job, 'id' | 'insertedAt'>,
-    options: UniqueOptions
+    options: UniqueOptions,
+    tx?: TransactionHandle
   ): Promise<{ job: Job; conflict: boolean }>;
   close(): Promise<void>;
   listen?(callback: (event: { queue: string }) => void): Promise<void>;
-  notify?(queue: string): Promise<void>;
+  /**
+   * Wakes queues for `queue`. When a transaction is supplied the notification
+   * must not be observable before it commits.
+   */
+  notify?(queue: string, tx?: TransactionHandle): Promise<void>;
 }
 
 export interface IsolationConfig {

--- a/tests/mysql-adapter.test.ts
+++ b/tests/mysql-adapter.test.ts
@@ -301,4 +301,68 @@ describeMySQL('MySQLAdapter', () => {
       }
     });
   });
+
+  describe('transactional insert', () => {
+    it('discards the job when the caller rolls back', async () => {
+      const conn = await pool.getConnection();
+      try {
+        await conn.beginTransaction();
+        await adapter.insertJob(jobData({ args: { orderId: 1 } }), conn);
+        await conn.rollback();
+      } finally {
+        conn.release();
+      }
+
+      const [rows] = await pool.query<mysql.RowDataPacket[]>('SELECT COUNT(*) AS c FROM izi_jobs');
+      expect(Number(rows[0].c)).toBe(0);
+    });
+
+    it('keeps the job when the caller commits', async () => {
+      const conn = await pool.getConnection();
+      try {
+        await conn.beginTransaction();
+        await adapter.insertJob(jobData({ args: { orderId: 1 } }), conn);
+        await conn.commit();
+      } finally {
+        conn.release();
+      }
+
+      const [rows] = await pool.query<mysql.RowDataPacket[]>('SELECT COUNT(*) AS c FROM izi_jobs');
+      expect(Number(rows[0].c)).toBe(1);
+    });
+
+    it('does not make the job visible to other connections before commit', async () => {
+      const conn = await pool.getConnection();
+      try {
+        await conn.beginTransaction();
+        await adapter.insertJob(jobData(), conn);
+
+        expect(await adapter.fetchJobs('default', 5, 'node-a')).toHaveLength(0);
+
+        await conn.commit();
+      } finally {
+        conn.release();
+      }
+
+      expect(await adapter.fetchJobs('default', 5, 'node-a')).toHaveLength(1);
+    });
+
+    it('refuses a unique insert inside a caller transaction rather than weakening the guarantee', async () => {
+      // GET_LOCK is connection-scoped and not transactional, so it cannot be
+      // held across the caller's commit. Releasing it at insert time would let
+      // a concurrent node insert a duplicate -- exactly the race that was fixed
+      // for the non-transactional path. Refusing is honest; silently degrading
+      // is not.
+      const conn = await pool.getConnection();
+      try {
+        await conn.beginTransaction();
+        await expect(
+          adapter.insertUnique(jobData({ args: { userId: 1 } }), { period: 60 }, conn)
+        ).rejects.toThrow(/unique/i);
+        await conn.rollback();
+      } finally {
+        conn.release();
+      }
+    });
+  });
 });

--- a/tests/postgres-adapter.test.ts
+++ b/tests/postgres-adapter.test.ts
@@ -257,4 +257,141 @@ describePostgres('PostgresAdapter', () => {
       }
     });
   });
+
+  describe('transactional insert', () => {
+    it('discards the job when the caller rolls back', async () => {
+      const client = await pool.connect();
+      try {
+        await client.query('BEGIN');
+        await adapter.insertJob(jobData({ args: { orderId: 1 } }), client);
+        await client.query('ROLLBACK');
+      } finally {
+        client.release();
+      }
+
+      const { rows } = await pool.query('SELECT COUNT(*)::int AS count FROM izi_jobs');
+      expect(rows[0].count).toBe(0);
+    });
+
+    it('keeps the job when the caller commits', async () => {
+      const client = await pool.connect();
+      try {
+        await client.query('BEGIN');
+        await adapter.insertJob(jobData({ args: { orderId: 1 } }), client);
+        await client.query('COMMIT');
+      } finally {
+        client.release();
+      }
+
+      const { rows } = await pool.query('SELECT COUNT(*)::int AS count FROM izi_jobs');
+      expect(rows[0].count).toBe(1);
+    });
+
+    it('does not make the job visible to other connections before commit', async () => {
+      const client = await pool.connect();
+      try {
+        await client.query('BEGIN');
+        await adapter.insertJob(jobData(), client);
+
+        // A worker on another connection must not be able to claim it yet.
+        const claimedEarly = await adapter.fetchJobs('default', 5, 'node-a');
+        expect(claimedEarly).toHaveLength(0);
+
+        await client.query('COMMIT');
+      } finally {
+        client.release();
+      }
+
+      const claimedAfter = await adapter.fetchJobs('default', 5, 'node-a');
+      expect(claimedAfter).toHaveLength(1);
+    });
+
+    it('holds the wake-up notification until commit', async () => {
+      const listener = await pool.connect();
+      const received: string[] = [];
+      try {
+        await listener.query('LISTEN izi_jobs_insert');
+        listener.on('notification', msg => received.push(msg.payload ?? ''));
+
+        const client = await pool.connect();
+        try {
+          await client.query('BEGIN');
+          await adapter.insertJob(jobData(), client);
+          await adapter.notify('default', client);
+
+          // PostgreSQL defers NOTIFY until commit, which is exactly what is
+          // wanted: waking a worker early sends it looking for an invisible row.
+          await new Promise(resolve => setTimeout(resolve, 150));
+          expect(received).toHaveLength(0);
+
+          await client.query('COMMIT');
+        } finally {
+          client.release();
+        }
+
+        await new Promise(resolve => setTimeout(resolve, 250));
+        expect(received.length).toBeGreaterThan(0);
+      } finally {
+        await listener.query('UNLISTEN izi_jobs_insert');
+        listener.release();
+      }
+    });
+
+    it('drops the notification entirely when the caller rolls back', async () => {
+      const listener = await pool.connect();
+      const received: string[] = [];
+      try {
+        await listener.query('LISTEN izi_jobs_insert');
+        listener.on('notification', msg => received.push(msg.payload ?? ''));
+
+        const client = await pool.connect();
+        try {
+          await client.query('BEGIN');
+          await adapter.insertJob(jobData(), client);
+          await adapter.notify('default', client);
+          await client.query('ROLLBACK');
+        } finally {
+          client.release();
+        }
+
+        await new Promise(resolve => setTimeout(resolve, 250));
+        expect(received).toHaveLength(0);
+      } finally {
+        await listener.query('UNLISTEN izi_jobs_insert');
+        listener.release();
+      }
+    });
+
+    it('rolls a unique job back with its transaction, leaving no phantom conflict', async () => {
+      const client = await pool.connect();
+      try {
+        await client.query('BEGIN');
+        await adapter.insertUnique(jobData({ args: { userId: 1 } }), { period: 60 }, client);
+        await client.query('ROLLBACK');
+      } finally {
+        client.release();
+      }
+
+      const after = await adapter.insertUnique(jobData({ args: { userId: 1 } }), { period: 60 });
+      expect(after.conflict).toBe(false);
+    });
+
+    it('still deduplicates unique jobs inside a transaction', async () => {
+      const client = await pool.connect();
+      try {
+        await client.query('BEGIN');
+        const first = await adapter.insertUnique(jobData({ args: { userId: 1 } }), { period: 60 }, client);
+        const second = await adapter.insertUnique(jobData({ args: { userId: 1 } }), { period: 60 }, client);
+        await client.query('COMMIT');
+
+        expect(first.conflict).toBe(false);
+        expect(second.conflict).toBe(true);
+      } finally {
+        client.release();
+      }
+
+      const { rows } = await pool.query('SELECT COUNT(*)::int AS count FROM izi_jobs');
+      expect(rows[0].count).toBe(1);
+    });
+  });
 });

--- a/tests/transactional-insert.test.ts
+++ b/tests/transactional-insert.test.ts
@@ -1,0 +1,106 @@
+import Database from 'better-sqlite3';
+import { IziQueue } from '../src/core/izi-queue.js';
+import { clearWorkers } from '../src/core/worker.js';
+import { createSQLiteAdapter, SQLiteAdapter } from '../src/database/sqlite.js';
+
+/**
+ * The point of a database-backed queue: a job must not survive a business write
+ * that rolled back, and must not be visible before one that committed.
+ */
+describe('transactional insert (SQLite)', () => {
+  let db: Database.Database;
+  let adapter: SQLiteAdapter;
+  let queue: IziQueue;
+
+  beforeEach(async () => {
+    db = new Database(':memory:');
+    adapter = createSQLiteAdapter(db);
+    await adapter.migrate();
+    db.exec('CREATE TABLE orders (id INTEGER PRIMARY KEY, total INTEGER NOT NULL)');
+    clearWorkers();
+
+    queue = new IziQueue({ database: adapter, queues: { default: 1 } });
+  });
+
+  afterEach(async () => {
+    await adapter.close();
+  });
+
+  function countJobs(): number {
+    return (db.prepare('SELECT COUNT(*) AS c FROM izi_jobs').get() as { c: number }).c;
+  }
+
+  it('discards the job when the surrounding transaction rolls back', async () => {
+    db.exec('BEGIN');
+    try {
+      db.prepare('INSERT INTO orders (total) VALUES (?)').run(100);
+      await queue.insert('send_receipt', { args: { orderId: 1 }, tx: db });
+      throw new Error('payment declined');
+    } catch {
+      db.exec('ROLLBACK');
+    }
+
+    expect(countJobs()).toBe(0);
+    expect((db.prepare('SELECT COUNT(*) AS c FROM orders').get() as { c: number }).c).toBe(0);
+  });
+
+  it('keeps the job when the surrounding transaction commits', async () => {
+    db.exec('BEGIN');
+    db.prepare('INSERT INTO orders (total) VALUES (?)').run(100);
+    const job = await queue.insert('send_receipt', { args: { orderId: 1 }, tx: db });
+    db.exec('COMMIT');
+
+    expect(countJobs()).toBe(1);
+    expect((await queue.getJob(job.id))?.args).toEqual({ orderId: 1 });
+  });
+
+  it('rolls back a unique job with its transaction', async () => {
+    db.exec('BEGIN');
+    await queue.insert('digest', { args: { userId: 1 }, unique: { period: 60 }, tx: db });
+    db.exec('ROLLBACK');
+
+    expect(countJobs()).toBe(0);
+
+    // The rolled-back job must not linger as a phantom conflict.
+    const { conflict } = await queue.insertWithResult('digest', {
+      args: { userId: 1 },
+      unique: { period: 60 },
+    });
+    expect(conflict).toBe(false);
+  });
+
+  it('still deduplicates unique jobs inside a transaction', async () => {
+    db.exec('BEGIN');
+    const first = await queue.insertWithResult('digest', {
+      args: { userId: 1 },
+      unique: { period: 60 },
+      tx: db,
+    });
+    const second = await queue.insertWithResult('digest', {
+      args: { userId: 1 },
+      unique: { period: 60 },
+      tx: db,
+    });
+    db.exec('COMMIT');
+
+    expect(first.conflict).toBe(false);
+    expect(second.conflict).toBe(true);
+    expect(countJobs()).toBe(1);
+  });
+
+  it('rejects a handle from a different database', async () => {
+    const other = new Database(':memory:');
+    try {
+      await expect(
+        queue.insert('send_receipt', { args: {}, tx: other })
+      ).rejects.toThrow(/same database/i);
+    } finally {
+      other.close();
+    }
+  });
+
+  it('inserts outside any transaction when no handle is given', async () => {
+    await queue.insert('send_receipt', { args: {} });
+    expect(countJobs()).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes #21 — the last of the original review's high-severity items, and the biggest remaining gap against Oban.

## The claim this makes true

The README's second bullet used to promise:

> **ACID guarantees** — Jobs are inserted transactionally with your business data

It was never true. Every insert committed on its own connection, so a job could outlive a rolled-back write, or become visible to a worker before the row it referred to. I removed the claim in the docs pass rather than leave it standing. This implements it, and puts it back.

```typescript
await client.query('BEGIN');
const { rows } = await client.query('INSERT INTO orders (total) VALUES ($1) RETURNING id', [total]);
await queue.insert('send_receipt', { args: { orderId: rows[0].id }, tx: client });
await client.query('COMMIT');   // job and order commit together
```

Proven end to end against PostgreSQL 16 with a real business table — one order placed, one payment declined:

```
order 1 -> committed
order 2 -> rolled back: payment declined

orders: 1   receipt jobs: 1   <- consistent
```

## Design

`tx` is whatever your driver already uses, so this composes with existing transaction management rather than imposing its own:

| Adapter | Pass as `tx` | Opened with |
| --- | --- | --- |
| PostgreSQL | `PoolClient` | `client.query('BEGIN')` |
| MySQL | `PoolConnection` | `connection.beginTransaction()` |
| SQLite | the `Database` | `db.exec('BEGIN')` |

### PostgreSQL gets correct notification semantics for free

The wake-up is issued on the caller's connection, and PostgreSQL defers `NOTIFY` until commit and discards it on rollback. So a worker is never nudged toward an uncommitted row, and not nudged at all if the caller rolls back. Both are covered by tests that `LISTEN` on a second connection and assert nothing arrives before commit.

Unique inserts participate too — `pg_advisory_xact_lock` is transaction-scoped, so the lock is held until the caller commits and uniqueness spans their transaction.

### MySQL refuses `unique` + `tx`, deliberately

`GET_LOCK` is connection-scoped and not transactional, so it cannot be held across the caller's commit. Releasing it at insert time would leave a window for a concurrent node to insert a duplicate — reopening the exact race that #19 closed.

So it throws, with an error naming the constraint and the two ways around it. A guarantee that quietly stops holding under one dialect is worse than a clear refusal.

### SQLite

One connection, so any insert during an open transaction is already part of it. The handle makes that explicit and rejects a *different* database, which would otherwise commit outside the caller's transaction without complaint. Note `db.exec('BEGIN')`, not `db.transaction()` — the latter is synchronous and cannot await.

## Compatibility

None. `tx` is optional on `insert`, and the new parameters on `insertJob`, `insertUnique` and `notify` are all optional, so third-party adapters keep compiling and behave exactly as before when no handle is passed.

## Verification

**342 tests** against SQLite, PostgreSQL 16 and MySQL 8.4, up from 325. New coverage: rollback discards the job, commit keeps it, an uncommitted job cannot be claimed by another connection, notification deferred to commit, notification dropped on rollback, unique jobs rolled back leave no phantom conflict, unique dedup still works inside a transaction, and the MySQL refusal.