### PR TITLE
feat(core): default to Oban's polynomial backoff curve

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -451,11 +451,23 @@ CI runs both on every push, so a change that only works on SQLite fails there.
 
 ## Key Formulas
 
-### Exponential Backoff
+### Backoff
+
+`calculateBackoff(attempt, options?)` in `src/core/job.ts` supports two named
+curves via `options.strategy`, plus an optional `options.maxDelay` cap (seconds,
+applies to either curve). `WorkerDefinition.backoff` accepts a `BackoffOptions`
+object with the same shape, or a custom `(job) => number` function.
 
 ```typescript
-// Default: (15 + 2^attempt) seconds with ±10% jitter
-const base = 15 + Math.pow(2, attempt);
+// Default ('polynomial') -- Oban's curve. Spreads maxAttempts: 20 across
+// ~8.4 days rather than ~3 hours; see README "Retry horizon" for the table.
+const base = Math.pow(attempt, 4) + 15;
+const jitter = Math.random() * 10 * attempt;
+const delayMs = (base + jitter) * 1000;
+
+// 'exponential' -- the original curve, opt-in only. Plateaus at ~17 minutes
+// once attempt reaches maxPower (default 10).
+const base = 15 + Math.pow(2, Math.min(attempt, 10));
 const jitter = base * 0.1 * (Math.random() * 2 - 1);
 const delayMs = (base + jitter) * 1000;
 ```

