### PR TITLE
feat(db): job querying API — listJobs and countJobs

### DIFF
--- a/src/core/izi-queue.ts
+++ b/src/core/izi-queue.ts
@@ -6,6 +6,8 @@ import type {
   Job,
   JobCriteria,
   JobInsertOptions,
+  JobListCriteria,
+  JobStateCounts,
   TransactionHandle,
   QueueConfig,
   TelemetryEvent,
@@ -45,7 +47,8 @@ function assertScoped(criteria: JobCriteria, operation: string): void {
     (criteria.ids && criteria.ids.length > 0) ||
     criteria.queue ||
     criteria.worker ||
-    (criteria.state && criteria.state.length > 0);
+    (criteria.state && criteria.state.length > 0) ||
+    (criteria.tags && criteria.tags.length > 0);
 
   if (!scoped) {
     throw new Error(
@@ -337,6 +340,43 @@ export class IziQueue {
 
   async getJob(id: number): Promise<Job | null> {
     return this.config.database.getJob(id);
+  }
+
+  /**
+   * Lists jobs matching `criteria` -- filtering by id/queue/worker/state/tags,
+   * ordered and paginated -- so consumers stop hand-writing SQL against
+   * `izi_jobs` and coupling to a schema this library may change (#31).
+   * Read-only, so unlike `cancelJobs`/`retryJobs` it is not required to be
+   * scoped: an empty criteria object simply returns the first page.
+   *
+   * `limit` defaults to 100 and is capped at 1000 regardless of what is
+   * requested. `orderBy` defaults to `{ field: 'insertedAt', direction: 'desc' }`
+   * and its `field` is restricted to a whitelist (`id`, `priority`,
+   * `scheduledAt`, `insertedAt`, `attemptedAt`) -- it can never carry
+   * free-form SQL, which is the injection class fixed in #18.
+   *
+   * `tags`, when given, matches jobs sharing at least one of the listed tags
+   * (match-any), with identical semantics across all three adapters.
+   */
+  async listJobs(criteria: JobListCriteria = {}): Promise<Job[]> {
+    if (!this.config.database.listJobs) {
+      throw new Error('The configured database adapter does not support listJobs');
+    }
+    return this.config.database.listJobs(criteria);
+  }
+
+  /**
+   * Counts jobs matching `criteria` (the same filters as `listJobs`, minus
+   * pagination/ordering), grouped by state. Every `JobState` key is always
+   * present at 0 or above, which is what a `/health` endpoint wants --
+   * `available + scheduled + retryable` for backlog depth, `discarded` for
+   * how many jobs gave up -- without guarding against a missing key.
+   */
+  async countJobs(criteria: JobCriteria = {}): Promise<JobStateCounts> {
+    if (!this.config.database.countJobs) {
+      throw new Error('The configured database adapter does not support countJobs');
+    }
+    return this.config.database.countJobs(criteria);
   }
 
   async cancelJobs(criteria: JobCriteria): Promise<number> {

--- a/src/database/adapter.ts
+++ b/src/database/adapter.ts
@@ -1,6 +1,17 @@
-import type { DatabaseAdapter, Job, JobState, Logger } from '../types.js';
+import type {
+  DatabaseAdapter,
+  Job,
+  JobOrderBy,
+  JobOrderByField,
+  JobState,
+  JobStateCounts,
+  Logger
+} from '../types.js';
 import { DEFAULT_UNIQUE_PERIOD, DEFAULT_UNIQUE_STATES } from '../core/unique.js';
 import { consoleLogger } from '../core/logger.js';
+
+/** SQL dialects `criteriaClause`'s tags handling branches on. */
+export type SqlDialect = 'postgres' | 'mysql' | 'sqlite';
 
 /**
  * Seconds a node may go without a heartbeat before it is presumed dead and its
@@ -394,12 +405,46 @@ export const SQL = {
 };
 
 /**
- * Builds the shared filter for bulk job operations. An empty criteria object is
- * rejected by the caller rather than silently matching every job.
+ * Appends the dialect-specific match-any tags predicate. `tags` is stored as
+ * `TEXT[]` on Postgres, and as a JSON array of strings on MySQL and SQLite --
+ * each dialect needs its own operator to express "shares at least one tag":
+ *
+ * - Postgres: `&&`, the native array-overlap operator.
+ * - MySQL: `JSON_OVERLAPS`, available from 8.0.17 (the `mysql:8` image this
+ *   library is tested against ships well past that).
+ * - SQLite: no overlap builtin, so `EXISTS` over `json_each` -- the same JSON1
+ *   function `checkUnique` already relies on -- checking membership per tag.
+ */
+function tagsClause(
+  dialect: SqlDialect,
+  tags: string[],
+  placeholder: (index: number) => string,
+  index: number
+): { clause: string; params: unknown[] } {
+  if (dialect === 'postgres') {
+    return { clause: ` AND tags && ${placeholder(index)}`, params: [tags] };
+  }
+  if (dialect === 'mysql') {
+    return { clause: ` AND JSON_OVERLAPS(tags, ${placeholder(index)})`, params: [JSON.stringify(tags)] };
+  }
+  const placeholders = tags.map((_, i) => placeholder(index + i)).join(',');
+  return {
+    clause: ` AND EXISTS (SELECT 1 FROM json_each(tags) WHERE json_each.value IN (${placeholders}))`,
+    params: [...tags]
+  };
+}
+
+/**
+ * Builds the shared filter for bulk job operations (`cancelJobs`,
+ * `retryJobs`) and for the read-only query API (`listJobs`, `countJobs`). An
+ * empty criteria object is rejected by callers of the bulk operations rather
+ * than silently matching every job -- see `assertScoped` in `izi-queue.ts`;
+ * `listJobs`/`countJobs` are read-only and impose no such requirement.
  */
 export function criteriaClause(
   criteria: import('../types.js').JobCriteria,
-  placeholder: (index: number) => string
+  placeholder: (index: number) => string,
+  dialect: SqlDialect
 ): { clause: string; params: unknown[] } {
   const params: unknown[] = [];
   let clause = '';
@@ -421,8 +466,107 @@ export function criteriaClause(
     clause += ` AND state IN (${criteria.state.map(() => placeholder(index++)).join(',')})`;
     params.push(...criteria.state);
   }
+  if (criteria.tags && criteria.tags.length > 0) {
+    const tags = tagsClause(dialect, criteria.tags, placeholder, index);
+    clause += tags.clause;
+    params.push(...tags.params);
+    index += dialect === 'sqlite' ? criteria.tags.length : 1;
+  }
 
   return { clause, params };
+}
+
+/**
+ * Default and maximum row count `listJobs` returns per call. The default
+ * keeps an unbounded dashboard query cheap; the cap means a caller-supplied
+ * `limit` can never turn `listJobs` into an unbounded scan of `izi_jobs`,
+ * mirroring why `pruneJobs`/`stageJobs` batch instead of running unbounded.
+ */
+export const DEFAULT_LIST_LIMIT = 100;
+export const MAX_LIST_LIMIT = 1000;
+
+/** Validates and clamps `listJobs`' `limit`, applying `DEFAULT_LIST_LIMIT`. */
+export function resolveListLimit(limit?: number): number {
+  if (limit === undefined) return DEFAULT_LIST_LIMIT;
+  if (!Number.isInteger(limit) || limit <= 0) {
+    throw new Error(`izi-queue: listJobs limit must be a positive integer, got ${limit}`);
+  }
+  return Math.min(limit, MAX_LIST_LIMIT);
+}
+
+/** Validates `listJobs`' `offset`, defaulting to 0. */
+export function resolveListOffset(offset?: number): number {
+  if (offset === undefined) return 0;
+  if (!Number.isInteger(offset) || offset < 0) {
+    throw new Error(`izi-queue: listJobs offset must be a non-negative integer, got ${offset}`);
+  }
+  return offset;
+}
+
+/**
+ * Maps a whitelisted `JobOrderByField` to its column. The whitelist is the
+ * point: `orderBy` can never carry a caller-supplied column name into SQL,
+ * which is the injection class fixed in #18.
+ */
+const JOB_ORDER_BY_COLUMNS: Record<JobOrderByField, string> = {
+  id: 'id',
+  priority: 'priority',
+  scheduledAt: 'scheduled_at',
+  insertedAt: 'inserted_at',
+  attemptedAt: 'attempted_at'
+};
+
+const DEFAULT_ORDER_BY: Required<JobOrderBy> = { field: 'insertedAt', direction: 'desc' };
+
+/**
+ * Builds `listJobs`' `ORDER BY` clause. Every ordering also breaks ties on
+ * `id` in the same direction, so two jobs sharing the primary sort value
+ * (e.g. the same `insertedAt` millisecond) still sort deterministically --
+ * without that, `limit`/`offset` pagination could skip or repeat a row
+ * across pages depending on how the database happened to break the tie.
+ */
+export function orderByClause(orderBy?: JobOrderBy): string {
+  const field = orderBy?.field ?? DEFAULT_ORDER_BY.field;
+  const direction = orderBy?.direction ?? DEFAULT_ORDER_BY.direction;
+
+  if (direction !== 'asc' && direction !== 'desc') {
+    throw new Error(`izi-queue: listJobs orderBy.direction must be 'asc' or 'desc', got ${String(direction)}`);
+  }
+
+  const column = JOB_ORDER_BY_COLUMNS[field];
+  if (!column) {
+    throw new Error(
+      `izi-queue: invalid listJobs orderBy.field "${String(field)}". Must be one of: ${Object.keys(JOB_ORDER_BY_COLUMNS).join(', ')}`
+    );
+  }
+
+  const sqlDirection = direction.toUpperCase();
+  const tiebreak = field === 'id' ? '' : `, id ${sqlDirection}`;
+  return `ORDER BY ${column} ${sqlDirection}${tiebreak}`;
+}
+
+/** Every job state, used to seed `countJobs`' result so every key is present. */
+export const JOB_STATES: JobState[] = [
+  'scheduled',
+  'available',
+  'executing',
+  'retryable',
+  'completed',
+  'discarded',
+  'cancelled'
+];
+
+/**
+ * Builds `countJobs`' result from `SELECT state, COUNT(*) ... GROUP BY state`
+ * rows, seeding every `JobState` at 0 first so a caller never has to guard
+ * against a state with no matching jobs being absent from the result.
+ */
+export function buildStateCounts(rows: { state: string; count: number | string | bigint }[]): JobStateCounts {
+  const counts = Object.fromEntries(JOB_STATES.map(state => [state, 0])) as JobStateCounts;
+  for (const row of rows) {
+    counts[row.state as JobState] = Number(row.count);
+  }
+  return counts;
 }
 
 export function rowToJob(row: Record<string, unknown>): Job {

--- a/src/database/mysql.ts
+++ b/src/database/mysql.ts
@@ -23,8 +23,28 @@ interface Pool {
   getConnection(): Promise<PoolConnection>;
   end(): Promise<void>;
 }
-import type { Job, JobCriteria, JobState, Logger, TransactionHandle, UniqueOptions } from '../types.js';
-import { BaseAdapter, DEFAULT_BATCH_SIZE, DEFAULT_NODE_TTL, SQL, criteriaClause, rowToJob } from './adapter.js';
+import type {
+  Job,
+  JobCriteria,
+  JobListCriteria,
+  JobState,
+  JobStateCounts,
+  Logger,
+  TransactionHandle,
+  UniqueOptions
+} from '../types.js';
+import {
+  BaseAdapter,
+  DEFAULT_BATCH_SIZE,
+  DEFAULT_NODE_TTL,
+  SQL,
+  buildStateCounts,
+  criteriaClause,
+  orderByClause,
+  resolveListLimit,
+  resolveListOffset,
+  rowToJob
+} from './adapter.js';
 import { computeUniqueKey } from '../core/unique.js';
 
 /** Arbitrary but fixed: all izi-queue instances must agree on this value. */
@@ -266,7 +286,7 @@ export class MySQLAdapter extends BaseAdapter {
   }
 
   async cancelJobs(criteria: JobCriteria): Promise<number> {
-    const { clause, params } = criteriaClause(criteria, () => '?');
+    const { clause, params } = criteriaClause(criteria, () => '?', 'mysql');
     const [result] = await this.pool.query<ResultSetHeader>(
       `${SQL.mysql.cancelJobs}${clause}`,
       params
@@ -275,7 +295,7 @@ export class MySQLAdapter extends BaseAdapter {
   }
 
   async retryJobs(criteria: JobCriteria): Promise<number> {
-    const { clause, params } = criteriaClause(criteria, () => '?');
+    const { clause, params } = criteriaClause(criteria, () => '?', 'mysql');
     // Raising max_attempts matters for jobs discarded after exhausting them:
     // without headroom the job is discarded again on its very next fetch.
     const [result] = await this.pool.query<ResultSetHeader>(
@@ -291,6 +311,28 @@ export class MySQLAdapter extends BaseAdapter {
       params
     );
     return result.affectedRows;
+  }
+
+  async listJobs(criteria: JobListCriteria = {}): Promise<Job[]> {
+    const { clause, params } = criteriaClause(criteria, () => '?', 'mysql');
+    const limit = resolveListLimit(criteria.limit);
+    const offset = resolveListOffset(criteria.offset);
+    const order = orderByClause(criteria.orderBy);
+
+    const [rows] = await this.pool.query<RowDataPacket[]>(
+      `SELECT * FROM izi_jobs WHERE 1=1${clause} ${order} LIMIT ? OFFSET ?`,
+      [...params, limit, offset]
+    );
+    return rows.map((row: RowDataPacket) => rowToJob(row as Record<string, unknown>));
+  }
+
+  async countJobs(criteria: JobCriteria = {}): Promise<JobStateCounts> {
+    const { clause, params } = criteriaClause(criteria, () => '?', 'mysql');
+    const [rows] = await this.pool.query<RowDataPacket[]>(
+      `SELECT state, COUNT(*) AS count FROM izi_jobs WHERE 1=1${clause} GROUP BY state`,
+      params
+    );
+    return buildStateCounts(rows as { state: string; count: number }[]);
   }
 
   async rescueStuckJobs(rescueAfter: number, nodeTtl = DEFAULT_NODE_TTL): Promise<number> {

--- a/src/database/postgres.ts
+++ b/src/database/postgres.ts
@@ -1,6 +1,26 @@
 import type { Pool, PoolClient } from 'pg';
-import type { Job, JobCriteria, JobState, Logger, TransactionHandle, UniqueOptions } from '../types.js';
-import { BaseAdapter, DEFAULT_BATCH_SIZE, DEFAULT_NODE_TTL, SQL, criteriaClause, rowToJob } from './adapter.js';
+import type {
+  Job,
+  JobCriteria,
+  JobListCriteria,
+  JobState,
+  JobStateCounts,
+  Logger,
+  TransactionHandle,
+  UniqueOptions
+} from '../types.js';
+import {
+  BaseAdapter,
+  DEFAULT_BATCH_SIZE,
+  DEFAULT_NODE_TTL,
+  SQL,
+  buildStateCounts,
+  criteriaClause,
+  orderByClause,
+  resolveListLimit,
+  resolveListOffset,
+  rowToJob
+} from './adapter.js';
 import { advisoryLockKey, computeUniqueKey } from '../core/unique.js';
 import { telemetry } from '../core/telemetry.js';
 
@@ -265,7 +285,7 @@ export class PostgresAdapter extends BaseAdapter {
   }
 
   async cancelJobs(criteria: JobCriteria): Promise<number> {
-    const { clause, params } = criteriaClause(criteria, i => `$${i}`);
+    const { clause, params } = criteriaClause(criteria, i => `$${i}`, 'postgres');
     const result = await this.pool.query(
       `${SQL.postgres.cancelJobs}${clause}`,
       params
@@ -274,7 +294,7 @@ export class PostgresAdapter extends BaseAdapter {
   }
 
   async retryJobs(criteria: JobCriteria): Promise<number> {
-    const { clause, params } = criteriaClause(criteria, i => `$${i}`);
+    const { clause, params } = criteriaClause(criteria, i => `$${i}`, 'postgres');
     // Raising max_attempts matters for jobs discarded after exhausting them:
     // without headroom the job is discarded again on its very next fetch.
     const result = await this.pool.query(
@@ -290,6 +310,28 @@ export class PostgresAdapter extends BaseAdapter {
       params
     );
     return result.rowCount ?? 0;
+  }
+
+  async listJobs(criteria: JobListCriteria = {}): Promise<Job[]> {
+    const { clause, params } = criteriaClause(criteria, i => `$${i}`, 'postgres');
+    const limit = resolveListLimit(criteria.limit);
+    const offset = resolveListOffset(criteria.offset);
+    const order = orderByClause(criteria.orderBy);
+
+    const result = await this.pool.query(
+      `SELECT * FROM izi_jobs WHERE 1=1${clause} ${order} LIMIT $${params.length + 1} OFFSET $${params.length + 2}`,
+      [...params, limit, offset]
+    );
+    return result.rows.map(rowToJob);
+  }
+
+  async countJobs(criteria: JobCriteria = {}): Promise<JobStateCounts> {
+    const { clause, params } = criteriaClause(criteria, i => `$${i}`, 'postgres');
+    const result = await this.pool.query(
+      `SELECT state, COUNT(*)::int AS count FROM izi_jobs WHERE 1=1${clause} GROUP BY state`,
+      params
+    );
+    return buildStateCounts(result.rows);
   }
 
   async rescueStuckJobs(rescueAfter: number, nodeTtl = DEFAULT_NODE_TTL): Promise<number> {

--- a/src/database/sqlite.ts
+++ b/src/database/sqlite.ts
@@ -1,6 +1,25 @@
 import type { Database } from 'better-sqlite3';
-import type { Job, JobCriteria, JobState, Logger, TransactionHandle, UniqueOptions } from '../types.js';
-import { BaseAdapter, DEFAULT_BATCH_SIZE, DEFAULT_NODE_TTL, criteriaClause, rowToJob } from './adapter.js';
+import type {
+  Job,
+  JobCriteria,
+  JobListCriteria,
+  JobState,
+  JobStateCounts,
+  Logger,
+  TransactionHandle,
+  UniqueOptions
+} from '../types.js';
+import {
+  BaseAdapter,
+  DEFAULT_BATCH_SIZE,
+  DEFAULT_NODE_TTL,
+  buildStateCounts,
+  criteriaClause,
+  orderByClause,
+  resolveListLimit,
+  resolveListOffset,
+  rowToJob
+} from './adapter.js';
 import { computeUniqueKey } from '../core/unique.js';
 import { sqliteMigrations } from './migrations.js';
 
@@ -232,7 +251,7 @@ export class SQLiteAdapter extends BaseAdapter {
   }
 
   async cancelJobs(criteria: JobCriteria): Promise<number> {
-    const { clause, params } = criteriaClause(criteria, () => '?');
+    const { clause, params } = criteriaClause(criteria, () => '?', 'sqlite');
     const stmt = this.db.prepare(`
       UPDATE izi_jobs
       SET state = 'cancelled', cancelled_at = datetime('now')
@@ -242,7 +261,7 @@ export class SQLiteAdapter extends BaseAdapter {
   }
 
   async retryJobs(criteria: JobCriteria): Promise<number> {
-    const { clause, params } = criteriaClause(criteria, () => '?');
+    const { clause, params } = criteriaClause(criteria, () => '?', 'sqlite');
     // Raising max_attempts matters for jobs that were discarded after
     // exhausting them: without headroom the job would be discarded again on
     // its very next fetch.
@@ -256,6 +275,24 @@ export class SQLiteAdapter extends BaseAdapter {
       WHERE state IN ('discarded', 'cancelled')${clause}
     `);
     return stmt.run(...params).changes;
+  }
+
+  async listJobs(criteria: JobListCriteria = {}): Promise<Job[]> {
+    const { clause, params } = criteriaClause(criteria, () => '?', 'sqlite');
+    const limit = resolveListLimit(criteria.limit);
+    const offset = resolveListOffset(criteria.offset);
+    const order = orderByClause(criteria.orderBy);
+
+    const stmt = this.db.prepare(`SELECT * FROM izi_jobs WHERE 1=1${clause} ${order} LIMIT ? OFFSET ?`);
+    const rows = stmt.all(...params, limit, offset) as Record<string, unknown>[];
+    return rows.map(rowToJob);
+  }
+
+  async countJobs(criteria: JobCriteria = {}): Promise<JobStateCounts> {
+    const { clause, params } = criteriaClause(criteria, () => '?', 'sqlite');
+    const stmt = this.db.prepare(`SELECT state, COUNT(*) AS count FROM izi_jobs WHERE 1=1${clause} GROUP BY state`);
+    const rows = stmt.all(...params) as { state: string; count: number }[];
+    return buildStateCounts(rows);
   }
 
   async rescueStuckJobs(rescueAfter: number, nodeTtl = DEFAULT_NODE_TTL): Promise<number> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,12 @@ export {
   createMySQLAdapter
 } from './database/index.js';
 
+export {
+  DEFAULT_LIST_LIMIT,
+  MAX_LIST_LIMIT,
+  JOB_STATES
+} from './database/adapter.js';
+
 // Plugins
 export {
   BasePlugin,
@@ -68,6 +74,11 @@ export type {
   JobState,
   JobError,
   JobInsertOptions,
+  JobCriteria,
+  JobListCriteria,
+  JobOrderBy,
+  JobOrderByField,
+  JobStateCounts,
   UniqueOptions,
   WorkerResult,
   WorkerDefinition,

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,11 +66,51 @@ export interface JobCriteria {
   worker?: string;
   state?: JobState[];
   /**
+   * Match-any: a job matches if it has at least one of these tags. Kept
+   * consistent across all three adapters -- Postgres uses `&&` (array
+   * overlap), MySQL `JSON_OVERLAPS`, SQLite a `json_each` membership check.
+   * Match-all was the alternative; match-any was chosen because the
+   * operational question this answers ("jobs tagged billing or urgent") is
+   * naturally an OR, and it maps onto a single native operator on every
+   * dialect instead of a chain of per-tag containment checks.
+   */
+  tags?: string[];
+  /**
    * Required to act on every job. Without it an empty criteria object is
    * rejected, so a handler forwarding optional filters cannot wipe the queue.
    */
   all?: boolean;
 }
+
+/**
+ * Fields `listJobs` may sort by, whitelisted by name -- `orderBy` can never
+ * carry free-form SQL, which is exactly the injection class fixed in #18.
+ */
+export type JobOrderByField = 'id' | 'priority' | 'scheduledAt' | 'insertedAt' | 'attemptedAt';
+
+export interface JobOrderBy {
+  field: JobOrderByField;
+  /** Defaults to 'desc'. */
+  direction?: 'asc' | 'desc';
+}
+
+export interface JobListCriteria extends JobCriteria {
+  /**
+   * Defaults to `DEFAULT_LIST_LIMIT` (100) and is capped at `MAX_LIST_LIMIT`
+   * (1000) regardless of what is requested -- see `database/adapter.ts`.
+   */
+  limit?: number;
+  offset?: number;
+  /** Defaults to `{ field: 'insertedAt', direction: 'desc' }`. */
+  orderBy?: JobOrderBy;
+}
+
+/**
+ * Job counts grouped by state. Every `JobState` key is always present (zero
+ * when nothing matches), so a caller building a /health response never has to
+ * guard against a missing key.
+ */
+export type JobStateCounts = Record<JobState, number>;
 
 /**
  * A caller-managed transaction handle, passed straight through to the adapter.
@@ -274,6 +314,21 @@ export interface DatabaseAdapter {
   cancelJobs(criteria: JobCriteria): Promise<number>;
   /** Returns discarded or cancelled jobs to the queue. */
   retryJobs?(criteria: JobCriteria): Promise<number>;
+  /**
+   * Lists jobs matching `criteria` so callers stop hand-writing SQL against
+   * `izi_jobs`. Ordered and paginated with a bounded, whitelisted `orderBy`
+   * and a default+max `limit` -- see `DEFAULT_LIST_LIMIT`/`MAX_LIST_LIMIT` in
+   * `database/adapter.ts`. Optional so third-party adapters predating this
+   * method keep compiling; `IziQueue.listJobs` throws a clear error when the
+   * configured adapter does not implement it.
+   */
+  listJobs?(criteria: JobListCriteria): Promise<Job[]>;
+  /**
+   * Counts jobs matching `criteria` (the same filters as `listJobs` minus
+   * pagination/ordering), grouped by state. Optional for the same
+   * backward-compatibility reason as `listJobs`.
+   */
+  countJobs?(criteria: JobCriteria): Promise<JobStateCounts>;
   /**
    * Returns jobs abandoned by dead nodes to the queue (or discards them when
    * their attempts are exhausted). `nodeTtl` is how many seconds a node may go

--- a/tests/adapter.test.ts
+++ b/tests/adapter.test.ts
@@ -1,4 +1,15 @@
-import { runInBatches } from '../src/database/adapter.js';
+import {
+  buildStateCounts,
+  criteriaClause,
+  DEFAULT_LIST_LIMIT,
+  JOB_STATES,
+  MAX_LIST_LIMIT,
+  orderByClause,
+  resolveListLimit,
+  resolveListOffset,
+  runInBatches
+} from '../src/database/adapter.js';
+import type { JobCriteria } from '../src/types.js';
 
 describe('runInBatches', () => {
   it.each([0, -1, NaN, Infinity])(
@@ -61,5 +72,150 @@ describe('runInBatches', () => {
     // after runInBatches had already finished -- proof the loop actually
     // yielded instead of running both batches back-to-back synchronously.
     expect(order).toEqual(['operation', 'event-loop', 'operation']);
+  });
+});
+
+describe('criteriaClause', () => {
+  const numbered = (i: number): string => `$${i}`;
+  const questionMark = (): string => '?';
+
+  it('builds no clause for an empty criteria object', () => {
+    const { clause, params } = criteriaClause({}, numbered, 'postgres');
+    expect(clause).toBe('');
+    expect(params).toEqual([]);
+  });
+
+  it('combines ids/queue/worker/state into one AND-ed clause with sequential placeholders', () => {
+    const criteria: JobCriteria = {
+      ids: [1, 2],
+      queue: 'default',
+      worker: 'W',
+      state: ['available', 'scheduled']
+    };
+    const { clause, params } = criteriaClause(criteria, numbered, 'postgres');
+
+    expect(clause).toBe(' AND id IN ($1,$2) AND queue = $3 AND worker = $4 AND state IN ($5,$6)');
+    expect(params).toEqual([1, 2, 'default', 'W', 'available', 'scheduled']);
+  });
+
+  it('emits the Postgres array-overlap operator for tags, passing the array as a single param', () => {
+    const { clause, params } = criteriaClause({ tags: ['billing', 'urgent'] }, numbered, 'postgres');
+    expect(clause).toBe(' AND tags && $1');
+    expect(params).toEqual([['billing', 'urgent']]);
+  });
+
+  it('emits JSON_OVERLAPS for MySQL, passing the tags as a JSON string param', () => {
+    const { clause, params } = criteriaClause({ tags: ['billing', 'urgent'] }, questionMark, 'mysql');
+    expect(clause).toBe(' AND JSON_OVERLAPS(tags, ?)');
+    expect(params).toEqual([JSON.stringify(['billing', 'urgent'])]);
+  });
+
+  it('emits a json_each membership EXISTS for SQLite, one placeholder per tag', () => {
+    const { clause, params } = criteriaClause({ tags: ['billing', 'urgent'] }, questionMark, 'sqlite');
+    expect(clause).toBe(' AND EXISTS (SELECT 1 FROM json_each(tags) WHERE json_each.value IN (?,?))');
+    expect(params).toEqual(['billing', 'urgent']);
+  });
+
+  it('ignores an empty tags array rather than emitting a clause that matches nothing', () => {
+    const { clause, params } = criteriaClause({ tags: [] }, numbered, 'postgres');
+    expect(clause).toBe('');
+    expect(params).toEqual([]);
+  });
+
+  it('keeps placeholder numbering correct on Postgres when tags follow other criteria', () => {
+    const { clause, params } = criteriaClause(
+      { queue: 'default', tags: ['a'] },
+      numbered,
+      'postgres'
+    );
+    expect(clause).toBe(' AND queue = $1 AND tags && $2');
+    expect(params).toEqual(['default', ['a']]);
+  });
+});
+
+describe('orderByClause', () => {
+  it('defaults to insertedAt desc, tie-broken by id desc', () => {
+    expect(orderByClause(undefined)).toBe('ORDER BY inserted_at DESC, id DESC');
+  });
+
+  it('maps every whitelisted field to its column and appends an id tiebreaker', () => {
+    expect(orderByClause({ field: 'priority', direction: 'asc' })).toBe(
+      'ORDER BY priority ASC, id ASC'
+    );
+    expect(orderByClause({ field: 'scheduledAt', direction: 'desc' })).toBe(
+      'ORDER BY scheduled_at DESC, id DESC'
+    );
+    expect(orderByClause({ field: 'attemptedAt', direction: 'asc' })).toBe(
+      'ORDER BY attempted_at ASC, id ASC'
+    );
+  });
+
+  it('does not double up the tiebreaker when the field is already id', () => {
+    expect(orderByClause({ field: 'id', direction: 'asc' })).toBe('ORDER BY id ASC');
+  });
+
+  it('rejects a field outside the whitelist -- the point being no caller-supplied SQL can ever reach the query', () => {
+    expect(() =>
+      orderByClause({ field: 'args' as never, direction: 'asc' })
+    ).toThrow(/invalid listJobs orderBy\.field/);
+  });
+
+  it('rejects a direction outside asc/desc even if TypeScript is bypassed', () => {
+    expect(() =>
+      orderByClause({ field: 'id', direction: 'ASC; DROP TABLE izi_jobs;--' as never })
+    ).toThrow(/direction must be 'asc' or 'desc'/);
+  });
+});
+
+describe('resolveListLimit', () => {
+  it(`defaults to ${DEFAULT_LIST_LIMIT}`, () => {
+    expect(resolveListLimit(undefined)).toBe(DEFAULT_LIST_LIMIT);
+  });
+
+  it('passes through a limit within range', () => {
+    expect(resolveListLimit(10)).toBe(10);
+  });
+
+  it(`caps a limit above ${MAX_LIST_LIMIT} rather than allowing an unbounded scan`, () => {
+    expect(resolveListLimit(1_000_000)).toBe(MAX_LIST_LIMIT);
+  });
+
+  it.each([0, -1, 1.5, NaN, Infinity])('rejects a non-positive or non-integer limit (%p)', (limit) => {
+    expect(() => resolveListLimit(limit)).toThrow(/positive integer/);
+  });
+});
+
+describe('resolveListOffset', () => {
+  it('defaults to 0', () => {
+    expect(resolveListOffset(undefined)).toBe(0);
+  });
+
+  it('passes through a non-negative offset', () => {
+    expect(resolveListOffset(50)).toBe(50);
+  });
+
+  it.each([-1, 1.5, NaN])('rejects a negative or non-integer offset (%p)', (offset) => {
+    expect(() => resolveListOffset(offset)).toThrow(/non-negative integer/);
+  });
+});
+
+describe('buildStateCounts', () => {
+  it('seeds every job state at 0, even with no rows', () => {
+    const counts = buildStateCounts([]);
+    expect(Object.keys(counts).sort()).toEqual([...JOB_STATES].sort());
+    expect(Object.values(counts).every((n) => n === 0)).toBe(true);
+  });
+
+  it('fills in counts from grouped rows, coercing string/bigint counts to number', () => {
+    const counts = buildStateCounts([
+      { state: 'available', count: '3' },
+      { state: 'discarded', count: 2 },
+      { state: 'completed', count: 5n }
+    ]);
+
+    expect(counts.available).toBe(3);
+    expect(counts.discarded).toBe(2);
+    expect(counts.completed).toBe(5);
+    expect(counts.executing).toBe(0);
   });
 });

--- a/tests/izi-queue.test.ts
+++ b/tests/izi-queue.test.ts
@@ -9,7 +9,24 @@ import {
   clearWorkers
 } from '../src/index.js';
 import { waitForEvent } from './helpers/wait.js';
-import type { Job, Logger } from '../src/types.js';
+import type { DatabaseAdapter, Job, Logger } from '../src/types.js';
+
+/**
+ * A class instance's methods live on its prototype, not as own properties, so
+ * `{ ...adapter, listJobs: undefined }` would silently drop every other
+ * method too. This proxy keeps every method delegating to `adapter` except
+ * the one under test, which is what actually simulates "an adapter that
+ * doesn't implement this optional method".
+ */
+function adapterWithout(adapter: DatabaseAdapter, methodName: 'listJobs' | 'countJobs'): DatabaseAdapter {
+  return new Proxy(adapter, {
+    get(target, prop, receiver) {
+      if (prop === methodName) return undefined;
+      const value = Reflect.get(target, prop, receiver);
+      return typeof value === 'function' ? value.bind(target) : value;
+    }
+  });
+}
 
 describe('IziQueue Class', () => {
   let db: Database.Database;
@@ -386,6 +403,78 @@ describe('IziQueue Class', () => {
     });
   });
 
+  describe('listJobs', () => {
+    it('delegates to the adapter and returns matching jobs', async () => {
+      const queue = createIziQueue({
+        database: adapter,
+        queues: { default: 5 }
+      });
+
+      await queue.insert('WorkerA', { args: {} });
+      await queue.insert('WorkerB', { args: {} });
+
+      const jobs = await queue.listJobs({ worker: 'WorkerA' });
+
+      expect(jobs).toHaveLength(1);
+      expect(jobs[0].worker).toBe('WorkerA');
+
+      await queue.shutdown();
+    });
+
+    it('does not require scoping -- unlike cancelJobs/retryJobs it is read-only', async () => {
+      const queue = createIziQueue({
+        database: adapter,
+        queues: { default: 5 }
+      });
+
+      await queue.insert('Worker', { args: {} });
+
+      await expect(queue.listJobs({})).resolves.toHaveLength(1);
+
+      await queue.shutdown();
+    });
+
+    it('throws a clear error when the adapter does not implement listJobs', async () => {
+      const queue = createIziQueue({
+        database: adapterWithout(adapter, 'listJobs'),
+        queues: { default: 5 }
+      });
+
+      await expect(queue.listJobs({})).rejects.toThrow(/does not support listJobs/);
+
+      await queue.shutdown();
+    });
+  });
+
+  describe('countJobs', () => {
+    it('delegates to the adapter and returns counts grouped by state', async () => {
+      const queue = createIziQueue({
+        database: adapter,
+        queues: { default: 5 }
+      });
+
+      await queue.insert('Worker', { args: {} });
+
+      const counts = await queue.countJobs({});
+
+      expect(counts.available).toBe(1);
+      expect(counts.completed).toBe(0);
+
+      await queue.shutdown();
+    });
+
+    it('throws a clear error when the adapter does not implement countJobs', async () => {
+      const queue = createIziQueue({
+        database: adapterWithout(adapter, 'countJobs'),
+        queues: { default: 5 }
+      });
+
+      await expect(queue.countJobs({})).rejects.toThrow(/does not support countJobs/);
+
+      await queue.shutdown();
+    });
+  });
+
   describe('cancelJobs', () => {
     it('should cancel jobs by worker name', async () => {
       const queue = createIziQueue({
@@ -433,6 +522,33 @@ describe('IziQueue Class', () => {
       const cancelled = await queue.cancelJobs({ state: ['available'] });
 
       expect(cancelled).toBe(1);
+
+      await queue.shutdown();
+    });
+
+    it('accepts tags alone as a valid scope, without needing { all: true }', async () => {
+      const queue = createIziQueue({
+        database: adapter,
+        queues: { default: 5 }
+      });
+
+      await queue.insert('Worker', { args: {}, tags: ['billing'] });
+      await queue.insert('Worker', { args: {}, tags: ['other'] });
+
+      const cancelled = await queue.cancelJobs({ tags: ['billing'] });
+
+      expect(cancelled).toBe(1);
+
+      await queue.shutdown();
+    });
+
+    it('still rejects a completely unscoped call', async () => {
+      const queue = createIziQueue({
+        database: adapter,
+        queues: { default: 5 }
+      });
+
+      await expect(queue.cancelJobs({})).rejects.toThrow(/requires at least one criterion/);
 
       await queue.shutdown();
     });

--- a/tests/mysql-adapter.test.ts
+++ b/tests/mysql-adapter.test.ts
@@ -266,6 +266,114 @@ describeMySQL('MySQLAdapter', () => {
     expect(await countByState()).toEqual({ available: 1 });
   });
 
+  describe('listJobs', () => {
+    it('filters by queue, worker, state, and ids', async () => {
+      const a = await adapter.insertJob(jobData({ queue: 'default', worker: 'WorkerA', state: 'available' }));
+      await adapter.insertJob(jobData({ queue: 'other', worker: 'WorkerB', state: 'completed' }));
+
+      expect(await adapter.listJobs({ queue: 'default' })).toHaveLength(1);
+      expect(await adapter.listJobs({ worker: 'WorkerA' })).toHaveLength(1);
+      expect(await adapter.listJobs({ state: ['completed'] })).toHaveLength(1);
+      expect((await adapter.listJobs({ ids: [a.id] }))[0].id).toBe(a.id);
+    });
+
+    it('matches tags with JSON_OVERLAPS (match-any) semantics, identical to Postgres', async () => {
+      await adapter.insertJob(jobData({ tags: ['billing'] }));
+      await adapter.insertJob(jobData({ tags: ['urgent'] }));
+      await adapter.insertJob(jobData({ tags: ['other'] }));
+      await adapter.insertJob(jobData({ tags: [] }));
+
+      const jobs = await adapter.listJobs({ tags: ['billing', 'urgent'] });
+
+      expect(jobs).toHaveLength(2);
+      expect(jobs.map((j) => j.tags).sort()).toEqual([['billing'], ['urgent']]);
+    });
+
+    it('combines multiple criteria with AND', async () => {
+      await adapter.insertJob(jobData({ queue: 'default', worker: 'WorkerA' }));
+      await adapter.insertJob(jobData({ queue: 'default', worker: 'WorkerB' }));
+
+      expect(await adapter.listJobs({ queue: 'default', worker: 'WorkerA' })).toHaveLength(1);
+    });
+
+    it('orders by insertedAt desc by default', async () => {
+      const first = await adapter.insertJob(jobData({ args: { order: 1 } }));
+      await pool.query('UPDATE izi_jobs SET inserted_at = NOW(6) - INTERVAL 1 MINUTE WHERE id = ?', [first.id]);
+      const second = await adapter.insertJob(jobData({ args: { order: 2 } }));
+
+      const jobs = await adapter.listJobs({});
+
+      expect(jobs.map((j) => j.id)).toEqual([second.id, first.id]);
+    });
+
+    it('orders by a whitelisted field and direction', async () => {
+      await adapter.insertJob(jobData({ priority: 5 }));
+      await adapter.insertJob(jobData({ priority: 1 }));
+      await adapter.insertJob(jobData({ priority: 3 }));
+
+      const jobs = await adapter.listJobs({ orderBy: { field: 'priority', direction: 'asc' } });
+
+      expect(jobs.map((j) => j.priority)).toEqual([1, 3, 5]);
+    });
+
+    it('rejects an orderBy field outside the whitelist', async () => {
+      await expect(
+        adapter.listJobs({ orderBy: { field: 'args' as never, direction: 'asc' } })
+      ).rejects.toThrow(/invalid listJobs orderBy\.field/);
+    });
+
+    it('applies limit and offset for pagination', async () => {
+      for (let i = 0; i < 5; i++) {
+        await adapter.insertJob(jobData({ priority: i }));
+      }
+
+      const page1 = await adapter.listJobs({ limit: 2, offset: 0, orderBy: { field: 'priority', direction: 'asc' } });
+      const page2 = await adapter.listJobs({ limit: 2, offset: 2, orderBy: { field: 'priority', direction: 'asc' } });
+
+      expect(page1.map((j) => j.priority)).toEqual([0, 1]);
+      expect(page2.map((j) => j.priority)).toEqual([2, 3]);
+    });
+
+    it('returns full Job objects shaped like getJob', async () => {
+      const inserted = await adapter.insertJob(jobData({ args: { a: 1 }, meta: { b: 2 } }));
+
+      const [job] = await adapter.listJobs({ ids: [inserted.id] });
+      const viaGetJob = await adapter.getJob(inserted.id);
+
+      expect(job).toEqual(viaGetJob);
+    });
+  });
+
+  describe('countJobs', () => {
+    it('groups counts by state, with every state present even at zero', async () => {
+      await adapter.insertJob(jobData({ state: 'available' }));
+      await adapter.insertJob(jobData({ state: 'available' }));
+      await adapter.insertJob(jobData({ state: 'completed' }));
+
+      const counts = await adapter.countJobs({});
+
+      expect(counts).toEqual({
+        scheduled: 0,
+        available: 2,
+        executing: 0,
+        retryable: 0,
+        completed: 1,
+        discarded: 0,
+        cancelled: 0
+      });
+    });
+
+    it('applies criteria before grouping, including tags with the same match-any semantics as listJobs', async () => {
+      await adapter.insertJob(jobData({ queue: 'default', tags: ['billing'], state: 'available' }));
+      await adapter.insertJob(jobData({ queue: 'default', tags: ['other'], state: 'available' }));
+      await adapter.insertJob(jobData({ queue: 'other', tags: ['billing'], state: 'available' }));
+
+      const counts = await adapter.countJobs({ queue: 'default', tags: ['billing'] });
+
+      expect(counts.available).toBe(1);
+    });
+  });
+
   describe('unique jobs', () => {
     const unique = { period: 60 };
 

--- a/tests/postgres-adapter.test.ts
+++ b/tests/postgres-adapter.test.ts
@@ -211,6 +211,114 @@ describePostgres('PostgresAdapter', () => {
     expect(after.rows).toHaveLength(0);
   });
 
+  describe('listJobs', () => {
+    it('filters by queue, worker, state, and ids', async () => {
+      const a = await adapter.insertJob(jobData({ queue: 'default', worker: 'WorkerA', state: 'available' }));
+      await adapter.insertJob(jobData({ queue: 'other', worker: 'WorkerB', state: 'completed' }));
+
+      expect(await adapter.listJobs({ queue: 'default' })).toHaveLength(1);
+      expect(await adapter.listJobs({ worker: 'WorkerA' })).toHaveLength(1);
+      expect(await adapter.listJobs({ state: ['completed'] })).toHaveLength(1);
+      expect((await adapter.listJobs({ ids: [a.id] }))[0].id).toBe(a.id);
+    });
+
+    it('matches tags with array-overlap (match-any) semantics', async () => {
+      await adapter.insertJob(jobData({ tags: ['billing'] }));
+      await adapter.insertJob(jobData({ tags: ['urgent'] }));
+      await adapter.insertJob(jobData({ tags: ['other'] }));
+      await adapter.insertJob(jobData({ tags: [] }));
+
+      const jobs = await adapter.listJobs({ tags: ['billing', 'urgent'] });
+
+      expect(jobs).toHaveLength(2);
+      expect(jobs.map((j) => j.tags).sort()).toEqual([['billing'], ['urgent']]);
+    });
+
+    it('combines multiple criteria with AND', async () => {
+      await adapter.insertJob(jobData({ queue: 'default', worker: 'WorkerA' }));
+      await adapter.insertJob(jobData({ queue: 'default', worker: 'WorkerB' }));
+
+      expect(await adapter.listJobs({ queue: 'default', worker: 'WorkerA' })).toHaveLength(1);
+    });
+
+    it('orders by insertedAt desc by default', async () => {
+      const first = await adapter.insertJob(jobData({ args: { order: 1 } }));
+      await pool.query(`UPDATE izi_jobs SET inserted_at = NOW() - INTERVAL '1 minute' WHERE id = $1`, [first.id]);
+      const second = await adapter.insertJob(jobData({ args: { order: 2 } }));
+
+      const jobs = await adapter.listJobs({});
+
+      expect(jobs.map((j) => j.id)).toEqual([second.id, first.id]);
+    });
+
+    it('orders by a whitelisted field and direction', async () => {
+      await adapter.insertJob(jobData({ priority: 5 }));
+      await adapter.insertJob(jobData({ priority: 1 }));
+      await adapter.insertJob(jobData({ priority: 3 }));
+
+      const jobs = await adapter.listJobs({ orderBy: { field: 'priority', direction: 'asc' } });
+
+      expect(jobs.map((j) => j.priority)).toEqual([1, 3, 5]);
+    });
+
+    it('rejects an orderBy field outside the whitelist', async () => {
+      await expect(
+        adapter.listJobs({ orderBy: { field: 'args' as never, direction: 'asc' } })
+      ).rejects.toThrow(/invalid listJobs orderBy\.field/);
+    });
+
+    it('applies limit and offset for pagination', async () => {
+      for (let i = 0; i < 5; i++) {
+        await adapter.insertJob(jobData({ priority: i }));
+      }
+
+      const page1 = await adapter.listJobs({ limit: 2, offset: 0, orderBy: { field: 'priority', direction: 'asc' } });
+      const page2 = await adapter.listJobs({ limit: 2, offset: 2, orderBy: { field: 'priority', direction: 'asc' } });
+
+      expect(page1.map((j) => j.priority)).toEqual([0, 1]);
+      expect(page2.map((j) => j.priority)).toEqual([2, 3]);
+    });
+
+    it('returns full Job objects shaped like getJob', async () => {
+      const inserted = await adapter.insertJob(jobData({ args: { a: 1 }, meta: { b: 2 } }));
+
+      const [job] = await adapter.listJobs({ ids: [inserted.id] });
+      const viaGetJob = await adapter.getJob(inserted.id);
+
+      expect(job).toEqual(viaGetJob);
+    });
+  });
+
+  describe('countJobs', () => {
+    it('groups counts by state, with every state present even at zero', async () => {
+      await adapter.insertJob(jobData({ state: 'available' }));
+      await adapter.insertJob(jobData({ state: 'available' }));
+      await adapter.insertJob(jobData({ state: 'completed' }));
+
+      const counts = await adapter.countJobs({});
+
+      expect(counts).toEqual({
+        scheduled: 0,
+        available: 2,
+        executing: 0,
+        retryable: 0,
+        completed: 1,
+        discarded: 0,
+        cancelled: 0
+      });
+    });
+
+    it('applies criteria before grouping, including tags with the same match-any semantics as listJobs', async () => {
+      await adapter.insertJob(jobData({ queue: 'default', tags: ['billing'], state: 'available' }));
+      await adapter.insertJob(jobData({ queue: 'default', tags: ['other'], state: 'available' }));
+      await adapter.insertJob(jobData({ queue: 'other', tags: ['billing'], state: 'available' }));
+
+      const counts = await adapter.countJobs({ queue: 'default', tags: ['billing'] });
+
+      expect(counts.available).toBe(1);
+    });
+  });
+
   describe('unique jobs', () => {
     const unique = { period: 60 };
 

--- a/tests/sqlite-adapter.test.ts
+++ b/tests/sqlite-adapter.test.ts
@@ -508,6 +508,178 @@ describe('SQLiteAdapter', () => {
     });
   });
 
+  describe('listJobs', () => {
+    it('filters by queue', async () => {
+      await adapter.insertJob(createJobData({ queue: 'default' }));
+      await adapter.insertJob(createJobData({ queue: 'other' }));
+
+      const jobs = await adapter.listJobs({ queue: 'default' });
+
+      expect(jobs).toHaveLength(1);
+      expect(jobs[0].queue).toBe('default');
+    });
+
+    it('filters by worker', async () => {
+      await adapter.insertJob(createJobData({ worker: 'WorkerA' }));
+      await adapter.insertJob(createJobData({ worker: 'WorkerB' }));
+
+      const jobs = await adapter.listJobs({ worker: 'WorkerA' });
+
+      expect(jobs).toHaveLength(1);
+      expect(jobs[0].worker).toBe('WorkerA');
+    });
+
+    it('filters by state', async () => {
+      await adapter.insertJob(createJobData({ state: 'available' }));
+      await adapter.insertJob(createJobData({ state: 'completed' }));
+
+      const jobs = await adapter.listJobs({ state: ['completed'] });
+
+      expect(jobs).toHaveLength(1);
+      expect(jobs[0].state).toBe('completed');
+    });
+
+    it('filters by ids', async () => {
+      const a = await adapter.insertJob(createJobData());
+      await adapter.insertJob(createJobData());
+
+      const jobs = await adapter.listJobs({ ids: [a.id] });
+
+      expect(jobs).toHaveLength(1);
+      expect(jobs[0].id).toBe(a.id);
+    });
+
+    it('filters by tags, match-any semantics', async () => {
+      await adapter.insertJob(createJobData({ tags: ['billing'] }));
+      await adapter.insertJob(createJobData({ tags: ['urgent'] }));
+      await adapter.insertJob(createJobData({ tags: ['other'] }));
+      await adapter.insertJob(createJobData({ tags: [] }));
+
+      const jobs = await adapter.listJobs({ tags: ['billing', 'urgent'] });
+
+      expect(jobs).toHaveLength(2);
+      expect(jobs.map((j) => j.tags).sort()).toEqual([['billing'], ['urgent']]);
+    });
+
+    it('combines multiple criteria with AND', async () => {
+      await adapter.insertJob(createJobData({ queue: 'default', worker: 'WorkerA', state: 'available' }));
+      await adapter.insertJob(createJobData({ queue: 'default', worker: 'WorkerB', state: 'available' }));
+      await adapter.insertJob(createJobData({ queue: 'other', worker: 'WorkerA', state: 'available' }));
+
+      const jobs = await adapter.listJobs({ queue: 'default', worker: 'WorkerA' });
+
+      expect(jobs).toHaveLength(1);
+    });
+
+    it('returns every job when given no criteria', async () => {
+      await adapter.insertJob(createJobData());
+      await adapter.insertJob(createJobData());
+
+      const jobs = await adapter.listJobs({});
+
+      expect(jobs).toHaveLength(2);
+    });
+
+    it('orders by insertedAt desc by default', async () => {
+      const first = await adapter.insertJob(createJobData({ args: { order: 1 } }));
+      db.prepare(`UPDATE izi_jobs SET inserted_at = datetime('now', '-1 minute') WHERE id = ?`).run(first.id);
+      const second = await adapter.insertJob(createJobData({ args: { order: 2 } }));
+
+      const jobs = await adapter.listJobs({});
+
+      expect(jobs.map((j) => j.id)).toEqual([second.id, first.id]);
+    });
+
+    it('orders by a whitelisted field and direction', async () => {
+      await adapter.insertJob(createJobData({ priority: 5 }));
+      await adapter.insertJob(createJobData({ priority: 1 }));
+      await adapter.insertJob(createJobData({ priority: 3 }));
+
+      const jobs = await adapter.listJobs({ orderBy: { field: 'priority', direction: 'asc' } });
+
+      expect(jobs.map((j) => j.priority)).toEqual([1, 3, 5]);
+    });
+
+    it('rejects an orderBy field outside the whitelist', async () => {
+      await expect(
+        adapter.listJobs({ orderBy: { field: 'args' as never, direction: 'asc' } })
+      ).rejects.toThrow(/invalid listJobs orderBy\.field/);
+    });
+
+    it('applies limit and offset for pagination', async () => {
+      for (let i = 0; i < 5; i++) {
+        await adapter.insertJob(createJobData({ priority: i }));
+      }
+
+      const page1 = await adapter.listJobs({ limit: 2, offset: 0, orderBy: { field: 'priority', direction: 'asc' } });
+      const page2 = await adapter.listJobs({ limit: 2, offset: 2, orderBy: { field: 'priority', direction: 'asc' } });
+
+      expect(page1.map((j) => j.priority)).toEqual([0, 1]);
+      expect(page2.map((j) => j.priority)).toEqual([2, 3]);
+    });
+
+    it('defaults to a bounded limit rather than returning the whole table', async () => {
+      for (let i = 0; i < 5; i++) {
+        await adapter.insertJob(createJobData());
+      }
+
+      const jobs = await adapter.listJobs({});
+
+      expect(jobs).toHaveLength(5); // under the default cap, so all come back
+    });
+
+    it('rejects a non-positive limit', async () => {
+      await expect(adapter.listJobs({ limit: 0 })).rejects.toThrow(/positive integer/);
+    });
+
+    it('returns full Job objects shaped like getJob', async () => {
+      const inserted = await adapter.insertJob(createJobData({ args: { a: 1 }, meta: { b: 2 } }));
+
+      const [job] = await adapter.listJobs({ ids: [inserted.id] });
+      const viaGetJob = await adapter.getJob(inserted.id);
+
+      expect(job).toEqual(viaGetJob);
+    });
+  });
+
+  describe('countJobs', () => {
+    it('groups counts by state, with every state present even at zero', async () => {
+      await adapter.insertJob(createJobData({ state: 'available' }));
+      await adapter.insertJob(createJobData({ state: 'available' }));
+      await adapter.insertJob(createJobData({ state: 'completed' }));
+
+      const counts = await adapter.countJobs({});
+
+      expect(counts).toEqual({
+        scheduled: 0,
+        available: 2,
+        executing: 0,
+        retryable: 0,
+        completed: 1,
+        discarded: 0,
+        cancelled: 0
+      });
+    });
+
+    it('applies criteria before grouping', async () => {
+      await adapter.insertJob(createJobData({ queue: 'default', state: 'available' }));
+      await adapter.insertJob(createJobData({ queue: 'other', state: 'available' }));
+
+      const counts = await adapter.countJobs({ queue: 'default' });
+
+      expect(counts.available).toBe(1);
+    });
+
+    it('filters by tags with the same match-any semantics as listJobs', async () => {
+      await adapter.insertJob(createJobData({ tags: ['billing'], state: 'available' }));
+      await adapter.insertJob(createJobData({ tags: ['other'], state: 'available' }));
+
+      const counts = await adapter.countJobs({ tags: ['billing'] });
+
+      expect(counts.available).toBe(1);
+    });
+  });
+
   describe('rescueStuckJobs', () => {
     it('should rescue jobs stuck in executing state', async () => {
       db.prepare(`


### PR DESCRIPTION
Closes #31.

## Problem

The only read API was `getJob(id)` — no list, filter, count, or search. Consumers hand-wrote SQL against `izi_jobs`, coupling to a schema the library may change; `getQueueStatus()` only reports in-memory runtime state.

## Change

- **`listJobs(criteria)`** — explicit filter surface: `ids`, `queue`, `worker`, `state[]`, `tags[]`, `limit` (default 100, hard cap 1000), `offset`, `orderBy`. `orderBy.field` is a TS union **and** runtime-whitelisted through a fixed column map — no caller string ever reaches SQL (the #18 injection class cannot reoccur). Every ordering tie-breaks on `id` so `limit`/`offset` pagination is stable.
- **`countJobs(criteria)`** — counts **grouped by state**, every `JobState` key always present at ≥0: one call gives a /health endpoint backlog depth and discard volume without guarding missing keys.
- **Tags** (match-any, documented): Postgres `&&` array overlap, MySQL `JSON_OVERLAPS` (8.0.17+), SQLite `EXISTS` over `json_each`. `tags` joined the shared `JobCriteria`, so `cancelJobs`/`retryJobs` gained it for free and `{ tags }` alone now satisfies their scoping guard.
- Both adapter methods are **optional** on `DatabaseAdapter` (same precedent as `retryJobs?`) — third-party adapters keep compiling; `IziQueue` throws a clear unsupported error otherwise. Results reuse `rowToJob`, so shapes match `getJob`.
- Incidental fix: `JobCriteria` was used by public methods but never exported — now exported.

## Testing

Unit tests for the helpers (orderBy whitelist rejection, limit/offset validation, dialect tag SQL) plus per-adapter tests for each criterion, combined criteria, tag semantics, ordering, pagination, and count shape. **448/448 tests, 21/21 suites against real Postgres 16 and MySQL 8** — including the `JSON_OVERLAPS` and `&&` paths that SQLite can't exercise. Build and lint clean.

Note: match-**any** tag semantics was a judgment call (the natural operational question, one native operator per dialect) — flagged in case match-all was intended.