### PR TITLE
fix(db): run pruneJobs and stageJobs in bounded batches

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,9 +242,12 @@ const queue = new IziQueue({
 not touch a job that is still running on a live node, so `rescueAfter` does not
 have to exceed your worker timeouts.
 
-**Pruner** deletes finished jobs. It currently deletes in one unbounded
-statement, so the first run against a large backlog is a long-running delete
-([#29](https://github.com/iagocavalcante/izi-queue/issues/29)).
+**Pruner** deletes finished jobs, at most `batchSize` rows per statement
+(default 5000), looping until the whole eligible backlog is cleared, rather
+than one unbounded DELETE that would lock the table for as long as a large
+backlog takes to scan. Staging (moving due `scheduled`/`retryable` jobs to
+`available`, which runs automatically -- no plugin needed) batches the same
+way; tune it with `stageBatchSize` on `IziQueue`'s config.
 
 > Every node runs every plugin: there is no leader election yet
 > ([#26](https://github.com/iagocavalcante/izi-queue/issues/26)). With several

--- a/src/core/izi-queue.ts
+++ b/src/core/izi-queue.ts
@@ -25,7 +25,7 @@ import {
   getIsolationStats
 } from './worker.js';
 import { randomUUID } from 'crypto';
-import { DEFAULT_NODE_TTL } from '../database/adapter.js';
+import { DEFAULT_BATCH_SIZE, DEFAULT_NODE_TTL, runInBatches } from '../database/adapter.js';
 
 export interface IziQueueFullConfig extends IziQueueConfig {
   plugins?: Plugin[];
@@ -84,6 +84,7 @@ export class IziQueue {
       plugins: config.plugins ?? [],
       node: config.node ?? `node-${randomUUID().slice(0, 8)}`,
       stageInterval: config.stageInterval ?? 1000,
+      stageBatchSize: config.stageBatchSize ?? DEFAULT_BATCH_SIZE,
       shutdownGracePeriod: config.shutdownGracePeriod ?? 15000,
       heartbeatInterval: config.heartbeatInterval ?? 15000,
       pollInterval: config.pollInterval ?? 1000,
@@ -370,8 +371,17 @@ export class IziQueue {
     return (await this.retryJobs({ ids: [id] })) > 0;
   }
 
-  async pruneJobs(maxAgeSeconds = 86400 * 7): Promise<number> {
-    return this.config.database.pruneJobs(maxAgeSeconds);
+  /**
+   * Deletes every prunable job older than `maxAgeSeconds`. Runs in bounded
+   * batches of `batchSize` rows -- looping, and yielding to the event loop
+   * between batches -- rather than one unbounded DELETE that would lock the
+   * table for however long the whole backlog takes to scan.
+   */
+  async pruneJobs(maxAgeSeconds = 86400 * 7, batchSize = DEFAULT_BATCH_SIZE): Promise<number> {
+    return runInBatches(
+      limit => this.config.database.pruneJobs(maxAgeSeconds, limit),
+      batchSize
+    );
   }
 
   async rescueStuckJobs(rescueAfterSeconds = 300): Promise<number> {
@@ -427,7 +437,10 @@ export class IziQueue {
 
   private async stageJobs(): Promise<void> {
     try {
-      const staged = await this.config.database.stageJobs();
+      const staged = await runInBatches(
+        limit => this.config.database.stageJobs(limit),
+        this.config.stageBatchSize
+      );
       if (staged > 0) {
         this.queues.forEach(queue => queue.dispatch());
       }

--- a/src/database/adapter.ts
+++ b/src/database/adapter.ts
@@ -8,6 +8,46 @@ import { DEFAULT_UNIQUE_PERIOD, DEFAULT_UNIQUE_STATES } from '../core/unique.js'
  */
 export const DEFAULT_NODE_TTL = 60;
 
+/**
+ * Default number of rows `pruneJobs`/`stageJobs` touch per statement. Both
+ * operations run in bounded batches rather than one unbounded, heavily-locking
+ * DELETE/UPDATE over the whole backlog -- see `runInBatches`.
+ */
+export const DEFAULT_BATCH_SIZE = 5000;
+
+/**
+ * Repeatedly calls `operation(limit)` -- which should perform at most `limit`
+ * rows of work and return how many it actually touched -- until a call
+ * touches fewer than `limit` rows, i.e. the backlog is exhausted. Yields to
+ * the event loop between calls so a large backlog is worked as many short
+ * statements instead of a single long-running one that locks the table for
+ * its entire duration.
+ */
+export async function runInBatches(
+  operation: (limit: number) => Promise<number>,
+  limit: number
+): Promise<number> {
+  // A non-positive or non-finite limit can never be exceeded by `affected`,
+  // which would otherwise turn the loop below into one that never stops:
+  // fail loudly instead of hanging with a runaway timer.
+  if (!Number.isFinite(limit) || limit <= 0) {
+    throw new Error(`runInBatches: limit must be a positive number, got ${limit}`);
+  }
+
+  let total = 0;
+
+  for (;;) {
+    const affected = await operation(limit);
+    total += affected;
+
+    if (affected < limit) return total;
+
+    // Give the event loop -- and any queue polling the same table -- a chance
+    // to run between batches instead of monopolizing it.
+    await new Promise<void>(resolve => setImmediate(resolve));
+  }
+}
+
 export const SQL = {
   postgres: {
     createTable: `
@@ -69,15 +109,26 @@ export const SQL = {
       RETURNING *
     `,
     getJob: 'SELECT * FROM izi_jobs WHERE id = $1',
+    // Postgres has no issue reading the target table in a DELETE/UPDATE's own
+    // subquery (unlike MySQL), so a plain `id IN (SELECT ...)` is enough to
+    // bound the statement to one batch.
     pruneJobs: `
       DELETE FROM izi_jobs
-      WHERE state IN ('completed', 'discarded', 'cancelled')
-        AND COALESCE(completed_at, discarded_at, cancelled_at) < NOW() - INTERVAL '1 second' * $1
+      WHERE id IN (
+        SELECT id FROM izi_jobs
+        WHERE state IN ('completed', 'discarded', 'cancelled')
+          AND COALESCE(completed_at, discarded_at, cancelled_at) < NOW() - INTERVAL '1 second' * $1
+        LIMIT $2
+      )
     `,
     stageJobs: `
       UPDATE izi_jobs
       SET state = 'available'
-      WHERE state IN ('scheduled', 'retryable') AND scheduled_at <= NOW()
+      WHERE id IN (
+        SELECT id FROM izi_jobs
+        WHERE state IN ('scheduled', 'retryable') AND scheduled_at <= NOW()
+        LIMIT $1
+      )
     `,
     cancelJobs: `
       UPDATE izi_jobs
@@ -167,15 +218,31 @@ export const SQL = {
       WHERE id = ?
     `,
     getJob: 'SELECT * FROM izi_jobs WHERE id = ?',
+    // MySQL raises ERROR 1093 ("You can't specify target table for update in
+    // FROM clause") for `DELETE ... WHERE id IN (SELECT id FROM same_table)`,
+    // so the inner SELECT must be wrapped in a derived table -- MySQL
+    // materializes that as a separate result set, which sidesteps the check.
     pruneJobs: `
       DELETE FROM izi_jobs
-      WHERE state IN ('completed', 'discarded', 'cancelled')
-        AND COALESCE(completed_at, discarded_at, cancelled_at) < DATE_SUB(NOW(), INTERVAL ? SECOND)
+      WHERE id IN (
+        SELECT id FROM (
+          SELECT id FROM izi_jobs
+          WHERE state IN ('completed', 'discarded', 'cancelled')
+            AND COALESCE(completed_at, discarded_at, cancelled_at) < DATE_SUB(NOW(), INTERVAL ? SECOND)
+          LIMIT ?
+        ) AS batch
+      )
     `,
     stageJobs: `
       UPDATE izi_jobs
       SET state = 'available'
-      WHERE state IN ('scheduled', 'retryable') AND scheduled_at <= NOW()
+      WHERE id IN (
+        SELECT id FROM (
+          SELECT id FROM izi_jobs
+          WHERE state IN ('scheduled', 'retryable') AND scheduled_at <= NOW()
+          LIMIT ?
+        ) AS batch
+      )
     `,
     cancelJobs: `
       UPDATE izi_jobs
@@ -266,15 +333,28 @@ export const SQL = {
       RETURNING *
     `,
     getJob: 'SELECT * FROM izi_jobs WHERE id = ?',
+    // SQLite's DELETE/UPDATE ... LIMIT syntax only works when the library was
+    // compiled with SQLITE_ENABLE_UPDATE_DELETE_LIMIT, which better-sqlite3's
+    // bundled build is not. `id IN (SELECT ... LIMIT n)` bounds the batch with
+    // standard SQL instead; unlike MySQL, SQLite has no restriction against a
+    // DELETE/UPDATE's subquery reading the table being modified.
     pruneJobs: `
       DELETE FROM izi_jobs
-      WHERE state IN ('completed', 'discarded', 'cancelled')
-        AND datetime(COALESCE(completed_at, discarded_at, cancelled_at)) < datetime('now', '-' || ? || ' seconds')
+      WHERE id IN (
+        SELECT id FROM izi_jobs
+        WHERE state IN ('completed', 'discarded', 'cancelled')
+          AND datetime(COALESCE(completed_at, discarded_at, cancelled_at)) < datetime('now', '-' || ? || ' seconds')
+        LIMIT ?
+      )
     `,
     stageJobs: `
       UPDATE izi_jobs
       SET state = 'available'
-      WHERE state IN ('scheduled', 'retryable') AND datetime(scheduled_at) <= datetime('now')
+      WHERE id IN (
+        SELECT id FROM izi_jobs
+        WHERE state IN ('scheduled', 'retryable') AND datetime(scheduled_at) <= datetime('now')
+        LIMIT ?
+      )
     `,
     cancelJobs: `
       UPDATE izi_jobs
@@ -391,8 +471,8 @@ export abstract class BaseAdapter implements DatabaseAdapter {
   abstract fetchJobs(queue: string, limit: number, node?: string): Promise<Job[]>;
   abstract updateJob(id: number, updates: Partial<Job>, expectedStates?: JobState[]): Promise<Job | null>;
   abstract getJob(id: number): Promise<Job | null>;
-  abstract pruneJobs(maxAge: number): Promise<number>;
-  abstract stageJobs(): Promise<number>;
+  abstract pruneJobs(maxAge: number, limit?: number): Promise<number>;
+  abstract stageJobs(limit?: number): Promise<number>;
   abstract cancelJobs(criteria: import('../types.js').JobCriteria): Promise<number>;
   abstract rescueStuckJobs(rescueAfter: number, nodeTtl?: number): Promise<number>;
 

--- a/src/database/mysql.ts
+++ b/src/database/mysql.ts
@@ -24,7 +24,7 @@ interface Pool {
   end(): Promise<void>;
 }
 import type { Job, JobCriteria, JobState, TransactionHandle, UniqueOptions } from '../types.js';
-import { BaseAdapter, DEFAULT_NODE_TTL, SQL, criteriaClause, rowToJob } from './adapter.js';
+import { BaseAdapter, DEFAULT_BATCH_SIZE, DEFAULT_NODE_TTL, SQL, criteriaClause, rowToJob } from './adapter.js';
 import { computeUniqueKey } from '../core/unique.js';
 
 /** Arbitrary but fixed: all izi-queue instances must agree on this value. */
@@ -252,13 +252,13 @@ export class MySQLAdapter extends BaseAdapter {
     return rows[0] ? rowToJob(rows[0] as Record<string, unknown>) : null;
   }
 
-  async pruneJobs(maxAge: number): Promise<number> {
-    const [result] = await this.pool.query<ResultSetHeader>(SQL.mysql.pruneJobs, [maxAge]);
+  async pruneJobs(maxAge: number, limit: number = DEFAULT_BATCH_SIZE): Promise<number> {
+    const [result] = await this.pool.query<ResultSetHeader>(SQL.mysql.pruneJobs, [maxAge, limit]);
     return result.affectedRows;
   }
 
-  async stageJobs(): Promise<number> {
-    const [result] = await this.pool.query<ResultSetHeader>(SQL.mysql.stageJobs);
+  async stageJobs(limit: number = DEFAULT_BATCH_SIZE): Promise<number> {
+    const [result] = await this.pool.query<ResultSetHeader>(SQL.mysql.stageJobs, [limit]);
     return result.affectedRows;
   }
 

--- a/src/database/postgres.ts
+++ b/src/database/postgres.ts
@@ -1,6 +1,6 @@
 import type { Pool, PoolClient } from 'pg';
 import type { Job, JobCriteria, JobState, TransactionHandle, UniqueOptions } from '../types.js';
-import { BaseAdapter, DEFAULT_NODE_TTL, SQL, criteriaClause, rowToJob } from './adapter.js';
+import { BaseAdapter, DEFAULT_BATCH_SIZE, DEFAULT_NODE_TTL, SQL, criteriaClause, rowToJob } from './adapter.js';
 import { advisoryLockKey, computeUniqueKey } from '../core/unique.js';
 import { telemetry } from '../core/telemetry.js';
 
@@ -246,13 +246,13 @@ export class PostgresAdapter extends BaseAdapter {
     return result.rows[0] ? rowToJob(result.rows[0]) : null;
   }
 
-  async pruneJobs(maxAge: number): Promise<number> {
-    const result = await this.pool.query(SQL.postgres.pruneJobs, [maxAge]);
+  async pruneJobs(maxAge: number, limit: number = DEFAULT_BATCH_SIZE): Promise<number> {
+    const result = await this.pool.query(SQL.postgres.pruneJobs, [maxAge, limit]);
     return result.rowCount ?? 0;
   }
 
-  async stageJobs(): Promise<number> {
-    const result = await this.pool.query(SQL.postgres.stageJobs);
+  async stageJobs(limit: number = DEFAULT_BATCH_SIZE): Promise<number> {
+    const result = await this.pool.query(SQL.postgres.stageJobs, [limit]);
     return result.rowCount ?? 0;
   }
 

--- a/src/database/sqlite.ts
+++ b/src/database/sqlite.ts
@@ -1,6 +1,6 @@
 import type { Database } from 'better-sqlite3';
 import type { Job, JobCriteria, JobState, TransactionHandle, UniqueOptions } from '../types.js';
-import { BaseAdapter, DEFAULT_NODE_TTL, criteriaClause, rowToJob } from './adapter.js';
+import { BaseAdapter, DEFAULT_BATCH_SIZE, DEFAULT_NODE_TTL, criteriaClause, rowToJob } from './adapter.js';
 import { computeUniqueKey } from '../core/unique.js';
 import { sqliteMigrations } from './migrations.js';
 
@@ -200,23 +200,34 @@ export class SQLiteAdapter extends BaseAdapter {
     return row ? rowToJob(row) : null;
   }
 
-  async pruneJobs(maxAge: number): Promise<number> {
+  async pruneJobs(maxAge: number, limit: number = DEFAULT_BATCH_SIZE): Promise<number> {
+    // `id IN (SELECT ... LIMIT n)` bounds the batch with standard SQL. A bare
+    // `DELETE ... LIMIT n` only works when SQLite was compiled with
+    // SQLITE_ENABLE_UPDATE_DELETE_LIMIT, which better-sqlite3's build is not.
     const stmt = this.db.prepare(`
       DELETE FROM izi_jobs
-      WHERE state IN ('completed', 'discarded', 'cancelled')
-        AND datetime(COALESCE(completed_at, discarded_at, cancelled_at)) < datetime('now', '-' || ? || ' seconds')
+      WHERE id IN (
+        SELECT id FROM izi_jobs
+        WHERE state IN ('completed', 'discarded', 'cancelled')
+          AND datetime(COALESCE(completed_at, discarded_at, cancelled_at)) < datetime('now', '-' || ? || ' seconds')
+        LIMIT ?
+      )
     `);
-    const result = stmt.run(maxAge);
+    const result = stmt.run(maxAge, limit);
     return result.changes;
   }
 
-  async stageJobs(): Promise<number> {
+  async stageJobs(limit: number = DEFAULT_BATCH_SIZE): Promise<number> {
     const stmt = this.db.prepare(`
       UPDATE izi_jobs
       SET state = 'available'
-      WHERE state IN ('scheduled', 'retryable') AND datetime(scheduled_at) <= datetime('now')
+      WHERE id IN (
+        SELECT id FROM izi_jobs
+        WHERE state IN ('scheduled', 'retryable') AND datetime(scheduled_at) <= datetime('now')
+        LIMIT ?
+      )
     `);
-    const result = stmt.run();
+    const result = stmt.run(limit);
     return result.changes;
   }
 

--- a/src/plugins/pruner.ts
+++ b/src/plugins/pruner.ts
@@ -1,9 +1,17 @@
 import { BasePlugin } from './plugin.js';
 import { telemetry } from '../core/telemetry.js';
+import { DEFAULT_BATCH_SIZE, runInBatches } from '../database/adapter.js';
 
 export interface PrunerConfig {
   interval?: number;
   maxAge?: number;
+  /**
+   * Maximum rows deleted per statement, per prune cycle. A large backlog is
+   * worked in this many rows at a time rather than one unbounded DELETE,
+   * looping (yielding to the event loop between batches) until it is caught
+   * up. Defaults to `DEFAULT_BATCH_SIZE` (5000).
+   */
+  batchSize?: number;
 }
 
 /**
@@ -17,7 +25,8 @@ export class PrunerPlugin extends BasePlugin {
     super();
     this.config = {
       interval: config.interval ?? 60000,
-      maxAge: config.maxAge ?? 86400
+      maxAge: config.maxAge ?? 86400,
+      batchSize: config.batchSize ?? DEFAULT_BATCH_SIZE
     };
   }
 
@@ -37,7 +46,11 @@ export class PrunerPlugin extends BasePlugin {
     if (!this.context || !this.running) return;
 
     try {
-      const pruned = await this.context.database.pruneJobs(this.config.maxAge);
+      const database = this.context.database;
+      const pruned = await runInBatches(
+        limit => database.pruneJobs(this.config.maxAge, limit),
+        this.config.batchSize
+      );
 
       if (pruned > 0) {
         // Deliberately not `job:complete`: pruning is maintenance, and counting
@@ -64,6 +77,10 @@ export class PrunerPlugin extends BasePlugin {
 
     if (this.config.maxAge < 60) {
       errors.push('Pruner maxAge must be at least 60 seconds');
+    }
+
+    if (this.config.batchSize < 1) {
+      errors.push('Pruner batchSize must be at least 1');
     }
 
     return errors;

--- a/src/types.ts
+++ b/src/types.ts
@@ -182,8 +182,20 @@ export interface DatabaseAdapter {
    */
   updateJob(id: number, updates: Partial<Job>, expectedStates?: JobState[]): Promise<Job | null>;
   getJob(id: number): Promise<Job | null>;
-  pruneJobs(maxAge: number): Promise<number>;
-  stageJobs(): Promise<number>;
+  /**
+   * Deletes at most `limit` prunable (completed/discarded/cancelled, past
+   * `maxAge`) rows and returns how many were deleted. Callers wanting the
+   * whole backlog cleared loop on the result rather than relying on a single
+   * unbounded statement, which would lock the table for as long as the
+   * backlog takes to scan. `limit` defaults to a safe batch size when omitted;
+   * a custom adapter that ignores it simply does not batch.
+   */
+  pruneJobs(maxAge: number, limit?: number): Promise<number>;
+  /**
+   * Promotes at most `limit` due scheduled/retryable jobs to available and
+   * returns how many were promoted. Same batching contract as `pruneJobs`.
+   */
+  stageJobs(limit?: number): Promise<number>;
   cancelJobs(criteria: JobCriteria): Promise<number>;
   /** Returns discarded or cancelled jobs to the queue. */
   retryJobs?(criteria: JobCriteria): Promise<number>;
@@ -233,6 +245,13 @@ export interface IziQueueConfig {
   queues: QueueConfig[] | Record<string, number>;
   node?: string;
   stageInterval?: number;
+  /**
+   * Maximum rows staged per statement, per stage cycle. A large backlog is
+   * worked in this many rows at a time rather than one unbounded UPDATE,
+   * looping (yielding to the event loop between batches) until it is caught
+   * up. Defaults to `DEFAULT_BATCH_SIZE` (5000).
+   */
+  stageBatchSize?: number;
   shutdownGracePeriod?: number;
   /**
    * How often this node refreshes its liveness record, in ms. A node is presumed

--- a/tests/adapter.test.ts
+++ b/tests/adapter.test.ts
@@ -1,0 +1,65 @@
+import { runInBatches } from '../src/database/adapter.js';
+
+describe('runInBatches', () => {
+  it.each([0, -1, NaN, Infinity])(
+    'rejects a non-positive or non-finite limit (%p) instead of looping forever',
+    async (limit) => {
+      const operation = jest.fn(async () => 1);
+
+      await expect(runInBatches(operation, limit)).rejects.toThrow(/limit must be a positive number/);
+      expect(operation).not.toHaveBeenCalled();
+    }
+  );
+
+  it('loops until a batch affects fewer than `limit` rows, summing the total', async () => {
+    const affectedPerCall = [5, 5, 2];
+    const operation = jest.fn(async (limit: number) => {
+      expect(limit).toBe(5);
+      return affectedPerCall.shift() ?? 0;
+    });
+
+    const total = await runInBatches(operation, 5);
+
+    expect(total).toBe(12);
+    expect(operation).toHaveBeenCalledTimes(3);
+  });
+
+  it('stops after the first call when it already affects fewer than `limit` rows', async () => {
+    const operation = jest.fn(async () => 3);
+
+    const total = await runInBatches(operation, 5);
+
+    expect(total).toBe(3);
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps looping when every batch is exactly full, until one comes back empty', async () => {
+    let calls = 0;
+    const operation = jest.fn(async () => {
+      calls++;
+      return calls <= 3 ? 5 : 0;
+    });
+
+    const total = await runInBatches(operation, 5);
+
+    expect(total).toBe(15);
+    expect(operation).toHaveBeenCalledTimes(4);
+  });
+
+  it('yields to the event loop between batches', async () => {
+    const order: string[] = [];
+    const operation = jest.fn(async () => {
+      order.push('operation');
+      return order.filter(e => e === 'operation').length < 2 ? 5 : 0;
+    });
+
+    setImmediate(() => order.push('event-loop'));
+
+    await runInBatches(operation, 5);
+
+    // The scheduled setImmediate ran in between the two full batches, not
+    // after runInBatches had already finished -- proof the loop actually
+    // yielded instead of running both batches back-to-back synchronously.
+    expect(order).toEqual(['operation', 'event-loop', 'operation']);
+  });
+});

--- a/tests/izi-queue.test.ts
+++ b/tests/izi-queue.test.ts
@@ -475,6 +475,70 @@ describe('IziQueue Class', () => {
 
       await queue.shutdown();
     });
+
+    it('prunes across multiple batches when the backlog exceeds batchSize', async () => {
+      // 2.5x the batch size: a single pruneJobs call must run three batches
+      // (5 + 5 + 2) internally rather than leaving most of the backlog behind.
+      for (let i = 0; i < 12; i++) {
+        db.prepare(`
+          INSERT INTO izi_jobs (state, queue, worker, args, completed_at)
+          VALUES ('completed', 'default', 'OldWorker', '{}', datetime('now', '-10 days'))
+        `).run();
+      }
+      db.prepare(`
+        INSERT INTO izi_jobs (state, queue, worker, args)
+        VALUES ('available', 'default', 'KeepWorker', '{}')
+      `).run();
+
+      const queue = createIziQueue({
+        database: adapter,
+        queues: { default: 5 }
+      });
+
+      const pruned = await queue.pruneJobs(86400 * 7, 5);
+
+      expect(pruned).toBe(12);
+      const remaining = db.prepare('SELECT state FROM izi_jobs').all() as { state: string }[];
+      expect(remaining).toEqual([{ state: 'available' }]);
+
+      await queue.shutdown();
+    });
+  });
+
+  describe('stageJobs batching (internal)', () => {
+    it('stages the whole backlog across multiple batches when it exceeds stageBatchSize', async () => {
+      // 2.5x the batch size: one stage cycle must run three batches (5 + 5 + 2)
+      // internally rather than leaving most of the backlog behind.
+      for (let i = 0; i < 12; i++) {
+        db.prepare(`
+          INSERT INTO izi_jobs (state, queue, worker, args, scheduled_at)
+          VALUES ('scheduled', 'default', 'DueWorker', '{}', datetime('now', '-1 minute'))
+        `).run();
+      }
+      db.prepare(`
+        INSERT INTO izi_jobs (state, queue, worker, args, scheduled_at)
+        VALUES ('scheduled', 'default', 'FutureWorker', '{}', datetime('now', '+1 hour'))
+      `).run();
+
+      const queue = createIziQueue({
+        database: adapter,
+        queues: { default: 5 },
+        stageBatchSize: 5
+      });
+
+      // Exercises the queue's own batching loop directly, without starting
+      // its poll/dispatch machinery, which would otherwise race staged jobs
+      // out of the 'available' state before this can observe them.
+      await (queue as unknown as { stageJobs(): Promise<void> }).stageJobs();
+
+      const states = (db.prepare('SELECT state FROM izi_jobs').all() as { state: string }[]).map(
+        r => r.state
+      );
+      expect(states.filter(s => s === 'available')).toHaveLength(12);
+      expect(states.filter(s => s === 'scheduled')).toHaveLength(1);
+
+      await queue.shutdown();
+    });
   });
 
   describe('rescueStuckJobs', () => {

--- a/tests/mysql-adapter.test.ts
+++ b/tests/mysql-adapter.test.ts
@@ -134,6 +134,26 @@ describeMySQL('MySQLAdapter', () => {
     expect(await countByState()).toEqual({ available: 2, retryable: 1 });
   });
 
+  it('stages at most `limit` rows per call, leaving the rest for the next batch', async () => {
+    for (let i = 0; i < 12; i++) {
+      await pool.query(
+        `INSERT INTO izi_jobs (state, queue, worker, args, meta, tags, errors, scheduled_at)
+         VALUES ('scheduled', 'default', 'W', '{}', '{}', '[]', '[]', NOW() - INTERVAL 1 MINUTE)`
+      );
+    }
+    await pool.query(
+      `INSERT INTO izi_jobs (state, queue, worker, args, meta, tags, errors, scheduled_at)
+       VALUES ('scheduled', 'default', 'FutureW', '{}', '{}', '[]', '[]', NOW() + INTERVAL 1 HOUR)`
+    );
+
+    expect(await adapter.stageJobs(5)).toBe(5);
+    expect(await adapter.stageJobs(5)).toBe(5);
+    expect(await adapter.stageJobs(5)).toBe(2);
+    expect(await adapter.stageJobs(5)).toBe(0);
+
+    expect(await countByState()).toEqual({ available: 12, scheduled: 1 });
+  });
+
   it('updates a job and preserves untouched columns', async () => {
     const job = await adapter.insertJob(jobData({ args: { keep: true } }));
 
@@ -226,6 +246,23 @@ describeMySQL('MySQLAdapter', () => {
     const pruned = await adapter.pruneJobs(3600);
 
     expect(pruned).toBe(1);
+    expect(await countByState()).toEqual({ available: 1 });
+  });
+
+  it('deletes at most `limit` rows per call, leaving the rest for the next batch', async () => {
+    for (let i = 0; i < 12; i++) {
+      await pool.query(
+        `INSERT INTO izi_jobs (state, queue, worker, args, meta, tags, errors, completed_at)
+         VALUES ('completed', 'default', 'W', '{}', '{}', '[]', '[]', NOW() - INTERVAL 2 HOUR)`
+      );
+    }
+    await adapter.insertJob(jobData());
+
+    expect(await adapter.pruneJobs(3600, 5)).toBe(5);
+    expect(await adapter.pruneJobs(3600, 5)).toBe(5);
+    expect(await adapter.pruneJobs(3600, 5)).toBe(2);
+    expect(await adapter.pruneJobs(3600, 5)).toBe(0);
+
     expect(await countByState()).toEqual({ available: 1 });
   });
 

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -6,6 +6,7 @@ import {
   clearWorkers
 } from '../src/index.js';
 import { telemetry } from '../src/core/telemetry.js';
+import { DEFAULT_BATCH_SIZE } from '../src/database/adapter.js';
 import type { PluginContext } from '../src/plugins/plugin.js';
 
 describe('Plugins', () => {
@@ -263,6 +264,15 @@ describe('Plugins', () => {
         });
         expect(plugin.name).toBe('pruner');
       });
+
+      it('should accept a custom batchSize', () => {
+        const plugin = createPrunerPlugin({
+          interval: 30000,
+          maxAge: 3600,
+          batchSize: 500
+        });
+        expect(plugin.name).toBe('pruner');
+      });
     });
 
     describe('validate', () => {
@@ -296,6 +306,18 @@ describe('Plugins', () => {
         const errors = plugin.validate();
         expect(errors.length).toBeGreaterThan(0);
         expect(errors[0]).toContain('maxAge');
+      });
+
+      it('should fail validation if batchSize is less than 1', () => {
+        const plugin = createPrunerPlugin({
+          interval: 5000,
+          maxAge: 3600,
+          batchSize: 0
+        });
+
+        const errors = plugin.validate();
+        expect(errors.length).toBeGreaterThan(0);
+        expect(errors[0]).toContain('batchSize');
       });
 
       it('should fail validation for multiple issues', () => {
@@ -373,7 +395,7 @@ describe('Plugins', () => {
         });
 
         // Bypass validation for testing
-        (plugin as any).config = { interval: 100, maxAge: 86400 };
+        (plugin as any).config = { interval: 100, maxAge: 86400, batchSize: DEFAULT_BATCH_SIZE };
 
         await plugin.start(pluginContext);
 
@@ -409,7 +431,7 @@ describe('Plugins', () => {
           maxAge: 86400
         });
 
-        (plugin as any).config = { interval: 100, maxAge: 86400 };
+        (plugin as any).config = { interval: 100, maxAge: 86400, batchSize: DEFAULT_BATCH_SIZE };
 
         await plugin.start(pluginContext);
         await new Promise(resolve => setTimeout(resolve, 200));
@@ -420,6 +442,32 @@ describe('Plugins', () => {
 
         unsubscribe();
         unsubscribeCompleted();
+        await plugin.stop();
+      });
+
+      it('prunes across multiple batches in a single cycle when the backlog exceeds batchSize', async () => {
+        // 2.5x the batch size, so a single prune cycle must run three batches
+        // (5 + 5 + 2) rather than leaving most of the backlog for next time.
+        for (let i = 0; i < 12; i++) {
+          db.prepare(`
+            INSERT INTO izi_jobs (state, queue, worker, args, completed_at)
+            VALUES ('completed', 'default', 'OldWorker', '{}', datetime('now', '-10 days'))
+          `).run();
+        }
+
+        const plugin = createPrunerPlugin({
+          interval: 100,
+          maxAge: 86400,
+          batchSize: 5
+        });
+        (plugin as any).config = { interval: 100, maxAge: 86400, batchSize: 5 };
+
+        await plugin.start(pluginContext);
+        await new Promise(resolve => setTimeout(resolve, 200));
+
+        const remaining = db.prepare('SELECT * FROM izi_jobs WHERE worker = ?').all('OldWorker');
+        expect(remaining).toHaveLength(0);
+
         await plugin.stop();
       });
     });
@@ -481,7 +529,7 @@ describe('Plugins', () => {
         interval: 100,
         maxAge: 86400
       });
-      (pruner as any).config = { interval: 100, maxAge: 86400 };
+      (pruner as any).config = { interval: 100, maxAge: 86400, batchSize: DEFAULT_BATCH_SIZE };
 
       await lifeline.start(pluginContext);
       await pruner.start(pluginContext);

--- a/tests/postgres-adapter.test.ts
+++ b/tests/postgres-adapter.test.ts
@@ -103,6 +103,68 @@ describePostgres('PostgresAdapter', () => {
     ]);
   });
 
+  it('stages at most `limit` rows per call, leaving the rest for the next batch', async () => {
+    for (let i = 0; i < 12; i++) {
+      await pool.query(
+        `INSERT INTO izi_jobs (state, queue, worker, args, scheduled_at)
+         VALUES ('scheduled', 'default', 'W', '{}', NOW() - INTERVAL '1 minute')`
+      );
+    }
+    await pool.query(
+      `INSERT INTO izi_jobs (state, queue, worker, args, scheduled_at)
+       VALUES ('scheduled', 'default', 'FutureW', '{}', NOW() + INTERVAL '1 hour')`
+    );
+
+    expect(await adapter.stageJobs(5)).toBe(5);
+    expect(await adapter.stageJobs(5)).toBe(5);
+    expect(await adapter.stageJobs(5)).toBe(2);
+    expect(await adapter.stageJobs(5)).toBe(0);
+
+    const { rows } = await pool.query(
+      `SELECT state, COUNT(*)::int AS count FROM izi_jobs GROUP BY state ORDER BY state`
+    );
+    expect(rows).toEqual([
+      { state: 'available', count: 12 },
+      { state: 'scheduled', count: 1 },
+    ]);
+  });
+
+  it('prunes only terminal jobs past the age cutoff', async () => {
+    await pool.query(
+      `INSERT INTO izi_jobs (state, queue, worker, args, completed_at)
+       VALUES ('completed', 'default', 'W', '{}', NOW() - INTERVAL '2 hours')`
+    );
+    await adapter.insertJob(jobData());
+
+    const pruned = await adapter.pruneJobs(3600);
+
+    expect(pruned).toBe(1);
+    const { rows } = await pool.query(
+      `SELECT state, COUNT(*)::int AS count FROM izi_jobs GROUP BY state ORDER BY state`
+    );
+    expect(rows).toEqual([{ state: 'available', count: 1 }]);
+  });
+
+  it('deletes at most `limit` rows per call, leaving the rest for the next batch', async () => {
+    for (let i = 0; i < 12; i++) {
+      await pool.query(
+        `INSERT INTO izi_jobs (state, queue, worker, args, completed_at)
+         VALUES ('completed', 'default', 'W', '{}', NOW() - INTERVAL '2 hours')`
+      );
+    }
+    await adapter.insertJob(jobData());
+
+    expect(await adapter.pruneJobs(3600, 5)).toBe(5);
+    expect(await adapter.pruneJobs(3600, 5)).toBe(5);
+    expect(await adapter.pruneJobs(3600, 5)).toBe(2);
+    expect(await adapter.pruneJobs(3600, 5)).toBe(0);
+
+    const { rows } = await pool.query(
+      `SELECT state, COUNT(*)::int AS count FROM izi_jobs GROUP BY state ORDER BY state`
+    );
+    expect(rows).toEqual([{ state: 'available', count: 1 }]);
+  });
+
   it('rescues orphans but leaves jobs owned by a live node alone', async () => {
     await adapter.heartbeat('live-node');
     await pool.query(

--- a/tests/sqlite-adapter.test.ts
+++ b/tests/sqlite-adapter.test.ts
@@ -362,6 +362,25 @@ describe('SQLiteAdapter', () => {
       const pruned = await adapter.pruneJobs(0); // Would delete everything if terminal
       expect(pruned).toBe(0);
     });
+
+    it('deletes at most `limit` rows per call, leaving the rest for the next batch', async () => {
+      for (let i = 0; i < 12; i++) {
+        db.prepare(`
+          INSERT INTO izi_jobs (state, queue, worker, args, completed_at)
+          VALUES ('completed', 'default', 'OldWorker', '{}', datetime('now', '-10 days'))
+        `).run();
+      }
+      // One non-prunable row that a batch must never touch regardless of limit.
+      await adapter.insertJob(createJobData({ state: 'available' }));
+
+      expect(await adapter.pruneJobs(86400, 5)).toBe(5);
+      expect(await adapter.pruneJobs(86400, 5)).toBe(5);
+      expect(await adapter.pruneJobs(86400, 5)).toBe(2);
+      expect(await adapter.pruneJobs(86400, 5)).toBe(0);
+
+      const remaining = db.prepare('SELECT state FROM izi_jobs').all() as { state: string }[];
+      expect(remaining).toEqual([{ state: 'available' }]);
+    });
   });
 
   describe('stageJobs', () => {
@@ -409,6 +428,31 @@ describe('SQLiteAdapter', () => {
         .prepare('SELECT state FROM izi_jobs WHERE worker = ?')
         .get('RetryableWorker') as { state: string };
       expect(job.state).toBe('available');
+    });
+
+    it('stages at most `limit` rows per call, leaving the rest for the next batch', async () => {
+      for (let i = 0; i < 12; i++) {
+        db.prepare(`
+          INSERT INTO izi_jobs (state, queue, worker, args, scheduled_at)
+          VALUES ('scheduled', 'default', 'DueWorker', '{}', datetime('now', '-1 minute'))
+        `).run();
+      }
+      // One future-scheduled row that a batch must never touch regardless of limit.
+      db.prepare(`
+        INSERT INTO izi_jobs (state, queue, worker, args, scheduled_at)
+        VALUES ('scheduled', 'default', 'FutureWorker', '{}', datetime('now', '+1 hour'))
+      `).run();
+
+      expect(await adapter.stageJobs(5)).toBe(5);
+      expect(await adapter.stageJobs(5)).toBe(5);
+      expect(await adapter.stageJobs(5)).toBe(2);
+      expect(await adapter.stageJobs(5)).toBe(0);
+
+      const states = (db.prepare('SELECT state FROM izi_jobs').all() as { state: string }[]).map(
+        r => r.state
+      );
+      expect(states.filter(s => s === 'available')).toHaveLength(12);
+      expect(states.filter(s => s === 'scheduled')).toHaveLength(1);
     });
   });
 


### PR DESCRIPTION
Closes #29.

## Problem

`pruneJobs` and `stageJobs` ran as single unbounded statements:

- the first prune after a long stretch of traffic became one `DELETE` over millions of rows — long transaction, table bloat, autovacuum pressure, replication lag
- a batch of scheduled jobs all becoming due at once (e.g. 500k reminders for 09:00) became one `UPDATE` blocking every concurrent fetch on the table
- with no leadership election yet (#26), every node does this simultaneously

## Fix

Modeled on Oban's Pruner/Stager, which work in bounded batches:

- New `runInBatches(operation, limit)` helper: calls `operation(limit)` repeatedly until a batch comes back short, yielding to the event loop between batches. Fails fast on a non-positive/non-finite limit instead of looping forever (this guard caught a real infinite-loop bug during testing).
- Batches are bounded with `id IN (SELECT id … LIMIT n)`, per dialect:
  - **Postgres**: plain subselect
  - **MySQL**: inner SELECT wrapped in a derived table (`… IN (SELECT id FROM (SELECT id … LIMIT ?) AS batch)`) — required to avoid `ERROR 1093`
  - **SQLite**: plain subselect too, since bare `DELETE … LIMIT` needs `SQLITE_ENABLE_UPDATE_DELETE_LIMIT`, which better-sqlite3's build lacks
- Batching applies to the Pruner plugin, the automatic staging loop, and the public `IziQueue.pruneJobs()` (which still clears the whole eligible backlog in one call — it just does it in batches now).
- New tuning knobs: `PrunerConfig.batchSize` and `IziQueueConfig.stageBatchSize`, both defaulting to 5000 (`DEFAULT_BATCH_SIZE`).

## Backward compatibility

The adapter interface change is additive-optional (`limit?: number`). A third-party adapter implementing the old signatures still satisfies `DatabaseAdapter` at the type level and still works at runtime — it returns everything in one call and the loop stops after one harmless follow-up. Not a breaking change.

## Testing

TDD, with new coverage in `tests/adapter.test.ts` (runInBatches unit tests incl. event-loop yielding and the invalid-limit guard), per-adapter `limit` tests for sqlite/postgres/mysql, Pruner `batchSize` config/validation tests, and multi-batch end-to-end tests (2.5× the batch size cleared in one call; 12 due jobs staged across 3 batches of 5 while a future job stays untouched).

Full suite: **368/368 tests, 20/20 suites**, including against real Postgres 16 and MySQL 8 via docker — not just SQLite. Build and lint clean.