### PR TITLE
feat(core): interrupt executing jobs on cancel via AbortSignal

### DIFF
--- a/src/core/isolation/executor.ts
+++ b/src/core/isolation/executor.ts
@@ -56,10 +56,12 @@ export async function executeIsolated(
   return threadPool!.execute(serializedJob, options, timeout);
 }
 
-export async function terminateIsolatedJob(jobId: number): Promise<void> {
-  if (threadPool) {
-    await threadPool.terminate(jobId);
-  }
+export async function terminateIsolatedJob(
+  jobId: number,
+  result?: WorkerResult
+): Promise<boolean> {
+  if (!threadPool) return false;
+  return threadPool.terminate(jobId, result);
 }
 
 export async function shutdownIsolation(): Promise<void> {

--- a/src/core/isolation/thread-pool.ts
+++ b/src/core/isolation/thread-pool.ts
@@ -411,27 +411,44 @@ export class ThreadPool {
     });
   }
 
-  async terminate(jobId: number): Promise<void> {
+  /**
+   * Pre-emptively kills the worker thread running `jobId`, if one is found.
+   * `result` is what the job's pending `execute()` promise resolves with --
+   * defaults to the same "terminated" error it always has, for callers (the
+   * shutdown grace-period timeout) unrelated to cancellation.
+   *
+   * Node gives worker threads no graceful pre-kill notice: `terminate()` is
+   * a hard stop, so there is no way to let an isolated job's own code react
+   * before its thread dies. That is why isolated cancellation is pre-emptive
+   * rather than cooperative like the in-process `AbortSignal` path.
+   *
+   * Returns whether a thread running that job was found and killed. Frees
+   * the slot immediately (`handOffToWaiter`) rather than waiting on the
+   * worker's `exit` event, so a waiter queued behind a saturated pool is not
+   * left stuck for however long the OS takes to actually tear the thread
+   * down.
+   */
+  async terminate(
+    jobId: number,
+    result: WorkerResult = { status: 'error', error: new Error('Job terminated') }
+  ): Promise<boolean> {
     for (const pooled of this.workers) {
       if (pooled.currentJobId === jobId) {
         const pending = this.pendingJobs.get(jobId);
         if (pending) {
           clearTimeout(pending.timeoutId);
           this.pendingJobs.delete(jobId);
-          pending.resolve({
-            status: 'error',
-            error: new Error('Job terminated')
-          });
+          pending.resolve(result);
         }
 
+        pooled.currentJobId = null;
         this.terminateWorker(pooled);
-        const index = this.workers.indexOf(pooled);
-        if (index !== -1) {
-          this.workers.splice(index, 1);
-        }
-        return;
+        this.removeWorker(pooled);
+        this.handOffToWaiter();
+        return true;
       }
     }
+    return false;
   }
 
   async shutdown(): Promise<void> {

--- a/src/core/izi-queue.ts
+++ b/src/core/izi-queue.ts
@@ -341,12 +341,28 @@ export class IziQueue {
 
   async cancelJobs(criteria: JobCriteria): Promise<number> {
     assertScoped(criteria, 'cancelJobs');
-    return this.config.database.cancelJobs(criteria);
+    const count = await this.config.database.cancelJobs(criteria);
+
+    // Best-effort local interruption, only possible when the caller told us
+    // which ids were targeted. `cancelJobs` reports how many rows it
+    // changed, not which ones, so a queue/worker/state-scoped call has no
+    // way to know which jobs to interrupt without an extra query -- out of
+    // scope here. Every queue on this node is asked regardless of which one
+    // (if any) actually has the job; each is a no-op unless it does.
+    if (count > 0 && criteria.ids && criteria.ids.length > 0) {
+      await Promise.all(
+        criteria.ids.flatMap(id =>
+          Array.from(this.queues.values()).map(queue => queue.cancelRunning(id))
+        )
+      );
+    }
+
+    return count;
   }
 
   /** Cancels one job. Returns false if it was already in a terminal state. */
   async cancelJob(id: number): Promise<boolean> {
-    return (await this.config.database.cancelJobs({ ids: [id] })) > 0;
+    return (await this.cancelJobs({ ids: [id] })) > 0;
   }
 
   /**

--- a/src/core/queue.ts
+++ b/src/core/queue.ts
@@ -12,6 +12,7 @@ export class Queue {
   private state: QueueState = 'stopped';
   private running: Map<number, Promise<void>> = new Map();
   private isolatedJobs: Set<number> = new Set();
+  private abortControllers: Map<number, AbortController> = new Map();
   private pollTimer?: ReturnType<typeof setTimeout>;
   private polling = false;
   private pollInFlight?: Promise<void>;
@@ -155,6 +156,46 @@ export class Queue {
   }
 
   /**
+   * Interrupts `jobId` if it is currently executing on this node: fires its
+   * `AbortSignal` for an in-process worker, or pre-emptively kills its
+   * worker thread for an isolated one. Returns whether the job was actually
+   * found running here.
+   *
+   * This is necessarily local. A job executing on another node cannot be
+   * reached from here -- there is no signal to fire and no thread to kill --
+   * so `IziQueue.cancelJob` calls this on every queue on every node's own
+   * `IziQueue` instance, and each one is a no-op except on the node that
+   * actually has the job. The database row is cancelled regardless (by the
+   * caller, before this runs); the #35 state-transition guard is what stops
+   * the other node's worker from resurrecting it once it finishes on its own.
+   * Building a cross-node "stop now" signal (e.g. over LISTEN/NOTIFY) is
+   * future work, not attempted here.
+   */
+  async cancelRunning(jobId: number): Promise<boolean> {
+    const controller = this.abortControllers.get(jobId);
+    if (controller) {
+      if (!controller.signal.aborted) {
+        controller.abort(new Error('Job cancelled'));
+      }
+      return true;
+    }
+
+    if (this.isolatedJobs.has(jobId)) {
+      // Only kills a thread already running the job. If the pool is
+      // saturated and the job is still queued waiting for one (added to
+      // `isolatedJobs` before that wait begins), `ThreadPool.terminate` finds
+      // nothing to kill and this is a no-op -- the job runs once a thread
+      // frees up, same as before this feature, and the state-transition
+      // guard still keeps it from resurrecting the cancelled row. Reaching
+      // into the pool's wait queue to pre-empt a not-yet-started job would
+      // need `Waiter` to carry a jobId; left as a follow-up.
+      return terminateIsolatedJob(jobId, { status: 'cancel', reason: 'Job cancelled' });
+    }
+
+    return false;
+  }
+
+  /**
    * Schedules the next poll, replacing any pending one.
    *
    * Always clearing first is what keeps a single poll loop per queue: `dispatch()`
@@ -241,12 +282,16 @@ export class Queue {
     const worker = getWorker(job.worker);
     const isIsolated = worker?.isolation?.isolated === true;
 
+    let controller: AbortController | undefined;
     if (isIsolated) {
       this.isolatedJobs.add(job.id);
+    } else {
+      controller = new AbortController();
+      this.abortControllers.set(job.id, controller);
     }
 
     try {
-      const result = await executeWorker(job);
+      const result = await executeWorker(job, controller);
       const duration = Date.now() - startTime;
 
       switch (result.status) {
@@ -274,6 +319,7 @@ export class Queue {
       );
     } finally {
       this.isolatedJobs.delete(job.id);
+      this.abortControllers.delete(job.id);
     }
   }
 

--- a/src/core/worker.ts
+++ b/src/core/worker.ts
@@ -1,4 +1,4 @@
-import type { Job, WorkerDefinition, WorkerResult, IsolationConfig } from '../types.js';
+import type { Job, WorkerDefinition, WorkerResult, IsolationConfig, WorkerContext } from '../types.js';
 import { calculateBackoff } from './job.js';
 import {
   executeIsolated,
@@ -32,7 +32,16 @@ export function clearWorkers(): void {
   workerRegistry.clear();
 }
 
-export async function executeWorker(job: Job): Promise<WorkerResult> {
+/**
+ * Runs `job`'s worker. `controller` -- owned by the caller, typically
+ * `Queue`, so it can be reached and aborted from outside this call while it
+ * is still in flight -- is only meaningful for in-process workers: isolated
+ * (worker-thread) jobs cannot receive a live signal across the thread
+ * boundary, so `executeIsolated` never sees it. When no controller is
+ * supplied one is created locally, which keeps this function usable on its
+ * own (as the tests for it do) without a caller that tracks cancellation.
+ */
+export async function executeWorker(job: Job, controller?: AbortController): Promise<WorkerResult> {
   const worker = getWorker(job.worker);
 
   if (!worker) {
@@ -48,12 +57,22 @@ export async function executeWorker(job: Job): Promise<WorkerResult> {
     return executeIsolated(job, worker.isolation, timeout);
   }
 
+  const abortController = controller ?? new AbortController();
+  const context: WorkerContext = { signal: abortController.signal };
+
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
   try {
     const result = await Promise.race([
-      worker.perform(job),
+      worker.perform(job, context),
       new Promise<never>((_, reject) => {
-        timeoutId = setTimeout(() => reject(new Error(`Job timed out after ${timeout}ms`)), timeout);
+        timeoutId = setTimeout(() => {
+          // A worker's own timeout is a reason to stop doing work too, the
+          // same as an operator cancelling it -- a well-behaved worker that
+          // threads `signal` through stops here instead of continuing on
+          // borrowed time for a result nothing will use.
+          abortController.abort(new Error(`Job timed out after ${timeout}ms`));
+          reject(new Error(`Job timed out after ${timeout}ms`));
+        }, timeout);
       })
     ]);
 
@@ -86,7 +105,7 @@ export function getBackoffDelay(job: Job): number {
 
 export function defineWorker<T = Record<string, unknown>>(
   name: string,
-  perform: (job: Job<T>) => Promise<WorkerResult | void>,
+  perform: (job: Job<T>, context: WorkerContext) => Promise<WorkerResult | void>,
   options: Partial<Omit<WorkerDefinition<T>, 'name' | 'perform'>> = {}
 ): WorkerDefinition<T> {
   return {
@@ -111,8 +130,20 @@ export async function shutdownIsolatedWorkers(): Promise<void> {
   await shutdownIsolation();
 }
 
-export async function terminateIsolatedJob(jobId: number): Promise<void> {
-  await terminateIsolated(jobId);
+/**
+ * Pre-emptively kills the worker thread running `jobId`, if any. `result` is
+ * what the job's still-pending `executeWorker` call resolves with -- callers
+ * cancelling a job pass `{ status: 'cancel', ... }` so it settles the same
+ * way an in-process worker's own cancel result would; `Queue.stop()`'s
+ * grace-period timeout leaves it at the default (an error), which is
+ * unrelated to cancellation and keeps its existing retry/discard behavior.
+ * Returns whether a thread running that job was actually found and killed.
+ */
+export async function terminateIsolatedJob(
+  jobId: number,
+  result?: WorkerResult
+): Promise<boolean> {
+  return terminateIsolated(jobId, result);
 }
 
 export { getIsolationStats };

--- a/src/types.ts
+++ b/src/types.ts
@@ -150,6 +150,22 @@ export type WorkerResult =
   | { status: 'snooze'; seconds: number };
 
 /**
+ * Passed as the second argument to `perform`. `signal` fires when the job is
+ * cancelled while executing on this node (via `cancelJob`/`cancelJobs`) or
+ * when the job's own timeout elapses. A worker that threads `signal` through
+ * to abortable operations (e.g. `fetch(url, { signal })`) stops promptly
+ * instead of running to completion for a result that will be discarded.
+ *
+ * Only available to in-process workers. Isolated (worker-thread) jobs cannot
+ * receive a live signal -- there is no way to hand a `AbortSignal` across the
+ * thread boundary and have it still fire -- so cancellation there is always
+ * pre-emptive thread termination instead; see `IsolatedWorkerOptions`.
+ */
+export interface WorkerContext {
+  signal: AbortSignal;
+}
+
+/**
  * How a single job resolved when executed inline by `IziQueue.drain()`.
  * `failure` is an error with retry budget left (the job becomes `retryable`);
  * `discarded` covers both an error with no attempts left and an unregistered
@@ -175,7 +191,11 @@ export interface IsolatedWorkerOptions {
 
 export interface WorkerDefinition<T = Record<string, unknown>> {
   name: string;
-  perform: (job: Job<T>) => Promise<WorkerResult | void>;
+  /**
+   * `context` is optional to accept: a worker that ignores it is unaffected
+   * by cooperative cancellation but otherwise keeps working unchanged.
+   */
+  perform: (job: Job<T>, context: WorkerContext) => Promise<WorkerResult | void>;
   queue?: string;
   maxAttempts?: number;
   priority?: number;

--- a/tests/isolation/integration.test.ts
+++ b/tests/isolation/integration.test.ts
@@ -9,6 +9,7 @@ import {
 } from '../../src/index.js';
 import { createSQLiteAdapter } from '../../src/database/sqlite.js';
 import type { Job } from '../../src/types.js';
+import { waitFor } from '../helpers/wait.js';
 
 const TEST_WORKER_PATH = join(__dirname, '../fixtures/test-isolated-worker.js');
 
@@ -348,5 +349,71 @@ describe('Isolated Workers Integration', () => {
 
     // Shutdown should complete despite running job (grace period will force termination)
     await expect(queue.shutdown()).resolves.not.toThrow();
+  });
+
+  describe('cancelling a running isolated job', () => {
+    it('pre-emptively terminates the thread, settles the job cancelled, and leaves the pool healthy', async () => {
+      const longWorker = defineWorker('LongIsolatedWorker', async () => WorkerResults.ok(), {
+        queue: 'default',
+        isolation: {
+          isolated: true,
+          workerPath: TEST_WORKER_PATH
+        }
+      });
+
+      const queue = createIziQueue({
+        database: db,
+        queues: { default: 5 },
+        pollInterval: 50,
+        isolation: { maxThreads: 2 }
+      });
+
+      queue.register(longWorker);
+      await queue.start();
+
+      const job = await queue.insert(longWorker, {
+        args: { action: 'delay', delay: 10000 }
+      });
+
+      await waitFor(
+        async () => (await queue.getJob(job.id))?.state === 'executing',
+        { describe: 'the isolated job to start executing' }
+      );
+      await waitFor(
+        () => (queue.getIsolationStats()?.busyWorkers ?? 0) > 0,
+        { describe: 'the worker thread to pick up the job' }
+      );
+
+      const cancelled = await queue.cancelJob(job.id);
+      expect(cancelled).toBe(true);
+
+      // Pre-emptive: the job must settle promptly, not after the 10s delay
+      // it asked for.
+      const final = await waitFor(
+        async () => {
+          const current = await queue.getJob(job.id);
+          return current?.state === 'cancelled' ? current : null;
+        },
+        { describe: 'the terminated isolated job to settle cancelled', timeout: 3000 }
+      );
+
+      expect(final?.state).toBe('cancelled');
+      // Terminating it must not have burned a retry or recorded a failure --
+      // it settles on the direct DB cancellation, not on the thread's result.
+      expect(final?.errors).toHaveLength(0);
+
+      // The pool must stay healthy: no leaked slot, capacity for a fresh job.
+      const healthy = await queue.insert(longWorker, { args: { action: 'success' } });
+      const healthyFinal = await waitFor(
+        async () => {
+          const current = await queue.getJob(healthy.id);
+          return current?.state === 'completed' ? current : null;
+        },
+        { describe: 'a fresh isolated job to complete after termination' }
+      );
+      expect(healthyFinal?.state).toBe('completed');
+
+      await queue.shutdown();
+    }, 20000);
   });
 });

--- a/tests/isolation/thread-pool.test.ts
+++ b/tests/isolation/thread-pool.test.ts
@@ -185,7 +185,8 @@ describe('ThreadPool', () => {
       await new Promise(resolve => setTimeout(resolve, 50));
 
       // Terminate the job
-      await pool.terminate(job.id);
+      const found = await pool.terminate(job.id);
+      expect(found).toBe(true);
 
       const result = await executePromise;
 
@@ -193,6 +194,73 @@ describe('ThreadPool', () => {
       if (result.status === 'error') {
         expect((result.error as Error).message).toContain('terminated');
       }
+    });
+
+    it('returns false and does nothing when the job is not running', async () => {
+      pool = new ThreadPool({ maxThreads: 2 });
+
+      const found = await pool.terminate(999999);
+
+      expect(found).toBe(false);
+    });
+
+    it('resolves the pending execution with a caller-supplied result', async () => {
+      pool = new ThreadPool({ maxThreads: 2 });
+
+      const job = createSerializableJob({
+        args: { action: 'delay', delay: 10000 }
+      });
+      const options = createIsolationOptions();
+
+      const executePromise = pool.execute(job, options, 30000);
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      await pool.terminate(job.id, { status: 'cancel', reason: 'Job cancelled' });
+
+      const result = await executePromise;
+      expect(result).toEqual({ status: 'cancel', reason: 'Job cancelled' });
+    });
+
+    it('frees the slot immediately so a queued job is handed a thread without waiting on the exit event', async () => {
+      pool = new ThreadPool({ maxThreads: 1 });
+      const options = createIsolationOptions();
+
+      const blocker = createSerializableJob({ id: 1, args: { action: 'delay', delay: 10000 } });
+      const blocked = pool.execute(blocker, options, 30000);
+
+      await waitFor(() => pool.getStats().busyWorkers === 1, { describe: 'the pool to be busy' });
+
+      const queuedJob = createSerializableJob({ id: 2, args: { action: 'success' } });
+      const queued = pool.execute(queuedJob, options, 10000);
+
+      // Give the second execute() call a moment to actually enqueue as a
+      // waiter before terminating the first job.
+      await new Promise(resolve => setTimeout(resolve, 20));
+
+      await pool.terminate(blocker.id);
+
+      const queuedResult = await queued;
+      expect(queuedResult.status).toBe('ok');
+
+      await blocked;
+    });
+
+    it('keeps the pool healthy after termination: a replacement thread serves the next job', async () => {
+      pool = new ThreadPool({ maxThreads: 1 });
+      const options = createIsolationOptions();
+
+      const job = createSerializableJob({ args: { action: 'delay', delay: 10000 } });
+      const executePromise = pool.execute(job, options, 30000);
+      await waitFor(() => pool.getStats().busyWorkers === 1, { describe: 'the pool to be busy' });
+
+      await pool.terminate(job.id);
+      await executePromise;
+
+      const nextJob = createSerializableJob({ args: { action: 'success' } });
+      const nextResult = await pool.execute(nextJob, options, 5000);
+
+      expect(nextResult.status).toBe('ok');
+      expect(pool.getStats().totalWorkers).toBe(1);
     });
   });
 

--- a/tests/lifecycle.test.ts
+++ b/tests/lifecycle.test.ts
@@ -182,6 +182,106 @@ describe('job lifecycle', () => {
     });
   });
 
+  describe('cooperative cancellation', () => {
+    it('aborts a running worker promptly on cancelJob and settles it cancelled with no error bookkeeping', async () => {
+      let sawAbort = false;
+      let performCalls = 0;
+
+      const queue = queueWith(
+        defineWorker('abortable', async (_job, { signal }) => {
+          performCalls++;
+          return new Promise<never>((_, reject) => {
+            signal.addEventListener('abort', () => {
+              sawAbort = true;
+              const abortError = new Error('The operation was aborted');
+              abortError.name = 'AbortError';
+              reject(abortError);
+            });
+          });
+        })
+      );
+
+      await queue.start();
+      const job = await queue.insert('abortable', { args: {} });
+
+      await waitFor(
+        async () => (await queue.getJob(job.id))?.state === 'executing',
+        { describe: 'the job to start executing' }
+      );
+
+      const cancelled = await queue.cancelJob(job.id);
+      expect(cancelled).toBe(true);
+
+      const final = await waitFor(
+        async () => {
+          if (!sawAbort) return null;
+          const current = await queue.getJob(job.id);
+          return current?.state === 'cancelled' ? current : null;
+        },
+        { describe: 'the aborted job to settle cancelled' }
+      );
+      await queue.stop();
+
+      expect(sawAbort).toBe(true);
+      expect(performCalls).toBe(1);
+      expect(final?.state).toBe('cancelled');
+      // The AbortError thrown by the worker must not be recorded as a job
+      // failure: no error entry, and the attempt fetch already consumed is
+      // the only one spent.
+      expect(final?.errors).toHaveLength(0);
+      expect(final?.attempt).toBe(1);
+    }, 20000);
+
+    it('still lets a legacy single-argument worker be cancelled the old way (no signal, guard-based)', async () => {
+      let started = false;
+
+      const queue = queueWith(
+        // No context parameter at all -- unaffected by cancellation, keeps
+        // running to completion; the #35 guard is what stops it resurrecting
+        // the job.
+        defineWorker('legacy-slow', async () => {
+          started = true;
+          await new Promise(resolve => setTimeout(resolve, 300));
+          return WorkerResults.ok();
+        })
+      );
+
+      await queue.start();
+      const job = await queue.insert('legacy-slow', { args: {} });
+
+      await waitFor(() => started, { describe: 'the legacy worker to start' });
+
+      const cancelled = await queue.cancelJob(job.id);
+      expect(cancelled).toBe(true);
+      expect((await queue.getJob(job.id))?.state).toBe('cancelled');
+
+      const final = await waitFor(
+        async () => {
+          const current = await queue.getJob(job.id);
+          return current?.state === 'cancelled' ? current : null;
+        },
+        { describe: 'the job to remain cancelled once the legacy worker finishes' }
+      );
+      await queue.stop();
+
+      expect(final?.state).toBe('cancelled');
+    }, 20000);
+
+    it('cancelling a non-executing job behaves as before', async () => {
+      const queue = queueWith(defineWorker('noop', async () => WorkerResults.ok()));
+      await queue.start();
+
+      const job = await queue.insert('noop', { args: {} });
+      // Don't let the poller pick it up.
+      await queue.stop();
+
+      const cancelled = await queue.cancelJob(job.id);
+
+      expect(cancelled).toBe(true);
+      expect((await queue.getJob(job.id))?.state).toBe('cancelled');
+    }, 20000);
+  });
+
   describe('cancel and retry', () => {
     it('cancels a single job by id', async () => {
       const queue = queueWith();

--- a/tests/queue.test.ts
+++ b/tests/queue.test.ts
@@ -473,6 +473,51 @@ describe('Queue Class', () => {
     });
   });
 
+  describe('cancelRunning', () => {
+    it('returns false for a job that is not executing on this queue', async () => {
+      const config = createQueueConfig({ name: 'default', pollInterval: 50 });
+      const queue = new Queue(config, adapter, 'node-1');
+
+      expect(await queue.cancelRunning(999999)).toBe(false);
+    });
+
+    it('fires the AbortSignal of an in-process job currently executing', async () => {
+      let seenSignal: AbortSignal | undefined;
+      let sawAbort = false;
+
+      registerWorker({
+        name: 'AbortableQueueWorker',
+        perform: async (_job, { signal }) => {
+          seenSignal = signal;
+          return new Promise<never>((_, reject) => {
+            signal.addEventListener('abort', () => {
+              sawAbort = true;
+              reject(new Error('AbortError'));
+            });
+          });
+        }
+      });
+
+      const config = createQueueConfig({ name: 'default', pollInterval: 50 });
+      const queue = new Queue(config, adapter, 'node-1');
+      const inserted = await adapter.insertJob(createJobData({ worker: 'AbortableQueueWorker' }));
+
+      await queue.start();
+      await waitFor(
+        async () => (await adapter.getJob(inserted.id))?.state === 'executing',
+        { describe: 'the job to start executing' }
+      );
+
+      const found = await queue.cancelRunning(inserted.id);
+      expect(found).toBe(true);
+
+      await waitFor(() => sawAbort, { describe: 'the worker to observe the abort' });
+      expect(seenSignal?.aborted).toBe(true);
+
+      await queue.stop();
+    });
+  });
+
   describe('concurrency', () => {
     it('should respect concurrency limit', async () => {
       let concurrent = 0;

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -241,6 +241,93 @@ describe('Worker Module', () => {
         jest.useRealTimers();
       }
     });
+
+    it('still calls a legacy single-argument worker unchanged', async () => {
+      // No second parameter declared at all -- the pre-#30 signature. Passing
+      // the context object anyway must not affect it: JS silently ignores an
+      // extra call argument.
+      registerWorker({
+        name: 'LegacyWorker',
+        perform: async (job) => WorkerResults.ok({ args: job.args })
+      });
+
+      const job = createMockJob({ worker: 'LegacyWorker', args: { n: 1 } });
+      const result = await executeWorker(job);
+
+      expect(result.status).toBe('ok');
+      if (result.status === 'ok') {
+        expect(result.value).toEqual({ args: { n: 1 } });
+      }
+    });
+
+    it('passes an AbortSignal as the second argument to perform', async () => {
+      let seenSignal: AbortSignal | undefined;
+      registerWorker({
+        name: 'SignalWorker',
+        perform: async (_job, { signal }) => {
+          seenSignal = signal;
+          return WorkerResults.ok();
+        }
+      });
+
+      await executeWorker(createMockJob({ worker: 'SignalWorker' }));
+
+      expect(seenSignal).toBeInstanceOf(AbortSignal);
+      expect(seenSignal?.aborted).toBe(false);
+    });
+
+    it('fires the signal of an externally supplied AbortController', async () => {
+      const controller = new AbortController();
+      let seenAborted: boolean | undefined;
+
+      registerWorker({
+        name: 'AbortAwareWorker',
+        perform: async (_job, { signal }) => {
+          return new Promise<never>((_, reject) => {
+            signal.addEventListener('abort', () => {
+              seenAborted = signal.aborted;
+              reject(new Error('AbortError'));
+            });
+          });
+        }
+      });
+
+      const job = createMockJob({ worker: 'AbortAwareWorker' });
+      const pending = executeWorker(job, controller);
+      controller.abort(new Error('cancelled'));
+
+      const result = await pending;
+
+      expect(seenAborted).toBe(true);
+      expect(result.status).toBe('error');
+    });
+
+    it('aborts the signal when the job times out, so a cooperative worker stops too', async () => {
+      let sawAbort = false;
+      registerWorker({
+        name: 'TimeoutAwareWorker',
+        perform: async (_job, { signal }) => {
+          return new Promise<never>((_, reject) => {
+            const guard = setTimeout(() => reject(new Error('should not reach this')), 5000);
+            signal.addEventListener('abort', () => {
+              sawAbort = true;
+              clearTimeout(guard);
+              reject(new Error('AbortError'));
+            });
+          });
+        },
+        timeout: 30
+      });
+
+      const job = createMockJob({ worker: 'TimeoutAwareWorker' });
+      const result = await executeWorker(job);
+
+      expect(sawAbort).toBe(true);
+      expect(result.status).toBe('error');
+      if (result.status === 'error') {
+        expect((result.error as Error).message).toContain('timed out');
+      }
+    });
   });
 
   describe('WorkerResults', () => {


### PR DESCRIPTION
Closes #30 (the remaining part — `cancelJob`/`retryJob`/criteria guards landed in #54).

## Problem

Cancelling an executing job only flipped the DB row — the worker ran to completion and its result was discarded. For long/expensive jobs that's real wasted work. Oban kills the executing process.

## Change

- **In-process workers**: `perform` gains an optional second context argument — `perform(job, { signal })` — whose `AbortSignal` fires on local cancellation **and** on the job's own timeout, so cooperative workers (`fetch(url, { signal })`, abortable DB clients) stop promptly. Existing 1-arg workers keep working unchanged (TS accepts fewer parameters).
- **Isolated workers**: pre-emptive `ThreadPool.terminate(jobId, result)` — settles the pending execution as `cancel` (not an attempt-burning error), resets the slot, and hands off to queued waiters immediately instead of waiting on the async `exit` event. `Queue.stop()`'s unrelated grace-period termination keeps its existing error semantics.
- **No new settle-as-cancelled path**: the row is cancelled *before* interruption fires, so whatever the interrupted worker returns is refused by the #35 DB-side transition guard — zero error entries, no attempt bookkeeping (asserted in tests).
- **Documented boundaries**: interruption is local to the executing node (no cross-node pub/sub built — the transition guard covers remote executions); bulk `cancelJobs` interrupts locally only for `ids`-scoped criteria; an isolated job still *queued* for a thread is not pre-empted (waiter carries no jobId — documented follow-up), it just runs and gets refused as before.

## Testing

TDD across worker/queue/lifecycle/thread-pool/isolation suites, all condition-based waits (no sleeps): cooperative abort settles cancelled with clean bookkeeping, legacy 1-arg workers unaffected, isolated termination leaves a healthy pool and unblocks waiters, timeout aborts the signal. 340 passed / 0 failed (SQLite — nothing here is dialect-specific; no SQL changed). Build and lint clean.