### PR TITLE
Make worker isolation work outside the test runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,3 +123,56 @@ jobs:
             if (typeof m.IziQueue !== 'function') { throw new Error('entry point did not resolve'); }
             console.log('izi-queue resolves, exports', Object.keys(m).length, 'symbols');
           })"
+
+      # The unit tests run under CommonJS, so they cannot catch ESM-only
+      # breakage. Worker isolation shipped broken for exactly that reason: the
+      # published package is ESM, and the path resolver used `require`. This
+      # runs a real isolated job through the packed tarball.
+      - name: Run an isolated job through the packed tarball
+        run: |
+          cd /tmp/consumer
+          mkdir -p workers
+          cat > workers/double.js <<'WORKER'
+          export async function perform(job) {
+            return { status: 'ok', value: { doubled: job.args.n * 2 } };
+          }
+          WORKER
+          cat > isolation-check.mjs <<'CHECK'
+          import Database from 'better-sqlite3';
+          import { IziQueue, defineWorker, createSQLiteAdapter } from 'izi-queue';
+          import { join } from 'path';
+
+          const queue = new IziQueue({
+            database: createSQLiteAdapter(new Database(':memory:')),
+            queues: { default: 2 },
+            pollInterval: 50,
+            stageInterval: 50,
+            isolation: { maxThreads: 2 },
+          });
+
+          queue.register(defineWorker('double', async () => ({ status: 'ok' }), {
+            isolation: { isolated: true, workerPath: join(process.cwd(), 'workers/double.js') },
+          }));
+
+          await queue.migrate();
+          await queue.start();
+          const job = await queue.insert('double', { args: { n: 21 } });
+
+          const deadline = Date.now() + 15000;
+          let final;
+          while (Date.now() < deadline) {
+            final = await queue.getJob(job.id);
+            if (final && final.state !== 'available' && final.state !== 'executing') break;
+            await new Promise(r => setTimeout(r, 50));
+          }
+
+          await queue.stop();
+
+          if (final?.state !== 'completed') {
+            console.error('isolated job did not complete:', final?.state, final?.errors?.[0]?.error);
+            process.exit(1);
+          }
+          console.log('isolated job completed in an ESM consumer');
+          process.exit(0);
+          CHECK
+          node isolation-check.mjs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ While the version is below 1.0.0, breaking changes are released as minor version
 
 ## [0.6.0] - 2026-08-04
 
