### PR TITLE
Queue saturated isolated jobs, apply resource limits, recover the listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 While the version is below 1.0.0, breaking changes are released as minor versions.
 
+## [Unreleased]
+
+### Fixed
+
+- **Isolated jobs failed when the thread pool was full.** A job arriving while
+  every thread was busy came back with `No available worker threads`, which the
+  queue recorded as a failure and charged one of the job's retry attempts --
+  for something the job had no part in. Any queue whose concurrency exceeded
+  `maxThreads` hit this routinely. Jobs now wait for a thread. The job's
+  `timeout` covers the wait as well as the execution, so a saturated pool
+  cannot leave work outstanding indefinitely, and giving up while queued
+  reports a distinct error rather than looking like an execution failure.
+  ([#22])
+- **`resourceLimits` were never applied.** They were typed, documented and
+  passed in, but the pool created every thread with no limits, so isolated
+  workers ran without the memory cap that is the main reason to isolate them at
+  all. Limits are now applied when the thread is created, and the pool is
+  partitioned by them so a job never lands on a thread with the wrong caps.
+  ([#23])
+- **The PostgreSQL notification listener never recovered from a dropped
+  connection.** After a failover, an idle-connection reaper or a network blip,
+  the listener stopped receiving notifications permanently and the queue
+  degraded to poll-only with nothing to indicate it. The listener now
+  re-subscribes with backoff, and reports the disconnect through telemetry.
+  Verified by terminating its backend mid-test and asserting notifications
+  resume. ([#24])
+
 ## [0.6.0] - 2026-08-04
 
 ### Fixed
@@ -278,6 +305,9 @@ production. Anyone running 0.3.0 or earlier should upgrade.
 [#20]: https://github.com/iagocavalcante/izi-queue/issues/20
 [#25]: https://github.com/iagocavalcante/izi-queue/issues/25
 [#21]: https://github.com/iagocavalcante/izi-queue/issues/21
+[#22]: https://github.com/iagocavalcante/izi-queue/issues/22
+[#23]: https://github.com/iagocavalcante/izi-queue/issues/23
+[#24]: https://github.com/iagocavalcante/izi-queue/issues/24
 [#28]: https://github.com/iagocavalcante/izi-queue/issues/28
 [#41]: https://github.com/iagocavalcante/izi-queue/issues/41
 [#42]: https://github.com/iagocavalcante/izi-queue/issues/42

--- a/README.md
+++ b/README.md
@@ -191,6 +191,10 @@ const isolatedWorker = defineWorker('heavy_computation', async (job) => {
   isolation: {
     isolated: true,
     workerPath: './workers/heavy-computation.js',
+    resourceLimits: {
+      maxOldGenerationSizeMb: 128,   // caps the worker's V8 heap
+      maxYoungGenerationSizeMb: 32,
+    },
   },
   timeout: 30000, // 30 seconds
 });
@@ -206,14 +210,16 @@ const queue = new IziQueue({
 });
 ```
 
-> **Keep a queue's concurrency at or below `maxThreads`.** A job that finds the
-> pool saturated currently fails with `No available worker threads` and consumes
-> a retry attempt rather than waiting. Tracked in
-> [#22](https://github.com/iagocavalcante/izi-queue/issues/22).
->
-> `resourceLimits` is accepted by the type but **not currently applied** to
-> worker threads, so isolated workers run without a memory cap. Tracked in
-> [#23](https://github.com/iagocavalcante/izi-queue/issues/23).
+A job that arrives while every thread is busy waits for one rather than
+failing, so a queue's concurrency may exceed `maxThreads` without jobs burning
+retry attempts on the pool being full. The job's `timeout` covers that wait as
+well as its execution, so a saturated pool cannot leave work outstanding
+indefinitely.
+
+`resourceLimits` are applied when the thread is created, and threads are pooled
+per limit set — jobs asking for different limits do not share a thread. Note
+that `maxOldGenerationSizeMb` caps the V8 heap; `Buffer` memory lives outside it
+and is not governed by that setting.
 
 ### Plugins
 

--- a/src/core/isolation/thread-pool.ts
+++ b/src/core/isolation/thread-pool.ts
@@ -4,6 +4,7 @@ import { join } from 'path';
 import { isolationDir } from './worker-path.js';
 import type {
   IsolatedWorkerOptions,
+  ResourceLimits,
   SerializableJob,
   WorkerResult,
   WorkerThreadMessage
@@ -31,6 +32,29 @@ interface PooledWorker {
   busy: boolean;
   lastUsed: number;
   currentJobId: number | null;
+  /**
+   * Resource limits are fixed when a thread is created, so a worker can only
+   * serve jobs asking for the same ones. This key partitions the pool.
+   */
+  limitsKey: string;
+  limits?: ResourceLimits;
+}
+
+interface Waiter {
+  limitsKey: string;
+  limits?: ResourceLimits;
+  resolve: (worker: PooledWorker | null) => void;
+}
+
+/** Stable identity for a set of resource limits, used to match threads to jobs. */
+function limitsKeyFor(limits?: ResourceLimits): string {
+  if (!limits) return '';
+  return JSON.stringify({
+    maxOldGenerationSizeMb: limits.maxOldGenerationSizeMb ?? null,
+    maxYoungGenerationSizeMb: limits.maxYoungGenerationSizeMb ?? null,
+    codeRangeSizeMb: limits.codeRangeSizeMb ?? null,
+    stackSizeMb: limits.stackSizeMb ?? null
+  });
 }
 
 export interface ThreadPoolConfig {
@@ -54,6 +78,7 @@ export class ThreadPool {
     timeoutId: ReturnType<typeof setTimeout>;
   }> = new Map();
   private cleanupInterval?: ReturnType<typeof setInterval>;
+  private waiters: Waiter[] = [];
   private shuttingDown = false;
 
   constructor(config: ThreadPoolConfig = {}) {
@@ -87,11 +112,13 @@ export class ThreadPool {
     });
   }
 
-  private createWorker(): PooledWorker {
+  private createWorker(limits?: ResourceLimits): PooledWorker {
     if (!WORKER_THREAD_PATH) {
       WORKER_THREAD_PATH = getWorkerThreadPath();
     }
-    const worker = new Worker(WORKER_THREAD_PATH);
+    // Limits have to be supplied at construction: a thread's heap cannot be
+    // capped after it starts. That is why the pool is partitioned by them.
+    const worker = new Worker(WORKER_THREAD_PATH, limits ? { resourceLimits: limits } : undefined);
 
     telemetry.emit('thread:spawn', {
       threadId: worker.threadId
@@ -101,7 +128,9 @@ export class ThreadPool {
       worker,
       busy: false,
       lastUsed: Date.now(),
-      currentJobId: null
+      currentJobId: null,
+      limitsKey: limitsKeyFor(limits),
+      limits
     };
 
     worker.on('message', (message: WorkerThreadMessage) => {
@@ -135,6 +164,8 @@ export class ThreadPool {
         } else {
           pending.resolve({ status: 'ok' });
         }
+
+        this.handOffToWaiter();
       }
     } else if (message.type === 'error' && message.jobId !== undefined) {
       const pending = this.pendingJobs.get(message.jobId);
@@ -149,6 +180,8 @@ export class ThreadPool {
           status: 'error',
           error: new Error(message.error || 'Unknown worker error')
         });
+
+        this.handOffToWaiter();
       }
     }
   }
@@ -166,10 +199,9 @@ export class ThreadPool {
       }
     }
 
-    const index = this.workers.indexOf(pooled);
-    if (index !== -1) {
-      this.workers.splice(index, 1);
-    }
+    this.removeWorker(pooled);
+    // Its slot is free even though it died, so someone queued can start.
+    this.handOffToWaiter();
 
     telemetry.emit('thread:exit', {
       threadId: pooled.worker.threadId,
@@ -190,28 +222,100 @@ export class ThreadPool {
       }
     }
 
-    const index = this.workers.indexOf(pooled);
-    if (index !== -1) {
-      this.workers.splice(index, 1);
-    }
+    this.removeWorker(pooled);
+    // Its slot is free even though it died, so someone queued can start.
+    this.handOffToWaiter();
 
     telemetry.emit('thread:exit', {
       threadId: pooled.worker.threadId
     });
   }
 
-  private getAvailableWorker(): PooledWorker | null {
-    for (const pooled of this.workers) {
-      if (!pooled.busy) {
-        return pooled;
-      }
+  /**
+   * Finds or creates a thread able to run a job with these limits, waiting if
+   * the pool is saturated.
+   *
+   * Waiting rather than failing is the point: a job that arrives while every
+   * thread is busy has not failed, it has not started. Returning an error would
+   * consume one of its retry attempts for something it had no part in, which is
+   * easy to hit whenever a queue's concurrency exceeds `maxThreads`.
+   */
+  private acquireWorker(limits: ResourceLimits | undefined, signal: { aborted: boolean }): Promise<PooledWorker | null> {
+    const limitsKey = limitsKeyFor(limits);
+
+    const immediate = this.takeIdleWorker(limitsKey, limits);
+    if (immediate) return Promise.resolve(immediate);
+
+    return new Promise<PooledWorker | null>(resolve => {
+      const waiter: Waiter = {
+        limitsKey,
+        limits,
+        resolve: worker => {
+          if (signal.aborted) {
+            // The job gave up while queued; hand the thread to the next in line.
+            if (worker) {
+              worker.busy = false;
+              this.handOffToWaiter();
+            }
+            resolve(null);
+            return;
+          }
+          resolve(worker);
+        }
+      };
+
+      this.waiters.push(waiter);
+    });
+  }
+
+  /** Returns a thread ready for `limitsKey`, or null if none can be had now. */
+  private takeIdleWorker(limitsKey: string, limits?: ResourceLimits): PooledWorker | null {
+    const matching = this.workers.find(w => !w.busy && w.limitsKey === limitsKey);
+    if (matching) {
+      matching.busy = true;
+      return matching;
     }
 
     if (this.workers.length < this.config.maxThreads) {
-      return this.createWorker();
+      const created = this.createWorker(limits);
+      created.busy = true;
+      return created;
+    }
+
+    // At capacity with only mismatched idle threads. Limits are fixed at
+    // construction, so the only way to serve this job is to replace one.
+    const mismatched = this.workers.find(w => !w.busy);
+    if (mismatched) {
+      this.removeWorker(mismatched);
+      this.terminateWorker(mismatched);
+      const created = this.createWorker(limits);
+      created.busy = true;
+      return created;
     }
 
     return null;
+  }
+
+  /** Called whenever a thread frees up or the pool gains capacity. */
+  private handOffToWaiter(): void {
+    if (this.shuttingDown) return;
+
+    for (let i = 0; i < this.waiters.length; i++) {
+      const waiter = this.waiters[i];
+      const worker = this.takeIdleWorker(waiter.limitsKey, waiter.limits);
+      if (!worker) return;
+
+      this.waiters.splice(i, 1);
+      waiter.resolve(worker);
+      return;
+    }
+  }
+
+  private removeWorker(pooled: PooledWorker): void {
+    const index = this.workers.indexOf(pooled);
+    if (index !== -1) {
+      this.workers.splice(index, 1);
+    }
   }
 
   private terminateWorker(pooled: PooledWorker): void {
@@ -233,15 +337,36 @@ export class ThreadPool {
       };
     }
 
-    const pooled = this.getAvailableWorker();
-    if (!pooled) {
-      return {
+    // The deadline covers queueing as well as execution, so a saturated pool
+    // cannot leave a job outstanding indefinitely.
+    const signal = { aborted: false };
+    let settle: ((result: WorkerResult) => void) | undefined;
+    const settled = new Promise<WorkerResult>(resolve => {
+      settle = resolve;
+    });
+
+    const waitTimer = setTimeout(() => {
+      signal.aborted = true;
+      this.waiters = this.waiters.filter(w => w.resolve !== waiterResolve);
+      settle?.({
         status: 'error',
-        error: new Error('No available worker threads')
-      };
+        error: new Error(`Timed out after ${timeout}ms waiting for a worker thread`)
+      });
+    }, timeout);
+
+    const waiterResolve = (): void => {};
+
+    const pooled = await Promise.race([
+      this.acquireWorker(options.resourceLimits, signal),
+      settled.then(() => null)
+    ]);
+
+    clearTimeout(waitTimer);
+
+    if (signal.aborted || !pooled) {
+      return settled;
     }
 
-    pooled.busy = true;
     pooled.currentJobId = job.id;
 
     telemetry.emit('job:isolated:start', {
@@ -250,7 +375,7 @@ export class ThreadPool {
       isolated: true
     });
 
-    return new Promise<WorkerResult>((resolve) => {
+    return new Promise<WorkerResult>(resolve => {
       const timeoutId = setTimeout(() => {
         const pending = this.pendingJobs.get(job.id);
         if (pending) {
@@ -263,10 +388,8 @@ export class ThreadPool {
           });
 
           this.terminateWorker(pooled);
-          const index = this.workers.indexOf(pooled);
-          if (index !== -1) {
-            this.workers.splice(index, 1);
-          }
+          this.removeWorker(pooled);
+          this.handOffToWaiter();
 
           resolve({
             status: 'error',
@@ -313,6 +436,12 @@ export class ThreadPool {
 
   async shutdown(): Promise<void> {
     this.shuttingDown = true;
+
+    // Nothing will free up now, so release anyone queued rather than leaving
+    // their promises pending forever.
+    const waiting = this.waiters;
+    this.waiters = [];
+    waiting.forEach(w => w.resolve(null));
 
     if (this.cleanupInterval) {
       clearInterval(this.cleanupInterval);

--- a/src/database/postgres.ts
+++ b/src/database/postgres.ts
@@ -2,6 +2,7 @@ import type { Pool, PoolClient } from 'pg';
 import type { Job, JobCriteria, JobState, TransactionHandle, UniqueOptions } from '../types.js';
 import { BaseAdapter, DEFAULT_NODE_TTL, SQL, criteriaClause, rowToJob } from './adapter.js';
 import { advisoryLockKey, computeUniqueKey } from '../core/unique.js';
+import { telemetry } from '../core/telemetry.js';
 
 /** Arbitrary but fixed: all izi-queue instances must agree on this value. */
 const MIGRATION_LOCK_KEY = '7451092386401173';
@@ -22,6 +23,8 @@ export class PostgresAdapter extends BaseAdapter {
   private pool: Pool;
   private client?: PoolClient;
   private listening = false;
+  private resubscribing = false;
+  private notificationHandler?: (event: { queue: string }) => void;
   private reconnecting = false;
   private reconnectAttempts = 0;
   private maxReconnectAttempts = 10;
@@ -371,20 +374,76 @@ export class PostgresAdapter extends BaseAdapter {
   async listen(callback: (event: { queue: string }) => void): Promise<void> {
     if (this.listening) return;
 
-    this.client = await this.pool.connect();
-    await this.client.query('LISTEN izi_jobs_insert');
     this.listening = true;
+    this.notificationHandler = callback;
+    await this.subscribe();
+  }
 
-    this.client.on('notification', (msg) => {
+  /**
+   * Takes a dedicated connection and starts listening on it.
+   *
+   * The connection is deliberately not returned to the pool: a listener has to
+   * keep the same backend to keep receiving notifications.
+   */
+  private async subscribe(): Promise<void> {
+    const client = await this.pool.connect();
+    this.client = client;
+
+    // A LISTEN connection dies like any other -- failover, an idle reaper, a
+    // network blip. Without re-subscribing, notifications stop arriving
+    // silently and the queue degrades to poll-only with nothing to show for it.
+    client.on('error', () => this.resubscribe());
+    client.on('end', () => this.resubscribe());
+
+    client.on('notification', msg => {
       if (msg.channel === 'izi_jobs_insert' && msg.payload) {
         try {
           const payload = JSON.parse(msg.payload);
-          callback({ queue: payload.queue });
+          this.notificationHandler?.({ queue: payload.queue });
         } catch {
           // Ignore parse errors
         }
       }
     });
+
+    await client.query('LISTEN izi_jobs_insert');
+  }
+
+  private async resubscribe(): Promise<void> {
+    if (!this.listening || this.resubscribing) return;
+    this.resubscribing = true;
+
+    // The old client is gone; release it so the pool can reclaim the slot.
+    try {
+      this.client?.release();
+    } catch {
+      // Already destroyed.
+    }
+    this.client = undefined;
+
+    telemetry.emit('plugin:error', {
+      queue: 'notifier',
+      error: new Error('izi-queue: notification listener disconnected, reconnecting')
+    });
+
+    for (let attempt = 1; this.listening; attempt++) {
+      const delay = Math.min(this.reconnectDelay * 2 ** (attempt - 1), 30000);
+      await new Promise(resolve => setTimeout(resolve, delay));
+
+      if (!this.listening) break;
+
+      try {
+        await this.subscribe();
+        this.resubscribing = false;
+        telemetry.emit('plugin:start', { queue: 'notifier' });
+        return;
+      } catch {
+        // Keep trying: polling still drains the queue meanwhile, so this is a
+        // degradation rather than an outage.
+      }
+    }
+
+    this.resubscribing = false;
   }
 
   async notify(queue: string, tx?: TransactionHandle): Promise<void> {
@@ -396,11 +455,20 @@ export class PostgresAdapter extends BaseAdapter {
   }
 
   async close(): Promise<void> {
+    // Cleared first so an in-flight reconnect gives up instead of racing the
+    // pool shutdown.
+    this.listening = false;
+    this.notificationHandler = undefined;
+
     if (this.client) {
-      this.client.release();
+      try {
+        this.client.release();
+      } catch {
+        // Already destroyed by the disconnect that triggered shutdown.
+      }
       this.client = undefined;
     }
-    this.listening = false;
+
     await this.pool.end();
   }
 }

--- a/tests/fixtures/test-isolated-worker.js
+++ b/tests/fixtures/test-isolated-worker.js
@@ -30,6 +30,22 @@ export async function perform(job) {
       };
     }
 
+    case 'allocate': {
+      // Used to prove resourceLimits are actually applied: with a small heap
+      // cap this must kill the thread rather than succeed.
+      // Arrays of numbers, not Buffers: maxOldGenerationSizeMb governs the V8
+      // heap, and Buffer memory is external to it, so buffers would sail past
+      // any cap. Each 1M-element array is roughly 8MB of old-generation heap.
+      const chunks = [];
+      const target = job.args.megabytes || 64;
+      for (let i = 0; i < Math.ceil(target / 8); i++) {
+        const chunk = new Array(1000000).fill(i);
+        chunk[0] = i; // touch it so it cannot be optimised away
+        chunks.push(chunk);
+      }
+      return { status: 'ok', value: { allocated: chunks.length } };
+    }
+
     case 'crash':
       throw new Error(crashMessage || 'Intentional crash');
 

--- a/tests/isolation/thread-pool.test.ts
+++ b/tests/isolation/thread-pool.test.ts
@@ -1,5 +1,6 @@
 import { join } from 'path';
 import { ThreadPool } from '../../src/core/isolation/thread-pool.js';
+import { waitFor } from '../helpers/wait.js';
 import type { SerializableJob, IsolatedWorkerOptions } from '../../src/types.js';
 
 const TEST_WORKER_PATH = join(__dirname, '../fixtures/test-isolated-worker.js');
@@ -265,31 +266,115 @@ describe('ThreadPool', () => {
       expect(results.filter(r => r.status === 'ok').length).toBe(2);
     });
 
-    it('should return error when no threads available', async () => {
+    it('should queue rather than error when no threads are free', async () => {
+      // Superseded behaviour: this used to assert that a saturated pool
+      // returned an error, which consumed one of the job's retry attempts for
+      // something it had no part in. It now waits for a thread.
       pool = new ThreadPool({ maxThreads: 1 });
       const options = createIsolationOptions();
 
-      // Start one long-running job
-      const longJob = createSerializableJob({
-        id: 1,
-        args: { action: 'delay', delay: 2000 }
-      });
-      pool.execute(longJob, options, 5000);
+      const longJob = createSerializableJob({ id: 1, args: { action: 'delay', delay: 300 } });
+      const first = pool.execute(longJob, options, 10000);
 
-      // Wait for thread to be busy
-      await new Promise(resolve => setTimeout(resolve, 50));
+      await waitFor(() => pool.getStats().busyWorkers === 1, { describe: 'the pool to be busy' });
 
-      // Try to start another job - should fail since thread is busy
-      const shortJob = createSerializableJob({
-        id: 2,
-        args: { action: 'success' }
-      });
-      const result = await pool.execute(shortJob, options, 1000);
+      const shortJob = createSerializableJob({ id: 2, args: { action: 'success' } });
+      const second = await pool.execute(shortJob, options, 10000);
 
-      expect(result.status).toBe('error');
-      if (result.status === 'error') {
-        expect((result.error as Error).message).toContain('No available worker threads');
+      expect(second.status).toBe('ok');
+      expect((await first).status).toBe('ok');
+  });
+  });
+
+  describe('saturation', () => {
+    it('queues jobs instead of failing them when every thread is busy', async () => {
+      // A job that arrives while the pool is full has not failed -- it has not
+      // started. Returning an error consumes one of its retry attempts for
+      // something the job had no part in.
+      pool = new ThreadPool({ maxThreads: 1 });
+
+      const jobs = Array.from({ length: 3 }, (_, i) =>
+        createSerializableJob({ id: i + 1, args: { action: 'delay', delay: 60 } })
+      );
+      const options = createIsolationOptions();
+
+      const results = await Promise.all(jobs.map(job => pool.execute(job, options, 10000)));
+
+      expect(results.every(r => r.status === 'ok')).toBe(true);
+      const errors = results
+        .filter((r): r is { status: 'error'; error: Error } => r.status === 'error')
+        .map(r => r.error.message);
+      expect(errors).toEqual([]);
+    }, 20000);
+
+    it('runs queued jobs one at a time on a single-thread pool', async () => {
+      pool = new ThreadPool({ maxThreads: 1 });
+
+      const jobs = Array.from({ length: 3 }, (_, i) =>
+        createSerializableJob({ id: i + 1, args: { action: 'delay', delay: 60 } })
+      );
+      const options = createIsolationOptions();
+
+      const results = await Promise.all(jobs.map(job => pool.execute(job, options, 10000)));
+      const runs = results.map(
+        r => (r as { status: 'ok'; value: { startedAt: number; finishedAt: number } }).value
+      );
+
+      const overlapping = runs.some((a, i) =>
+        runs.some((b, j) => i !== j && a.startedAt < b.finishedAt && b.startedAt < a.finishedAt)
+      );
+      expect(overlapping).toBe(false);
+    }, 20000);
+
+    it('reports a distinct error when a job gives up waiting for a thread', async () => {
+      pool = new ThreadPool({ maxThreads: 1 });
+      const options = createIsolationOptions();
+
+      const blocker = pool.execute(
+        createSerializableJob({ id: 1, args: { action: 'delay', delay: 2000 } }),
+        options,
+        10000
+      );
+
+      const queued = await pool.execute(
+        createSerializableJob({ id: 2, args: { action: 'success' } }),
+        options,
+        150
+      );
+
+      expect(queued.status).toBe('error');
+      if (queued.status === 'error') {
+        expect((queued.error as Error).message).toMatch(/waiting for a worker thread/i);
       }
-    });
+
+      await blocker;
+    }, 20000);
+  });
+
+  describe('resource limits', () => {
+    it('applies the configured heap cap to the worker thread', async () => {
+      pool = new ThreadPool({ maxThreads: 1 });
+
+      const job = createSerializableJob({ args: { action: 'allocate', megabytes: 128 } });
+      const options = createIsolationOptions({
+        resourceLimits: { maxOldGenerationSizeMb: 16 }
+      });
+
+      const result = await pool.execute(job, options, 20000);
+
+      // 128MB of live buffers cannot fit in a 16MB heap: the thread must die
+      // rather than the allocation quietly succeeding.
+      expect(result.status).toBe('error');
+    }, 30000);
+
+    it('runs the same work fine without a cap', async () => {
+      pool = new ThreadPool({ maxThreads: 1 });
+
+      const job = createSerializableJob({ args: { action: 'allocate', megabytes: 128 } });
+
+      const result = await pool.execute(job, createIsolationOptions(), 20000);
+
+      expect(result.status).toBe('ok');
+    }, 30000);
   });
 });

--- a/tests/postgres-adapter.test.ts
+++ b/tests/postgres-adapter.test.ts
@@ -1,5 +1,6 @@
 import pg from 'pg';
 import { randomBytes } from 'crypto';
+import { waitFor } from './helpers/wait.js';
 import { createPostgresAdapter, PostgresAdapter } from '../src/database/postgres.js';
 import type { Job } from '../src/types.js';
 
@@ -393,5 +394,47 @@ describePostgres('PostgresAdapter', () => {
       const { rows } = await pool.query('SELECT COUNT(*)::int AS count FROM izi_jobs');
       expect(rows[0].count).toBe(1);
     });
+  });
+
+  describe('listener resilience', () => {
+    it('re-subscribes after its connection is dropped', async () => {
+      const listenerAdapter = createPostgresAdapter(new pg.Pool({ connectionString: CONNECTION_STRING }));
+      const received: string[] = [];
+
+      try {
+        await listenerAdapter.listen(({ queue }) => received.push(queue));
+
+        // Sanity: notifications arrive before anything is broken.
+        await adapter.notify('before');
+        await waitFor(() => received.includes('before'), {
+          describe: 'the first notification',
+        });
+
+        // Kill the listener's backend from another connection, the way a
+        // failover, an idle-connection reaper or a network blip would.
+        const { rows } = await pool.query(
+          `SELECT pid FROM pg_stat_activity
+           WHERE query LIKE 'LISTEN%' AND pid <> pg_backend_pid()`
+        );
+        expect(rows.length).toBeGreaterThan(0);
+        for (const row of rows) {
+          await pool.query('SELECT pg_terminate_backend($1)', [row.pid]);
+        }
+
+        // Without re-subscribing, notifications are silently lost from here on
+        // and the queue degrades to poll-only with no indication.
+        await waitFor(
+          async () => {
+            await adapter.notify('after');
+            return received.includes('after');
+          },
+          { timeout: 20000, interval: 500, describe: 'notifications to resume' }
+        );
+
+        expect(received).toContain('after');
+      } finally {
+        await listenerAdapter.close().catch(() => {});
+      }
+    }, 40000);
   });
 });


### PR DESCRIPTION
Closes #22, #23, #24 — the three remaining bugs from the original review. What is left on #46 after this is feature work.

## #22 — saturated pool failed jobs instead of queueing them

A job arriving while every thread was busy came back with `No available worker threads`. The queue recorded that as a **failure and charged one of the job's retry attempts** — for something the job had no part in. Any queue whose concurrency exceeds `maxThreads` hits this routinely, which `content-processor-api` does today (`emails: 20` against `maxThreads: 8`).

Jobs now wait for a thread. The job's `timeout` covers the wait as well as the execution, so a saturated pool cannot leave work outstanding indefinitely, and giving up while queued reports a distinct error rather than looking like an execution failure.

## #23 — `resourceLimits` were never applied

Typed, documented, passed in — and every thread was created with none, so isolated workers ran without the memory cap that is the main reason to isolate them.

Limits are fixed when a thread starts and cannot be changed after, so the pool is now **partitioned by them**: a job never lands on a thread with the wrong caps, and when the pool is full of mismatched idle threads one is replaced rather than the job being refused.

**The first version of this test passed against the broken code.** It allocated `Buffer`s, which live outside the V8 heap and sail past `maxOldGenerationSizeMb` regardless — so it would have certified the bug as fixed. The test now allocates in the old generation, and that distinction is documented in the fixture and the README.

## #24 — the listener never recovered from a dropped connection

After a failover, an idle-connection reaper or a network blip, the listener stopped receiving notifications **permanently**, and the queue degraded to poll-only with nothing to indicate it. Worse, the pool's error handler logged `Reconnected successfully` after running `SELECT 1` — having never re-issued `LISTEN`.

It now re-subscribes with backoff and reports the disconnect through telemetry. The test terminates the listener's backend from another connection and asserts notifications resume:

```sql
SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE query LIKE 'LISTEN%'
```

Before the fix that test times out after 20s with notifications never resuming.

## Verification

**348 tests** against SQLite, PostgreSQL 16 and MySQL 8.4, up from 342.

One existing test asserted the old saturation behaviour (`should return error when no threads available`) and was **rewritten rather than deleted**, so the change of contract is visible in the diff rather than silently disappearing.

README updated: the two caveats warning about #22 and #23 are replaced with the real behaviour, and `resourceLimits` is back in the isolation example — now that it does something.