### PR TITLE
chore(release): 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 While the version is below 1.0.0, breaking changes are released as minor versions.
 
-## [Unreleased]
+## [0.6.0] - 2026-08-04
 
 ### Added
 
@@ -281,3 +281,4 @@ production. Anyone running 0.3.0 or earlier should upgrade.
 [0.4.0]: https://github.com/iagocavalcante/izi-queue/compare/v0.3.0...v0.4.0
 [0.4.1]: https://github.com/iagocavalcante/izi-queue/compare/v0.4.0...v0.4.1
 [0.5.0]: https://github.com/iagocavalcante/izi-queue/compare/v0.4.1...v0.5.0
+[0.6.0]: https://github.com/iagocavalcante/izi-queue/compare/v0.5.0...v0.6.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "izi-queue",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "izi-queue",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "izi-queue",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A minimal, reliable, database-backed job queue for Node.js inspired by Oban",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Version bump and changelog for 0.6.0, shipping #60.

## Why 0.6.0 and not 0.5.1

It adds public API surface — `tx` on `insert`, and new optional parameters on `insertJob`, `insertUnique` and `notify`. A patch would understate a new capability, even though **nothing breaks**: every new parameter is optional, so existing callers and third-party adapters behave exactly as before.

**No migrations in this release.**

## What ships

Transactional inserts (#21) — the last high-severity item from the original production review:

```typescript
await client.query('BEGIN');
const { rows } = await client.query('INSERT INTO orders (total) VALUES ($1) RETURNING id', [total]);
await queue.insert('send_receipt', { args: { orderId: rows[0].id }, tx: client });
await client.query('COMMIT');   // job and order commit together
```

Verified end to end against PostgreSQL 16 with a real business table — one order placed, one payment declined:

```
order 1 -> committed
order 2 -> rolled back: payment declined

orders: 1   receipt jobs: 1   <- consistent
```

## Verification

- **342 tests**, all 9 CI checks green on #60 — Node 18/20/22/24 against PostgreSQL 16 and MySQL 8, with `342 passed, 0 skipped` in CI, so the transaction tests genuinely ran against real databases
- Clean rebuild, lint clean, suite exits without forced teardown
- `npm pack` produces a 60.9 kB tarball

## Known issue

#57 — the intermittent single-test failure remains open and unidentified. It did not appear during this release build.