### PR TITLE
fix(core): reimplement drain() as an inline executor

### DIFF
--- a/src/core/izi-queue.ts
+++ b/src/core/izi-queue.ts
@@ -1,5 +1,6 @@
 import type {
   DatabaseAdapter,
+  DrainResult,
   IziQueueConfig,
   IsolationConfig,
   Job,
@@ -436,28 +437,58 @@ export class IziQueue {
     }
   }
 
-  async drain(queueName?: string): Promise<void> {
-    const queuesToDrain = queueName
-      ? [this.queues.get(queueName)].filter(Boolean)
-      : Array.from(this.queues.values());
+  /**
+   * Synchronously runs every available job in the given queue (or all queues)
+   * to completion, modeled on `Oban.drain_queue/2`. Jobs are fetched (which
+   * marks them `executing` and consumes one attempt, same as the live poller)
+   * and executed inline through the same worker-execution path the poller
+   * uses, one at a time, until a fetch comes back empty.
+   *
+   * If the queue is currently running, its poller is paused for the duration
+   * of the drain and resumed afterward -- otherwise the poller and the inline
+   * executor would race to claim the same backlog. A poll already in flight
+   * when drain() is called is allowed to finish claiming its jobs first; those
+   * jobs are not re-fetched here; and they run to completion independently,
+   * so they are not reflected in the returned tally.
+   */
+  async drain(queueName?: string): Promise<DrainResult> {
+    const queuesToDrain: Queue[] = (
+      queueName ? [this.queues.get(queueName)] : Array.from(this.queues.values())
+    ).filter((queue): queue is Queue => queue !== undefined);
 
-    await this.stageJobs();
+    // Pausing is synchronous and happens before any other work here, so
+    // nothing can slip a new poll in between deciding to drain and doing so.
+    const pausedQueues = queuesToDrain.filter(queue => queue.currentState === 'running');
+    pausedQueues.forEach(queue => queue.pause());
 
-    let hasJobs = true;
-    while (hasJobs) {
-      hasJobs = false;
+    try {
+      await Promise.all(queuesToDrain.map(queue => queue.awaitInFlightPoll()));
+
+      await this.stageJobs();
+
+      const tally: DrainResult = {
+        success: 0,
+        failure: 0,
+        snoozed: 0,
+        discarded: 0,
+        cancelled: 0
+      };
+
       for (const queue of queuesToDrain) {
-        if (!queue) continue;
-        const jobs = await this.config.database.fetchJobs(queue.name, queue.limit);
-        if (jobs.length > 0) {
-          hasJobs = true;
+        let jobs = await this.config.database.fetchJobs(queue.name, queue.limit, this.config.node);
+
+        while (jobs.length > 0) {
           for (const job of jobs) {
-            await this.config.database.updateJob(job.id, { state: 'available' });
+            const outcome = await queue.executeInline(job);
+            tally[outcome] += 1;
           }
-          queue.dispatch();
-          await new Promise(resolve => setTimeout(resolve, 100));
+          jobs = await this.config.database.fetchJobs(queue.name, queue.limit, this.config.node);
         }
       }
+
+      return tally;
+    } finally {
+      pausedQueues.forEach(queue => queue.resume());
     }
   }
 }

--- a/src/core/queue.ts
+++ b/src/core/queue.ts
@@ -1,4 +1,4 @@
-import type { DatabaseAdapter, Job, QueueConfig } from '../types.js';
+import type { DatabaseAdapter, DrainOutcome, Job, QueueConfig } from '../types.js';
 import { formatError, sourceStatesFor } from './job.js';
 import { executeWorker, getBackoffDelay, hasWorker, getWorker, terminateIsolatedJob } from './worker.js';
 import { telemetry } from './telemetry.js';
@@ -127,6 +127,31 @@ export class Queue {
   }
 
   /**
+   * Resolves once any poll currently in flight has finished fetching.
+   * `IziQueue.drain()` calls this right after pausing so a fetch the live
+   * poller already started cannot still be claiming jobs from this queue's
+   * backlog when the inline executor starts claiming its own.
+   */
+  async awaitInFlightPoll(): Promise<void> {
+    if (this.pollInFlight) {
+      await this.pollInFlight.catch(() => {});
+    }
+  }
+
+  /**
+   * Executes `job` synchronously through the same worker-execution path the
+   * live poller uses -- `executeWorker`, then the ordinary state-machine
+   * transition for whatever it returns -- and reports the outcome instead of
+   * discarding it. This is the inline executor behind `IziQueue.drain()`; the
+   * caller is responsible for having fetched `job` (which already marked it
+   * `executing` and incremented its attempt) and for keeping the live poller
+   * from fetching the same backlog concurrently.
+   */
+  async executeInline(job: Job): Promise<DrainOutcome> {
+    return this.runJob(job);
+  }
+
+  /**
    * Schedules the next poll, replacing any pending one.
    *
    * Always clearing first is what keeps a single poll loop per queue: `dispatch()`
@@ -195,7 +220,7 @@ export class Queue {
     }
   }
 
-  private async runJob(job: Job): Promise<void> {
+  private async runJob(job: Job): Promise<DrainOutcome> {
     const startTime = Date.now();
 
     telemetry.emit('job:start', { job, queue: this.name });
@@ -205,7 +230,7 @@ export class Queue {
       // node, so retrying only occupies fetch slots for hours before the job is
       // discarded anyway.
       await this.handleUnknownWorker(job, startTime);
-      return;
+      return 'discarded';
     }
 
     const worker = getWorker(job.worker);
@@ -222,23 +247,22 @@ export class Queue {
       switch (result.status) {
         case 'ok':
           await this.handleSuccess(job, result.value, duration);
-          break;
+          return 'success';
         case 'error':
-          await this.handleError(
+          return await this.handleError(
             job,
             result.error instanceof Error ? result.error : new Error(String(result.error)),
             startTime
           );
-          break;
         case 'cancel':
           await this.handleCancel(job, result.reason, duration);
-          break;
+          return 'cancelled';
         case 'snooze':
           await this.handleSnooze(job, result.seconds, duration);
-          break;
+          return 'snoozed';
       }
     } catch (error) {
-      await this.handleError(
+      return await this.handleError(
         job,
         error instanceof Error ? error : new Error(String(error)),
         startTime
@@ -305,7 +329,11 @@ export class Queue {
     });
   }
 
-  private async handleError(job: Job, error: Error, startTime: number): Promise<void> {
+  private async handleError(
+    job: Job,
+    error: Error,
+    startTime: number
+  ): Promise<'failure' | 'discarded'> {
     const duration = Date.now() - startTime;
     const newErrors = [...job.errors, formatError(error, job.attempt)];
 
@@ -314,7 +342,7 @@ export class Queue {
         errors: newErrors,
         discardedAt: new Date()
       });
-      if (!applied) return;
+      if (!applied) return 'discarded';
 
       telemetry.emit('job:error', {
         job: { ...job, state: 'discarded', errors: newErrors },
@@ -322,6 +350,7 @@ export class Queue {
         duration,
         error
       });
+      return 'discarded';
     } else {
       const backoffMs = getBackoffDelay(job);
       const scheduledAt = new Date(Date.now() + backoffMs);
@@ -330,7 +359,7 @@ export class Queue {
         errors: newErrors,
         scheduledAt
       });
-      if (!applied) return;
+      if (!applied) return 'failure';
 
       telemetry.emit('job:error', {
         job: { ...job, state: 'retryable', errors: newErrors },
@@ -338,6 +367,7 @@ export class Queue {
         duration,
         error
       });
+      return 'failure';
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,8 @@ export type {
   WorkerDefinition,
   QueueConfig,
   DatabaseAdapter,
+  DrainOutcome,
+  DrainResult,
   IziQueueConfig,
   TelemetryEvent,
   TelemetryPayload,

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,6 +90,17 @@ export type WorkerResult =
   | { status: 'cancel'; reason: string }
   | { status: 'snooze'; seconds: number };
 
+/**
+ * How a single job resolved when executed inline by `IziQueue.drain()`.
+ * `failure` is an error with retry budget left (the job becomes `retryable`);
+ * `discarded` covers both an error with no attempts left and an unregistered
+ * worker -- both land the job in the `discarded` state.
+ */
+export type DrainOutcome = 'success' | 'failure' | 'snoozed' | 'discarded' | 'cancelled';
+
+/** Tally of drain outcomes, returned by `IziQueue.drain()`. */
+export type DrainResult = Record<DrainOutcome, number>;
+
 export interface ResourceLimits {
   maxOldGenerationSizeMb?: number;
   maxYoungGenerationSizeMb?: number;

--- a/tests/drain.test.ts
+++ b/tests/drain.test.ts
@@ -1,0 +1,260 @@
+import Database from 'better-sqlite3';
+import { IziQueue } from '../src/core/izi-queue.js';
+import { defineWorker, WorkerResults, clearWorkers } from '../src/core/worker.js';
+import { createSQLiteAdapter, SQLiteAdapter } from '../src/database/sqlite.js';
+import { telemetry } from '../src/core/telemetry.js';
+import { waitFor } from './helpers/wait.js';
+
+describe('drain', () => {
+  let db: Database.Database;
+  let adapter: SQLiteAdapter;
+
+  beforeEach(async () => {
+    db = new Database(':memory:');
+    adapter = createSQLiteAdapter(db);
+    await adapter.migrate();
+    clearWorkers();
+    telemetry.off();
+  });
+
+  afterEach(async () => {
+    telemetry.off();
+    await adapter.close();
+  });
+
+  function queueWith(...workers: Parameters<IziQueue['register']>[0][]): IziQueue {
+    const queue = new IziQueue({
+      database: adapter,
+      queues: { default: 2 },
+      stageInterval: 50,
+      pollInterval: 50
+    });
+    workers.forEach((w) => queue.register(w));
+    return queue;
+  }
+
+  /**
+   * Starts the queue (so `IziQueue` populates its internal `Queue` instances)
+   * and immediately pauses it, so setup work (inserting jobs) cannot race the
+   * live poller. Tests that specifically exercise the poller race resume the
+   * queue themselves.
+   */
+  async function startPaused(queue: IziQueue, name = 'default'): Promise<void> {
+    await queue.start();
+    queue.pauseQueue(name);
+  }
+
+  it("increments a drained job's attempt exactly once", async () => {
+    const queue = queueWith(defineWorker('ok', async () => WorkerResults.ok()));
+    await startPaused(queue);
+
+    const inserted = await queue.insert('ok', { args: {} });
+
+    await queue.drain();
+
+    const final = await queue.getJob(inserted.id);
+    await queue.shutdown();
+
+    expect(final?.attempt).toBe(1);
+    expect(final?.state).toBe('completed');
+  }, 20000);
+
+  it('returns a tally that matches the jobs it executed', async () => {
+    const queue = queueWith(
+      defineWorker('succeed', async () => WorkerResults.ok()),
+      defineWorker('fail', async () => WorkerResults.error('boom'), { maxAttempts: 5 }),
+      defineWorker('discard', async () => WorkerResults.error('boom'), { maxAttempts: 1 }),
+      defineWorker('cancel', async () => WorkerResults.cancel('nope')),
+      defineWorker('snooze', async () => WorkerResults.snooze(60))
+    );
+    await startPaused(queue);
+
+    await queue.insert('succeed', { args: {} });
+    await queue.insert('fail', { args: {} });
+    await queue.insert('discard', { args: {} });
+    await queue.insert('cancel', { args: {} });
+    await queue.insert('snooze', { args: {} });
+
+    const tally = await queue.drain();
+    await queue.shutdown();
+
+    expect(tally).toEqual({
+      success: 1,
+      failure: 1,
+      snoozed: 1,
+      discarded: 1,
+      cancelled: 1
+    });
+  }, 20000);
+
+  it('drains a backlog larger than the queue limit', async () => {
+    let executions = 0;
+    const queue = queueWith(
+      defineWorker('bulk', async () => {
+        executions++;
+        return WorkerResults.ok();
+      })
+    );
+    await startPaused(queue); // limit is 2, backlog is 7 -- forces multiple fetch rounds
+
+    for (let i = 0; i < 7; i++) {
+      await queue.insert('bulk', { args: { i } });
+    }
+
+    const tally = await queue.drain();
+    await queue.shutdown();
+
+    expect(executions).toBe(7);
+    expect(tally.success).toBe(7);
+  }, 20000);
+
+  it('completes only once the queue has no more available jobs', async () => {
+    const queue = queueWith(defineWorker('ok', async () => WorkerResults.ok()));
+    await startPaused(queue);
+
+    const jobs = await Promise.all(
+      Array.from({ length: 5 }, (_, i) => queue.insert('ok', { args: { i } }))
+    );
+
+    await queue.drain();
+
+    for (const job of jobs) {
+      const final = await queue.getJob(job.id);
+      expect(final?.state).toBe('completed');
+    }
+
+    // Nothing left runnable: the backlog drain() was asked to clear is gone.
+    const remaining = db
+      .prepare("SELECT COUNT(*) as n FROM izi_jobs WHERE state = 'available'")
+      .get() as { n: number };
+    expect(remaining.n).toBe(0);
+
+    await queue.shutdown();
+  }, 20000);
+
+  it('never resets a fetched job back to available', async () => {
+    // A worker that errors without exhausting attempts should land on
+    // `retryable`, never bounce back through `available` on the way there.
+    const queue = queueWith(
+      defineWorker('flaky', async () => WorkerResults.error('boom'), { maxAttempts: 5 })
+    );
+    await startPaused(queue);
+
+    const inserted = await queue.insert('flaky', { args: {} });
+    await queue.drain();
+
+    const final = await queue.getJob(inserted.id);
+    await queue.shutdown();
+
+    expect(final?.state).toBe('retryable');
+    expect(final?.attempt).toBe(1);
+  }, 20000);
+
+  it('leaves the queue running again after draining a started, running queue', async () => {
+    const queue = queueWith(defineWorker('ok', async () => WorkerResults.ok()));
+    await startPaused(queue);
+    await queue.insert('ok', { args: {} });
+    queue.resumeQueue('default');
+
+    await queue.drain();
+
+    expect(queue.getQueueStatus('default')?.state).toBe('running');
+
+    // Prove the poller genuinely resumed: a job inserted after drain() is
+    // picked up by the live poll loop, not left stranded.
+    const job = await queue.insert('ok', { args: {} });
+    const final = await waitFor(
+      async () => {
+        const current = await queue.getJob(job.id);
+        return current?.state === 'completed' ? current : null;
+      },
+      { describe: 'the poller to resume and process a post-drain job' }
+    );
+
+    await queue.shutdown();
+    expect(final?.state).toBe('completed');
+  }, 20000);
+
+  it('leaves a paused queue paused after draining', async () => {
+    const queue = queueWith(defineWorker('ok', async () => WorkerResults.ok()));
+    await startPaused(queue);
+    await queue.insert('ok', { args: {} });
+
+    await queue.drain();
+
+    expect(queue.getQueueStatus('default')?.state).toBe('paused');
+
+    await queue.shutdown();
+  }, 20000);
+
+  it('does not double-run or double-count a job the live poller also raced for', async () => {
+    // Poll aggressively and make jobs slow enough that, without pausing the
+    // poller during drain, the old bug (drain resets fetched jobs back to
+    // `available`, then calls dispatch()) would let both the poller and
+    // drain's own loop claim the same job.
+    const executedJobIds: number[] = [];
+    const queue = new IziQueue({
+      database: adapter,
+      queues: { default: 3 },
+      stageInterval: 50,
+      pollInterval: 5
+    });
+    queue.register(
+      defineWorker(
+        'slow',
+        async (job) => {
+          executedJobIds.push(job.id);
+          await new Promise((resolve) => setTimeout(resolve, 30));
+          return WorkerResults.ok();
+        },
+        { maxAttempts: 3 }
+      )
+    );
+
+    await queue.start();
+    const jobs = await Promise.all(
+      Array.from({ length: 6 }, (_, i) => queue.insert('slow', { args: { i } }))
+    );
+
+    await queue.drain();
+
+    const counts = new Map<number, number>();
+    for (const id of executedJobIds) counts.set(id, (counts.get(id) ?? 0) + 1);
+
+    const finals = await Promise.all(jobs.map((job) => queue.getJob(job.id)));
+    await queue.shutdown();
+
+    for (const [index, job] of jobs.entries()) {
+      expect(counts.get(job.id)).toBe(1);
+      expect(finals[index]?.attempt).toBe(1);
+      expect(finals[index]?.state).toBe('completed');
+    }
+  }, 20000);
+
+  it('returns only once every claimed job has actually finished executing', async () => {
+    // The old implementation fired queue.dispatch() and a fixed 100ms sleep,
+    // so it could return while dispatched jobs were still running
+    // asynchronously in the background. A job that takes longer than that
+    // sleep must still be finished, and no longer counted as running, by the
+    // time drain() resolves.
+    const queue = queueWith(
+      defineWorker('slow', async () => {
+        await new Promise((resolve) => setTimeout(resolve, 250));
+        return WorkerResults.ok();
+      })
+    );
+    await startPaused(queue);
+    const inserted = await queue.insert('slow', { args: {} });
+    queue.resumeQueue('default');
+
+    const tally = await queue.drain();
+
+    expect(tally.success).toBe(1);
+    expect(queue.getQueueStatus('default')?.running).toBe(0);
+
+    const final = await queue.getJob(inserted.id);
+    expect(final?.state).toBe('completed');
+
+    await queue.shutdown();
+  }, 20000);
+});


### PR DESCRIPTION
Closes #36.

## Problem

`drain()` fetched jobs (marking them `executing` and consuming an attempt), forced them back to `available`, called `queue.dispatch()`, and paced itself with `setTimeout(100)`. Consequences:

- every drain pass inflated `attempt` for every job it touched, so drained jobs hit `maxAttempts` early
- it raced the live poller for the same rows
- each pass leaked a permanent poll loop via `dispatch()`
- it could return while jobs were still executing, so nothing was actually guaranteed drained

## Fix

Modeled on `Oban.drain_queue/2`:

- `drain()` synchronously pauses running pollers (before any `await`, so no poll can start in between), waits out any poll already in flight, then loops fetch → execute inline → apply result until a fetch comes back empty, resuming pollers in a `finally`.
- Jobs run through the exact `runJob` path the live poller uses, so attempt counts, state-transition guards, and telemetry behave identically. `runJob`/`handleError` now report each job's outcome.
- `drain()` returns a `DrainResult` tally: `{ success, failure, snoozed, discarded, cancelled }` (new exported types `DrainOutcome`/`DrainResult`).
- Also passes the configured `node` to `fetchJobs`, so drained jobs record `attemptedBy` like poller-fetched jobs do.

**Documented scope boundary:** a job the live poller claimed *before* `drain()` was called finishes independently and is not in the tally — the same usage contract as Oban's `drain_queue`.

**API change:** `drain()` goes from `Promise<void>` to `Promise<DrainResult>`. The old return value carried no information and the old behavior was broken, so this is proposed as a minor-version change.

## Testing

New `tests/drain.test.ts` (9 tests): attempt incremented exactly once, tally matches outcomes across all five states, backlogs larger than queue concurrency drain fully, jobs never bounce back through `available`, queue running/paused state restored either way, a racing live poller never double-executes, and `drain()` only returns once claimed jobs finished.

Full suite: 357/357 tests, 20/20 suites — including against real Postgres 16 and MySQL 8 via docker, not just SQLite. Build and lint clean.