--- a/README.md
+++ b/README.md
@@ -120,22 +120,73 @@ await queue.insert('send_email', {
 
 ### Retries with Backoff
 
+A failed job is retried up to `maxAttempts` times (default 20), waiting between
+attempts according to a backoff curve. The default curve is polynomial,
+matching Oban's default:
+
 ```typescript
 const myWorker = defineWorker('my_worker', async (job) => {
-  // Automatic exponential backoff on failure
-  // Formula: (15 + 2^attempt) seconds with ±10% jitter
+  // Automatic backoff on failure.
+  // Formula: attempt^4 + 15 + rand(0..10) * attempt seconds
   return WorkerResults.error('Something went wrong');
 }, {
   maxAttempts: 5, // Retry up to 5 times
 });
+```
 
-// Or define custom backoff
+#### Retry horizon
+
+The polynomial curve is deliberately steep: it spreads a 20-attempt budget
+across days rather than exhausting it in a few hours, which is what makes
+`maxAttempts: 20` a meaningful safety margin instead of a formality. With the
+default options (jitter shown at its midpoint):
+
+| attempt | delay    | cumulative time    |
+|---------|----------|---------------------|
+| 1       | ~21s     | ~21s                |
+| 5       | ~11min   | ~19min               |
+| 10      | ~2.8hr   | ~7.2hr               |
+| 15      | ~14.1hr  | ~49.8hr (~2.1 days)  |
+| 20      | ~44.5hr  | ~201hr (~8.4 days)   |
+
+> **Behavior change:** prior to backoff curve support, the default curve was
+> exponential and capped at `15 + 2^10 ≈ 17 minutes` per attempt, so all 20
+> attempts of a default worker completed within ~3 hours. If you rely on the
+> old, faster-exhausting timeline, opt back in explicitly (see below) or
+> reduce `maxAttempts`.
+
+#### Choosing a strategy
+
+`backoff` on `defineWorker` accepts either a custom function, or a config
+object selecting and tuning one of the two built-in curves:
+
+```typescript
+// Opt back into the original exponential curve (basePad + multiplier *
+// 2^min(attempt, maxPower) seconds, with ±jitterPercent jitter). Plateaus at
+// ~17 minutes once attempt reaches maxPower (default 10).
+const legacyBackoffWorker = defineWorker('legacy_worker', async (job) => {
+  return WorkerResults.error('Something went wrong');
+}, {
+  backoff: { strategy: 'exponential' },
+});
+
+// Cap either curve's delay, in seconds
+const cappedBackoffWorker = defineWorker('capped_worker', async (job) => {
+  return WorkerResults.error('Something went wrong');
+}, {
+  backoff: { maxDelay: 3600 }, // never wait longer than 1 hour
+});
+
+// Or bypass curves entirely with a custom function
 const customBackoffWorker = defineWorker('custom_worker', async (job) => {
   return WorkerResults.ok();
 }, {
   backoff: (job) => job.attempt * 60, // Linear: 60s, 120s, 180s...
 });
 ```
+
+`calculateBackoff(attempt, options?)` is also exported directly if you want to
+compute a delay outside of a worker definition.
 
 ### Priority Queues
 

--- a/src/core/job.ts
+++ b/src/core/job.ts
@@ -1,4 +1,4 @@
-import type { Job, JobInsertOptions, JobState } from '../types.js';
+import type { BackoffOptions, Job, JobInsertOptions, JobState } from '../types.js';
 
 export const STATE_TRANSITIONS: Record<JobState, JobState[]> = {
   scheduled: ['available', 'cancelled'],
@@ -63,30 +63,65 @@ export function createJob<T = Record<string, unknown>>(
 }
 
 /**
- * Calculate backoff delay with exponential backoff and jitter
- * Default: 15 + 2^attempt seconds with +/-10% jitter
+ * Calculate the backoff delay (in ms) before a failed job is retried.
+ *
+ * Defaults to Oban's polynomial curve: `attempt^4 + padSeconds + rand(0..jitterMax)
+ * * attempt` seconds. That spreads `maxAttempts: 20` across ~44 hours by the
+ * final attempt, rather than plateauing at ~17 minutes -- see
+ * `calculatePolynomialBackoffSeconds` below for the attempt -> delay table.
+ *
+ * Pass `{ strategy: 'exponential' }` for the original curve: `basePad +
+ * multiplier * 2^min(attempt, maxPower)` seconds with `+/-jitterPercent` jitter.
+ *
+ * `maxDelay` (seconds) caps either curve's result. Neither curve is capped by
+ * default; the exponential curve is already implicitly bounded via `maxPower`.
  */
-export function calculateBackoff(
-  attempt: number,
-  options: {
-    basePad?: number;
-    multiplier?: number;
-    maxPower?: number;
-    jitterPercent?: number;
-  } = {}
-): number {
-  const {
-    basePad = 15,
-    multiplier = 1,
-    maxPower = 10,
-    jitterPercent = 0.1
-  } = options;
+export function calculateBackoff(attempt: number, options: BackoffOptions = {}): number {
+  const { strategy = 'polynomial', maxDelay } = options;
+
+  const delaySeconds = strategy === 'exponential'
+    ? calculateExponentialBackoffSeconds(attempt, options)
+    : calculatePolynomialBackoffSeconds(attempt, options);
+
+  const cappedSeconds = maxDelay !== undefined ? Math.min(delaySeconds, maxDelay) : delaySeconds;
+
+  return Math.round(cappedSeconds * 1000);
+}
+
+/**
+ * Oban's default curve: `attempt^4 + padSeconds + rand(0..jitterMax) * attempt`
+ * seconds. Attempt -> cumulative time (default options, jitter midpoint):
+ *
+ * | attempt | delay     | cumulative      |
+ * |---------|-----------|-----------------|
+ * | 1       | ~21s      | ~21s            |
+ * | 5       | ~11min    | ~19min          |
+ * | 10      | ~2.8hr    | ~7.2hr          |
+ * | 15      | ~14.1hr   | ~49.8hr (~2.1d) |
+ * | 20      | ~44.5hr   | ~201hr (~8.4d)  |
+ */
+function calculatePolynomialBackoffSeconds(attempt: number, options: BackoffOptions): number {
+  const { padSeconds = 15, power = 4, jitterMax = 10 } = options;
+
+  const base = Math.pow(attempt, power) + padSeconds;
+  const jitter = Math.random() * jitterMax * attempt;
+
+  return base + jitter;
+}
+
+/**
+ * The original izi-queue curve: `basePad + multiplier * 2^min(attempt,
+ * maxPower)` seconds with `+/-jitterPercent` jitter. Plateaus at ~17 minutes
+ * once `attempt` reaches `maxPower` (default 10).
+ */
+function calculateExponentialBackoffSeconds(attempt: number, options: BackoffOptions): number {
+  const { basePad = 15, multiplier = 1, maxPower = 10, jitterPercent = 0.1 } = options;
 
   const power = Math.min(attempt, maxPower);
   const base = basePad + multiplier * Math.pow(2, power);
   const jitter = base * jitterPercent * (Math.random() * 2 - 1);
 
-  return Math.round((base + jitter) * 1000);
+  return base + jitter;
 }
 
 export function formatError(error: Error | string, attempt: number): Job['errors'][0] {

--- a/src/core/worker.ts
+++ b/src/core/worker.ts
@@ -77,11 +77,11 @@ export async function executeWorker(job: Job): Promise<WorkerResult> {
 export function getBackoffDelay(job: Job): number {
   const worker = getWorker(job.worker);
 
-  if (worker?.backoff) {
+  if (typeof worker?.backoff === 'function') {
     return worker.backoff(job);
   }
 
-  return calculateBackoff(job.attempt);
+  return calculateBackoff(job.attempt, worker?.backoff);
 }
 
 export function defineWorker<T = Record<string, unknown>>(

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,8 @@ export type {
   UniqueOptions,
   WorkerResult,
   WorkerDefinition,
+  BackoffStrategy,
+  BackoffOptions,
   QueueConfig,
   DatabaseAdapter,
   DrainOutcome,

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,6 +84,50 @@ export interface JobInsertOptions<T = Record<string, unknown>> {
   tx?: TransactionHandle;
 }
 
+/**
+ * Named backoff curves for `calculateBackoff`/`WorkerDefinition.backoff`.
+ *
+ * `polynomial` is Oban's default: `attempt^4 + padSeconds + rand(0..jitterMax) *
+ * attempt` seconds. It spreads `maxAttempts: 20` across days rather than hours,
+ * which is what makes a 20-attempt budget meaningful.
+ *
+ * `exponential` is izi-queue's original curve: `basePad + multiplier *
+ * 2^min(attempt, maxPower)` seconds with `±jitterPercent` jitter. Kept for
+ * callers that already depend on its ~17-minute plateau.
+ */
+export type BackoffStrategy = 'polynomial' | 'exponential';
+
+export interface BackoffOptions {
+  /** Which curve to use. Defaults to `'polynomial'`. */
+  strategy?: BackoffStrategy;
+  /**
+   * Cap on the computed delay, in seconds, applied after jitter. Applies to
+   * both strategies. Unset by default -- the polynomial curve is uncapped
+   * (that's the point: it needs to span days for `maxAttempts: 20` to mean
+   * anything), and the exponential curve is already implicitly capped via
+   * `maxPower`.
+   */
+  maxDelay?: number;
+
+  // polynomial-only
+  /** Base seconds added before the polynomial term. Default 15. */
+  padSeconds?: number;
+  /** Exponent applied to `attempt`. Default 4. */
+  power?: number;
+  /** Upper bound (exclusive) of the uniform jitter, scaled by `attempt`. Default 10. */
+  jitterMax?: number;
+
+  // exponential-only
+  /** Base seconds added before the exponential term. Default 15. */
+  basePad?: number;
+  /** Multiplier applied to `2^power`. Default 1. */
+  multiplier?: number;
+  /** Caps `attempt` before it is used as the exponent. Default 10. */
+  maxPower?: number;
+  /** Symmetric jitter as a fraction of the base delay. Default 0.1 (±10%). */
+  jitterPercent?: number;
+}
+
 export type WorkerResult =
   | { status: 'ok'; value?: unknown }
   | { status: 'error'; error: Error | string }
@@ -120,7 +164,12 @@ export interface WorkerDefinition<T = Record<string, unknown>> {
   queue?: string;
   maxAttempts?: number;
   priority?: number;
-  backoff?: (job: Job<T>) => number;
+  /**
+   * A custom backoff function, or a `BackoffOptions` config selecting/tuning
+   * one of the named curves (`calculateBackoff`'s default is used when this
+   * is omitted entirely).
+   */
+  backoff?: ((job: Job<T>) => number) | BackoffOptions;
   timeout?: number;
   isolation?: IsolatedWorkerOptions;
 }

--- a/tests/job.test.ts
+++ b/tests/job.test.ts
@@ -66,34 +66,111 @@ describe('Job Module', () => {
   });
 
   describe('calculateBackoff', () => {
-    it('should calculate exponential backoff with default options', () => {
-      // Attempt 1: 15 + 2^1 = 17 seconds (±10% jitter)
-      const backoff1 = calculateBackoff(1);
-      expect(backoff1).toBeGreaterThanOrEqual(15300); // 17 * 0.9 * 1000
-      expect(backoff1).toBeLessThanOrEqual(18700);    // 17 * 1.1 * 1000
+    describe('polynomial strategy (default)', () => {
+      it('defaults to the polynomial strategy when none is given', () => {
+        const withDefault = calculateBackoff(3);
+        const withExplicitStrategy = calculateBackoff(3, { strategy: 'polynomial' });
 
-      // Attempt 5: 15 + 2^5 = 47 seconds (±10% jitter)
-      const backoff5 = calculateBackoff(5);
-      expect(backoff5).toBeGreaterThanOrEqual(42300);
-      expect(backoff5).toBeLessThanOrEqual(51700);
-    });
-
-    it('should respect maxPower option', () => {
-      // With maxPower=2, attempt 10 should behave like attempt 2
-      const backoff = calculateBackoff(10, { maxPower: 2 });
-      // 15 + 2^2 = 19 seconds
-      expect(backoff).toBeGreaterThanOrEqual(17100);
-      expect(backoff).toBeLessThanOrEqual(20900);
-    });
-
-    it('should apply custom basePad and multiplier', () => {
-      const backoff = calculateBackoff(1, {
-        basePad: 5,
-        multiplier: 2,
-        jitterPercent: 0 // No jitter for predictable test
+        // Both draw from the same formula and bounds; compare bounds rather
+        // than exact values since each call re-rolls the random jitter term.
+        expect(withDefault).toBeGreaterThanOrEqual(96000); // 3^4 + 15 = 96s
+        expect(withDefault).toBeLessThanOrEqual(126000);   // + rand(0..10) * 3 = 30s max
+        expect(withExplicitStrategy).toBeGreaterThanOrEqual(96000);
+        expect(withExplicitStrategy).toBeLessThanOrEqual(126000);
       });
-      // 5 + 2 * 2^1 = 9 seconds = 9000ms
-      expect(backoff).toBe(9000);
+
+      it('computes attempt^4 + 15 + rand(0..10) * attempt seconds', () => {
+        // Attempt 1: 1 + 15 = 16s, + rand(0..10)*1 => [16, 26]
+        const backoff1 = calculateBackoff(1);
+        expect(backoff1).toBeGreaterThanOrEqual(16000);
+        expect(backoff1).toBeLessThanOrEqual(26000);
+
+        // Attempt 20: 20^4 + 15 = 160015s, + rand(0..10)*20 => up to 160215s
+        const backoff20 = calculateBackoff(20);
+        expect(backoff20).toBeGreaterThanOrEqual(160015000);
+        expect(backoff20).toBeLessThanOrEqual(160215000);
+        // ~44.4 hours, the horizon the issue asked for
+        expect(backoff20 / 1000 / 3600).toBeGreaterThan(44);
+      });
+
+      it('has zero jitter at attempt 0', () => {
+        // rand(0..10) * 0 == 0, so attempt 0 is deterministic
+        expect(calculateBackoff(0)).toBe(15000);
+      });
+
+      it('grows monotonically: the minimum possible delay for attempt n+1 exceeds the maximum possible delay for attempt n', () => {
+        const maxPossible = (attempt: number) => Math.pow(attempt, 4) + 15 + 10 * attempt;
+        const minPossible = (attempt: number) => Math.pow(attempt, 4) + 15;
+
+        for (let attempt = 0; attempt < 20; attempt++) {
+          expect(minPossible(attempt + 1)).toBeGreaterThan(maxPossible(attempt));
+        }
+      });
+
+      it('respects a custom padSeconds, power, and jitterMax', () => {
+        const backoff = calculateBackoff(2, {
+          padSeconds: 5,
+          power: 2,
+          jitterMax: 0 // no jitter for a predictable test
+        });
+        // 2^2 + 5 = 9 seconds = 9000ms
+        expect(backoff).toBe(9000);
+      });
+
+      it('applies maxDelay as a cap on the polynomial curve', () => {
+        const backoff = calculateBackoff(20, { maxDelay: 100 });
+        expect(backoff).toBe(100000);
+      });
+
+      it('has no cap by default, even at high attempts', () => {
+        const backoff = calculateBackoff(20);
+        expect(backoff).toBeGreaterThan(100000);
+      });
+    });
+
+    describe('exponential strategy (legacy, explicit opt-in)', () => {
+      it('calculates exponential backoff with default options, unchanged from before', () => {
+        // Attempt 1: 15 + 2^1 = 17 seconds (±10% jitter)
+        const backoff1 = calculateBackoff(1, { strategy: 'exponential' });
+        expect(backoff1).toBeGreaterThanOrEqual(15300); // 17 * 0.9 * 1000
+        expect(backoff1).toBeLessThanOrEqual(18700);    // 17 * 1.1 * 1000
+
+        // Attempt 5: 15 + 2^5 = 47 seconds (±10% jitter)
+        const backoff5 = calculateBackoff(5, { strategy: 'exponential' });
+        expect(backoff5).toBeGreaterThanOrEqual(42300);
+        expect(backoff5).toBeLessThanOrEqual(51700);
+      });
+
+      it('respects maxPower option', () => {
+        // With maxPower=2, attempt 10 should behave like attempt 2
+        const backoff = calculateBackoff(10, { strategy: 'exponential', maxPower: 2 });
+        // 15 + 2^2 = 19 seconds
+        expect(backoff).toBeGreaterThanOrEqual(17100);
+        expect(backoff).toBeLessThanOrEqual(20900);
+      });
+
+      it('applies custom basePad and multiplier', () => {
+        const backoff = calculateBackoff(1, {
+          strategy: 'exponential',
+          basePad: 5,
+          multiplier: 2,
+          jitterPercent: 0 // No jitter for predictable test
+        });
+        // 5 + 2 * 2^1 = 9 seconds = 9000ms
+        expect(backoff).toBe(9000);
+      });
+
+      it('caps at maxPower=10 by default, same as before (attempts 10-20 plateau at ~17 minutes)', () => {
+        const backoffAt10 = calculateBackoff(10, { strategy: 'exponential', jitterPercent: 0 });
+        const backoffAt20 = calculateBackoff(20, { strategy: 'exponential', jitterPercent: 0 });
+        expect(backoffAt10).toBe(backoffAt20);
+        expect(backoffAt10).toBe((15 + Math.pow(2, 10)) * 1000);
+      });
+
+      it('applies maxDelay as a cap on the exponential curve', () => {
+        const backoff = calculateBackoff(10, { strategy: 'exponential', jitterPercent: 0, maxDelay: 60 });
+        expect(backoff).toBe(60000);
+      });
     });
   });
 

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -5,6 +5,7 @@ import {
   getWorkerNames,
   clearWorkers,
   executeWorker,
+  getBackoffDelay,
   defineWorker,
   WorkerResults
 } from '../src/core/worker.js';
@@ -272,6 +273,54 @@ describe('Worker Module', () => {
     it('should create snooze result', () => {
       const result = WorkerResults.snooze(300);
       expect(result).toEqual({ status: 'snooze', seconds: 300 });
+    });
+  });
+
+  describe('getBackoffDelay', () => {
+    it('uses the polynomial default when the worker declares no backoff at all', () => {
+      registerWorker(defineWorker('NoBackoffWorker', async () => WorkerResults.ok()));
+      const job = createMockJob({ worker: 'NoBackoffWorker', attempt: 3 });
+
+      const delay = getBackoffDelay(job);
+
+      // attempt^4 + 15 + rand(0..10)*attempt seconds, in ms
+      expect(delay).toBeGreaterThanOrEqual(96000);
+      expect(delay).toBeLessThanOrEqual(126000);
+    });
+
+    it('calls a custom backoff function when one is provided', () => {
+      registerWorker(defineWorker('CustomFnWorker', async () => WorkerResults.ok(), {
+        backoff: (job) => job.attempt * 60000
+      }));
+      const job = createMockJob({ worker: 'CustomFnWorker', attempt: 3 });
+
+      expect(getBackoffDelay(job)).toBe(180000);
+    });
+
+    it('selects the legacy exponential strategy via a config object', () => {
+      registerWorker(defineWorker('ExponentialWorker', async () => WorkerResults.ok(), {
+        backoff: { strategy: 'exponential', jitterPercent: 0 }
+      }));
+      const job = createMockJob({ worker: 'ExponentialWorker', attempt: 1 });
+
+      // 15 + 2^1 = 17s, no jitter
+      expect(getBackoffDelay(job)).toBe(17000);
+    });
+
+    it('applies maxDelay from a config object', () => {
+      registerWorker(defineWorker('CappedWorker', async () => WorkerResults.ok(), {
+        backoff: { maxDelay: 50 }
+      }));
+      const job = createMockJob({ worker: 'CappedWorker', attempt: 20 });
+
+      expect(getBackoffDelay(job)).toBe(50000);
+    });
+
+    it('falls back to the default when the worker is not registered', () => {
+      const job = createMockJob({ worker: 'GhostWorker', attempt: 0 });
+
+      // attempt 0 is deterministic: 0^4 + 15 + rand(0..10)*0 = 15s
+      expect(getBackoffDelay(job)).toBe(15000);
     });
   });
 });


### PR DESCRIPTION
Closes #34.

## Problem

The default backoff plateaus at ~17 minutes (`15 + 2^min(attempt, 10)`s) while `maxAttempts` defaults to 20 — all 20 attempts are spent in ~3 hours, which doesn't survive a real downstream outage. Attempts 10–20 all wait the same delay.

## Change

- **New default**: Oban's polynomial curve — `attempt^4 + 15 + rand(0..10) × attempt` seconds. Attempt 20 waits ~44.5h; the full 20-attempt horizon spans ~8.4 days cumulative. Delay intervals are provably non-overlapping under jitter (tested), so the curve is strictly monotonic.
- **Legacy curve kept**: `backoff: { strategy: 'exponential' }` on `defineWorker` reproduces the old numbers exactly (tested byte-for-byte against the old bounds).
- **`maxDelay`** (seconds) caps either strategy; polynomial is deliberately uncapped by default.
- Custom `backoff` functions are unaffected — `WorkerDefinition.backoff` now accepts a function **or** a `BackoffOptions` object.
- README gains a retry-horizon table and a strategy-selection section; CLAUDE.md's formula reference updated.

## ⚠️ Behavior change

Runtime retry timing changes for every consumer on default settings (no code-level breakage). Per the 0.x convention this ships in the next **minor** (0.8.0) with a changelog callout.

## Testing

Curve shape, attempt-0 determinism, ~44h attempt-20 bound, monotonicity proof over attempts 0–20, `maxDelay` capping, legacy strategy equivalence, and `getBackoffDelay` dispatch (default / custom fn / config object). Full suite: 340 passed (SQLite; change is pure logic in job.ts/worker.ts, nothing dialect-dependent). Build and lint clean.