### PR TITLE
chore(release): 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 While the version is below 1.0.0, breaking changes are released as minor versions.
 
-## [Unreleased]
+## [0.7.0] - 2026-08-04
 
 ### Fixed
 
@@ -323,3 +323,4 @@ production. Anyone running 0.3.0 or earlier should upgrade.
 [0.4.1]: https://github.com/iagocavalcante/izi-queue/compare/v0.4.0...v0.4.1
 [0.5.0]: https://github.com/iagocavalcante/izi-queue/compare/v0.4.1...v0.5.0
 [0.6.0]: https://github.com/iagocavalcante/izi-queue/compare/v0.5.0...v0.6.0
+[0.7.0]: https://github.com/iagocavalcante/izi-queue/compare/v0.6.0...v0.7.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "izi-queue",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "izi-queue",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "izi-queue",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A minimal, reliable, database-backed job queue for Node.js inspired by Oban",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Version bump and changelog for 0.7.0, shipping #63.

**No breaking changes, no migrations.** A clean bump from 0.6.0.

## What ships

Closes the last three bugs from the original production review — #22, #23, #24. Everything still open on #46 is feature work.

| | |
|---|---|
| #22 | Saturated thread pool queued jobs instead of failing them |
| #23 | `resourceLimits` actually applied to worker threads |
| #24 | PostgreSQL listener recovers from a dropped connection |

## Why 0.7.0 and not 0.6.1

#22 and #24 change observable behaviour rather than just fixing faults: a job that used to fail immediately on a full pool now waits, and a listener that used to stay dead now reconnects. Both are what users wanted, but a patch would understate a behavioural change.

## Verification

**348 tests**, all 9 CI checks green on #63 — Node 18/20/22/24 against PostgreSQL 16 and MySQL 8, with the adapter suites executing rather than skipping.

Clean rebuild, lint clean, 64.6 kB tarball.