+### Fixed
+
+- **Worker isolation never worked outside the test runner.** The published
+  package is ESM-only, and the worker path resolver called `require('fs')`
+  unconditionally, so every isolated job failed with `require is not defined`.
+  The unit tests stayed green because Jest transpiles to CommonJS, where
+  `require` exists -- they never exercised the shipped artifact. Resolution now
+  uses `import.meta.url`, and CI runs a real isolated job through the packed
+  tarball in an ESM project, which is the only place this class of breakage is
+  visible.
+
 ### Added
 
 - **Transactional inserts.** Pass your open transaction as `tx` and the job is

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -3,6 +3,10 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   moduleNameMapper: {
+    // worker-path reads import.meta.url, which cannot be parsed as CommonJS.
+    // The real module is covered by the CI job that runs an isolated job from
+    // the packed tarball in an ESM project.
+    '^(.*/)?worker-path\\.js$': '<rootDir>/tests/helpers/worker-path-cjs.ts',
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },
   transform: {

--- a/src/core/isolation/thread-pool.ts
+++ b/src/core/isolation/thread-pool.ts
@@ -1,6 +1,7 @@
 import { Worker } from 'worker_threads';
-import { fileURLToPath } from 'url';
-import { dirname, join } from 'path';
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { isolationDir } from './worker-path.js';
 import type {
   IsolatedWorkerOptions,
   SerializableJob,
@@ -9,44 +10,18 @@ import type {
 } from '../../types.js';
 import { telemetry } from '../telemetry.js';
 
+/** Locates the compiled worker thread entry point next to this module. */
 function getWorkerThreadPath(): string {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const fs = require('fs');
+  const path = join(isolationDir(), 'worker-thread.js');
 
-  // CommonJS environment (Jest and some Node.js setups)
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore - __dirname may not be available in ESM
-  if (typeof __dirname !== 'undefined') {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore - __dirname available in CommonJS
-    let workerPath = join(__dirname, 'worker-thread.js');
-
-    // If running from source (e.g., Jest), try to find the compiled version in dist
-    if (!fs.existsSync(workerPath)) {
-      // Try dist path - src/core/isolation -> dist/core/isolation
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore - __dirname available in CommonJS
-      const distPath = __dirname.replace('/src/', '/dist/').replace('\\src\\', '\\dist\\');
-      const distWorkerPath = join(distPath, 'worker-thread.js');
-      if (fs.existsSync(distWorkerPath)) {
-        workerPath = distWorkerPath;
-      }
-    }
-
-    return workerPath;
+  if (!existsSync(path)) {
+    throw new Error(
+      `izi-queue: could not find the isolated worker entry point at ${path}. ` +
+        'If you are running from source, build the package first.'
+    );
   }
 
-  // ESM environment - use dynamic evaluation to avoid parser errors in CJS
-  // eslint-disable-next-line no-eval
-  const getMetaUrl = new Function('return import.meta.url');
-  try {
-    const currentUrl = getMetaUrl();
-    const currentFilename = fileURLToPath(currentUrl);
-    const currentDirname = dirname(currentFilename);
-    return join(currentDirname, 'worker-thread.js');
-  } catch {
-    throw new Error('Cannot determine worker thread path - neither __dirname nor import.meta.url available');
-  }
+  return path;
 }
 
 let WORKER_THREAD_PATH: string;

--- a/src/core/isolation/worker-path.ts
+++ b/src/core/isolation/worker-path.ts
@@ -1,0 +1,21 @@
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+/**
+ * Directory holding the compiled isolation modules, and therefore the worker
+ * thread entry point.
+ *
+ * `import.meta.url` has to appear literally: it is the only way an ES module
+ * can learn its own location, and there is no runtime substitute. `require`
+ * does not exist in the published package (it is ESM-only), and a direct
+ * `eval` does not help either -- eval code is parsed as a script, where
+ * `import.meta` is a syntax error regardless of the enclosing module.
+ *
+ * That makes this file unloadable under the CommonJS test runner, so Jest maps
+ * it to a stand-in (see `moduleNameMapper`). The real implementation is
+ * exercised where it matters: the CI job that installs the packed tarball into
+ * an ESM project and runs an isolated job through it.
+ */
+export function isolationDir(): string {
+  return dirname(fileURLToPath(import.meta.url));
+}

--- a/tests/fixtures/test-isolated-worker.js
+++ b/tests/fixtures/test-isolated-worker.js
@@ -1,5 +1,5 @@
 // Test worker for isolated execution tests
-import { isMainThread } from 'worker_threads';
+import { isMainThread, threadId } from 'worker_threads';
 
 export async function perform(job) {
   // Verify we're running in a worker thread
@@ -19,12 +19,16 @@ export async function perform(job) {
         value: { processed: true, jobId: job.id, isMainThread }
       };
 
-    case 'delay':
+    case 'delay': {
+      // Reported so tests can observe parallelism directly, rather than
+      // inferring it from how long the batch took on the wall clock.
+      const startedAt = Date.now();
       await new Promise(resolve => setTimeout(resolve, delay || 100));
       return {
         status: 'ok',
-        value: { delayed: delay, jobId: job.id }
+        value: { delayed: delay, jobId: job.id, threadId, startedAt, finishedAt: Date.now() }
       };
+    }
 
     case 'crash':
       throw new Error(crashMessage || 'Intentional crash');

--- a/tests/helpers/worker-path-cjs.ts
+++ b/tests/helpers/worker-path-cjs.ts
@@ -1,0 +1,12 @@
+import { join } from 'path';
+
+/**
+ * CommonJS stand-in for `src/core/isolation/worker-path.ts`, which cannot load
+ * under the CommonJS test runner because it reads `import.meta.url`.
+ *
+ * The compiled worker thread only exists under `dist`, which `pretest`
+ * guarantees is built and current.
+ */
+export function isolationDir(): string {
+  return join(process.cwd(), 'dist', 'core', 'isolation');
+}

--- a/tests/isolation/thread-pool.test.ts
+++ b/tests/isolation/thread-pool.test.ts
@@ -143,17 +143,28 @@ describe('ThreadPool', () => {
       );
       const options = createIsolationOptions();
 
-      const startTime = Date.now();
       const results = await Promise.all(
         jobs.map(job => pool.execute(job, options, 5000))
       );
-      const elapsed = Date.now() - startTime;
 
-      // All jobs should complete
       expect(results.every(r => r.status === 'ok')).toBe(true);
 
-      // Should complete in roughly the time of one job since they run in parallel
-      expect(elapsed).toBeLessThan(400); // Allow some overhead
+      // Parallelism is asserted from what the workers report, not from how long
+      // the batch took. A wall-clock ceiling has to cover spawning four threads
+      // as well as the work itself, so on a loaded machine it fails for reasons
+      // that have nothing to do with whether the jobs ran in parallel.
+      const runs = results.map(
+        r => (r as { status: 'ok'; value: { threadId: number; startedAt: number; finishedAt: number } }).value
+      );
+
+      // Spread across the pool rather than queued onto one thread.
+      expect(new Set(runs.map(r => r.threadId)).size).toBeGreaterThan(1);
+
+      // And genuinely overlapping in time, not merely on different threads.
+      const overlapping = runs.some((a, i) =>
+        runs.some((b, j) => i !== j && a.startedAt < b.finishedAt && b.startedAt < a.finishedAt)
+      );
+      expect(overlapping).toBe(true);
     });
   });
 


### PR DESCRIPTION
Closes #57. **Found while running the 0.6.0 publish** — `prepublishOnly` failed, so 0.6.0 was never published. This should go out with it.

## Worker isolation has never worked for anyone

```
state : retryable
error : require is not defined
```

That is izi-queue **0.5.0**, installed from npm into an ESM project, running an isolated worker. The path resolver called `require('fs')` unconditionally and the package is ESM-only, so `require` does not exist there. A documented headline feature, failing 100% of the time in real use.

**The unit tests were green the whole time**, because Jest transpiles to CommonJS where `require` is defined. They were testing a module system the package does not ship in. That is the actual lesson here, and it is why the fix comes with a CI job rather than another unit test.

After:

```
state : completed
error : (none)
```

## Why the fix looks the way it does

`import.meta.url` is the only way an ES module can learn its own location. I tried the two runtime workarounds before settling, rather than assuming:

| Attempt | Result |
|---|---|
| `new Function('return import.meta.url')` | Evaluates in **global** scope — `import.meta` invalid |
| `eval('import.meta.url')` | Eval code is parsed as a **script** — `SyntaxError: Cannot use 'import.meta' outside a module`, even inside an ES module |

So it has to appear literally, which means that module cannot be parsed as CommonJS. It is therefore isolated in its own file (`worker-path.ts`) and Jest maps it to a stand-in.

That trade is deliberate and I want it visible: **the source stays correct for the artifact that ships**, and the real resolver is covered where the failure actually appears —

## The CI job that would have caught this

```yaml
- name: Run an isolated job through the packed tarball
```

It installs the packed tarball into a clean ESM project, defines a worker, and runs a real isolated job end to end. Unit tests structurally cannot catch ESM-only breakage; this can.

## Also fixes #57 — the flake, finally identified

Three sightings, and it surfaced during the publish with its name at last:

```
● ThreadPool › execute › should execute multiple jobs concurrently
  expect(elapsed).toBeLessThan(400)
  Received: 573
```

Four 100ms jobs asserted to finish in under 400ms — **exactly the sequential time**, so zero margin, and the window also had to cover spawning four worker threads from scratch. On a machine that had just run `npm run build`, it lost.

It now asserts parallelism from what the workers report — distinct thread ids and overlapping execution intervals — which is what the test was actually trying to establish and does not depend on machine speed. Verified stable under deliberate CPU saturation.

So #57 was a test defect, not a product race. That was the open question on it.

## Verification

342 tests, clean rebuild, lint clean. The ESM isolation path verified by hand against the packed tarball, and now guarded in CI.