### PR TITLE
feat(db): atomic bulk insertAll

### DIFF
--- a/src/core/izi-queue.ts
+++ b/src/core/izi-queue.ts
@@ -1,4 +1,5 @@
 import type {
+  BulkJobInsert,
   DatabaseAdapter,
   DrainResult,
   IziQueueConfig,
@@ -335,7 +336,181 @@ export class IziQueue {
     worker: string | WorkerDefinition<T>,
     jobs: JobInsertOptions<T>[]
   ): Promise<Job<T>[]> {
-    return Promise.all(jobs.map(options => this.insert(worker, options)));
+    const results = await this.insertAllWithResult(worker, jobs);
+    return results.map(result => result.job);
+  }
+
+  /**
+   * Bulk-inserts every job in `jobs` in one transaction and as few round
+   * trips as the database's parameter limits allow (chunked only to stay
+   * under them), modeled on `Oban.insert_all/2`. A failure partway through
+   * rolls back the whole batch rather than leaving it half-applied -- unlike
+   * calling `insert` once per job, which is what this used to do.
+   *
+   * Jobs sharing a unique key within the same call are deduplicated before
+   * anything reaches the database: only the first occurrence is a candidate
+   * for insertion. Every later occurrence, and every job that conflicts with
+   * a pre-existing row, comes back the way a single conflicting `insert`
+   * does -- `conflict: true` and the job that already exists (or that already
+   * won the batch) -- rather than inserting a duplicate.
+   *
+   * At most one wake-up notification is sent per distinct queue represented
+   * in the batch, regardless of how many jobs landed in it.
+   *
+   * Each entry may carry its own `tx`, the same as a single `insert`, but
+   * since the whole batch commits or rolls back together there can only be
+   * one transaction: every entry that sets `tx` must set the *same* handle,
+   * or the call is rejected.
+   */
+  async insertAllWithResult<T = Record<string, unknown>>(
+    worker: string | WorkerDefinition<T>,
+    jobs: JobInsertOptions<T>[]
+  ): Promise<InsertResult<T>[]> {
+    if (jobs.length === 0) return [];
+
+    const tx = this.resolveBatchTx(jobs);
+
+    const workerName = typeof worker === 'string' ? worker : worker.name;
+    const workerDef = getWorker(workerName);
+
+    const jobDatas = jobs.map(options =>
+      createJob(workerName, {
+        ...options,
+        queue: options.queue ?? workerDef?.queue ?? 'default',
+        maxAttempts: options.maxAttempts ?? workerDef?.maxAttempts ?? 20,
+        priority: options.priority ?? workerDef?.priority ?? 0
+      })
+    );
+
+    // Collapse in-batch duplicates: entries sharing a unique key resolve to
+    // whichever occurrence came first. Everything after it is skipped here
+    // and treated exactly like a conflict with a pre-existing row once the
+    // first occurrence's outcome is known.
+    const primaryOf: number[] = jobDatas.map((_, i) => i);
+    const seenKeys = new Map<string, number>();
+    const bulkEntries: Array<BulkJobInsert & { index: number }> = [];
+
+    jobDatas.forEach((data, i) => {
+      const unique = jobs[i].unique;
+      if (!unique) {
+        bulkEntries.push({ index: i, job: data as Omit<Job, 'id' | 'insertedAt'> });
+        return;
+      }
+
+      const uniqueKey = computeUniqueKey(data, unique);
+      const seenAt = seenKeys.get(uniqueKey);
+      if (seenAt !== undefined) {
+        primaryOf[i] = seenAt;
+        return;
+      }
+
+      seenKeys.set(uniqueKey, i);
+      bulkEntries.push({
+        index: i,
+        job: { ...data, uniqueKey } as Omit<Job, 'id' | 'insertedAt'>,
+        unique
+      });
+    });
+
+    const inserted = this.config.database.insertJobs
+      ? await this.config.database.insertJobs(
+          bulkEntries.map(({ job, unique }) => ({ job, unique })),
+          tx
+        )
+      : await this.insertJobsUnsafely(bulkEntries, tx);
+
+    const byIndex = new Map<number, { job: Job; conflict: boolean }>();
+    bulkEntries.forEach((entry, i) => byIndex.set(entry.index, inserted[i]));
+
+    const results: InsertResult<T>[] = jobDatas.map((_, i) => {
+      const direct = byIndex.get(i);
+      if (direct) {
+        return { job: direct.job as Job<T>, conflict: direct.conflict };
+      }
+
+      // In-batch duplicate: always resolves to its primary's job, and is
+      // always reported as a conflict -- it did not create a new row.
+      const primary = byIndex.get(primaryOf[i])!;
+      return { job: primary.job as Job<T>, conflict: true };
+    });
+
+    for (const result of results) {
+      if (result.conflict) {
+        telemetry.emit('job:unique_conflict', { job: result.job as Job, queue: result.job.queue });
+      }
+    }
+
+    const queuesToWake = new Set(results.filter(r => !r.conflict).map(r => r.job.queue));
+    for (const queue of queuesToWake) {
+      await this.wake(queue, tx);
+    }
+
+    return results;
+  }
+
+  /**
+   * Every entry in an `insertAll` batch shares one transaction, since the
+   * batch commits or rolls back as a unit. An entry that sets `tx` must set
+   * the same handle as every other entry that does; mixing handles, or
+   * setting one only on some entries, is rejected rather than silently
+   * picking one and ignoring the rest.
+   */
+  private resolveBatchTx<T>(jobs: JobInsertOptions<T>[]): TransactionHandle | undefined {
+    let tx: TransactionHandle | undefined;
+    let entriesWithTx = 0;
+
+    for (const options of jobs) {
+      if (options.tx === undefined) continue;
+
+      if (entriesWithTx === 0) {
+        tx = options.tx;
+      } else if (options.tx !== tx) {
+        throw new Error(
+          'izi-queue: insertAll requires every entry to share the same transaction handle ' +
+            '(or none at all), since the whole batch commits or rolls back together.'
+        );
+      }
+      entriesWithTx++;
+    }
+
+    // An entry without tx in a batch that has one would silently ride along
+    // in the caller's transaction -- and vanish with its rollback -- despite
+    // the caller never attaching it. All-or-none keeps that explicit.
+    if (entriesWithTx > 0 && entriesWithTx !== jobs.length) {
+      throw new Error(
+        'izi-queue: insertAll requires every entry to share the same transaction handle ' +
+          '(or none at all), since the whole batch commits or rolls back together.'
+      );
+    }
+
+    return tx;
+  }
+
+  /**
+   * Fallback for adapters predating `insertJobs`. Each row is a separate
+   * round trip and the batch is not atomic -- a failure partway through
+   * leaves earlier rows committed. This is exactly `insertAll`'s pre-#32
+   * behavior, kept only so a third-party adapter that has not added bulk
+   * support yet still works.
+   */
+  private async insertJobsUnsafely(
+    entries: Array<BulkJobInsert & { index: number }>,
+    tx?: TransactionHandle
+  ): Promise<{ job: Job; conflict: boolean }[]> {
+    const results: { job: Job; conflict: boolean }[] = [];
+
+    for (const entry of entries) {
+      if (entry.unique) {
+        const result = this.config.database.insertUnique
+          ? await this.config.database.insertUnique(entry.job, entry.unique, tx)
+          : await this.insertUniqueUnsafely(entry.job, entry.unique, tx);
+        results.push(result);
+      } else {
+        results.push({ job: await this.config.database.insertJob(entry.job, tx), conflict: false });
+      }
+    }
+
+    return results;
   }
 
   async getJob(id: number): Promise<Job | null> {

--- a/src/database/adapter.ts
+++ b/src/database/adapter.ts
@@ -1,11 +1,13 @@
 import type {
+  BulkJobInsert,
   DatabaseAdapter,
   Job,
   JobOrderBy,
   JobOrderByField,
   JobState,
   JobStateCounts,
-  Logger
+  Logger,
+  UniqueOptions
 } from '../types.js';
 import { DEFAULT_UNIQUE_PERIOD, DEFAULT_UNIQUE_STATES } from '../core/unique.js';
 import { consoleLogger } from '../core/logger.js';
@@ -58,6 +60,66 @@ export async function runInBatches(
     // to run between batches instead of monopolizing it.
     await new Promise<void>(resolve => setImmediate(resolve));
   }
+}
+
+/**
+ * Column count of a single `izi_jobs` insert row: state, queue, worker, args,
+ * meta, tags, errors, attempt, max_attempts, priority, scheduled_at,
+ * unique_key. `insertJobs` sizes its chunks off this so a single multi-row
+ * INSERT statement cannot exceed a database's bind-parameter limit.
+ */
+export const INSERT_JOB_COLUMNS = 12;
+
+/**
+ * How many rows of `columns` columns each fit under `paramLimit` bind
+ * parameters, rounded down so the chunk never reaches the limit.
+ */
+export function maxRowsPerStatement(paramLimit: number, columns: number = INSERT_JOB_COLUMNS): number {
+  return Math.max(1, Math.floor(paramLimit / columns));
+}
+
+export function chunkArray<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}
+
+/**
+ * A run of consecutive `insertJobs` entries that share how they must be
+ * inserted: a `plain` run is anything without `unique`, safe to fold into one
+ * multi-row INSERT (or several, chunked); a `unique` run is always a single
+ * entry, since each one needs its own check-then-insert against the database.
+ *
+ * Grouping into runs -- rather than partitioning the whole batch into "all
+ * plain" and "all unique" up front -- preserves the caller's ordering without
+ * giving up multi-row batching for the (typically dominant) plain jobs: two
+ * plain entries stay in the same INSERT as long as nothing unique-only sits
+ * between them in the input.
+ */
+export type BulkRun =
+  | { kind: 'plain'; jobs: Omit<Job, 'id' | 'insertedAt'>[] }
+  | { kind: 'unique'; job: Omit<Job, 'id' | 'insertedAt'>; unique: UniqueOptions };
+
+export function groupBulkRuns(entries: BulkJobInsert[]): BulkRun[] {
+  const runs: BulkRun[] = [];
+
+  for (const entry of entries) {
+    if (entry.unique) {
+      runs.push({ kind: 'unique', job: entry.job, unique: entry.unique });
+      continue;
+    }
+
+    const last = runs[runs.length - 1];
+    if (last?.kind === 'plain') {
+      last.jobs.push(entry.job);
+    } else {
+      runs.push({ kind: 'plain', jobs: [entry.job] });
+    }
+  }
+
+  return runs;
 }
 
 export const SQL = {

--- a/src/database/mysql.ts
+++ b/src/database/mysql.ts
@@ -24,6 +24,7 @@ interface Pool {
   end(): Promise<void>;
 }
 import type {
+  BulkJobInsert,
   Job,
   JobCriteria,
   JobListCriteria,
@@ -37,9 +38,13 @@ import {
   BaseAdapter,
   DEFAULT_BATCH_SIZE,
   DEFAULT_NODE_TTL,
+  INSERT_JOB_COLUMNS,
   SQL,
   buildStateCounts,
+  chunkArray,
   criteriaClause,
+  groupBulkRuns,
+  maxRowsPerStatement,
   orderByClause,
   resolveListLimit,
   resolveListOffset,
@@ -49,6 +54,19 @@ import { computeUniqueKey } from '../core/unique.js';
 
 /** Arbitrary but fixed: all izi-queue instances must agree on this value. */
 const MIGRATION_LOCK_NAME = 'izi_queue_migrations';
+
+/**
+ * mysql2's `.query()` (used throughout this adapter, unlike `.execute()`)
+ * interpolates values into the SQL text client-side rather than binding them
+ * through a server-side prepared statement, so there is no protocol-level
+ * parameter cap here the way there is for PostgreSQL. The same 65535 ceiling
+ * is reused anyway, as a predictable, defensive chunk size against
+ * `max_allowed_packet` and so a future move to `.execute()` would not
+ * silently regress this: floor(65535 / 12 columns) = 5461 rows per statement.
+ */
+const MYSQL_MAX_BIND_PARAMS = 65535;
+export const INSERT_JOBS_CHUNK_SIZE = maxRowsPerStatement(MYSQL_MAX_BIND_PARAMS);
+
 import { mysqlMigrations } from './migrations.js';
 
 export class MySQLAdapter extends BaseAdapter {
@@ -440,6 +458,192 @@ export class MySQLAdapter extends BaseAdapter {
       throw error;
     } finally {
       await connection.query('SELECT RELEASE_LOCK(?)', [lockName]).catch(() => {});
+      connection.release();
+    }
+  }
+
+  /**
+   * One multi-row `INSERT ... VALUES (...), (...), ...` with no `RETURNING`,
+   * followed by recovering the inserted rows by id range.
+   *
+   * This is safe because of how InnoDB allocates AUTO_INCREMENT values for a
+   * "simple insert" -- an `INSERT ... VALUES` statement (no `INSERT ...
+   * SELECT`, no `ON DUPLICATE KEY UPDATE`, no trigger side effects) whose row
+   * count is known before any value is generated:
+   *
+   *   - Because the number of ids needed (`batch.length`) is known up front,
+   *     InnoDB reserves one contiguous block for the whole statement in a
+   *     single allocation, rather than one id at a time.
+   *   - `result.insertId` is the value assigned to the *first* row of that
+   *     block (mysql2's documented behavior, matching `LAST_INSERT_ID()`
+   *     semantics for a multi-row insert).
+   *   - Row *i* of the VALUES list gets `insertId + i`, in order. This holds
+   *     under every `innodb_autoinc_lock_mode`: modes 0/1 (traditional /
+   *     consecutive) hold the table-level auto-increment lock for the whole
+   *     statement, so nothing else can interleave; mode 2 (interleaved) only
+   *     lets *other statements* interleave their own blocks with this one --
+   *     it cannot fragment a single simple insert's own block, because that
+   *     statement already knows exactly how many values it needs and
+   *     reserves them together up front. (Interleaving only produces gaps
+   *     *between* statements/sessions, which is irrelevant here since we only
+   *     rely on our own statement's block being contiguous.)
+   *
+   * So `[insertId, insertId + affectedRows - 1]` is exactly this chunk's
+   * rows, and ordering by id recovers the original VALUES order. The
+   * `rows.length` check below is a hard guard against this reasoning ever
+   * being silently wrong for a future MySQL version or statement shape.
+   */
+  private async insertPlainChunk(
+    executor: Pool | PoolConnection,
+    batch: Omit<Job, 'id' | 'insertedAt'>[]
+  ): Promise<Job[]> {
+    const rowPlaceholder = `(${Array(INSERT_JOB_COLUMNS).fill('?').join(', ')})`;
+    const params: unknown[] = [];
+
+    for (const job of batch) {
+      params.push(
+        job.state,
+        job.queue,
+        job.worker,
+        JSON.stringify(job.args),
+        JSON.stringify(job.meta),
+        JSON.stringify(job.tags),
+        JSON.stringify(job.errors),
+        job.attempt,
+        job.maxAttempts,
+        job.priority,
+        job.scheduledAt,
+        job.uniqueKey ?? null
+      );
+    }
+
+    const [result] = await executor.query<ResultSetHeader>(
+      `
+        INSERT INTO izi_jobs (state, queue, worker, args, meta, tags, errors, attempt, max_attempts, priority, scheduled_at, unique_key)
+        VALUES ${batch.map(() => rowPlaceholder).join(', ')}
+      `,
+      params
+    );
+
+    const firstId = result.insertId;
+    const lastId = firstId + result.affectedRows - 1;
+
+    const [rows] = await executor.query<RowDataPacket[]>(
+      'SELECT * FROM izi_jobs WHERE id BETWEEN ? AND ? ORDER BY id ASC',
+      [firstId, lastId]
+    );
+
+    if (rows.length !== batch.length) {
+      throw new Error(
+        `izi-queue: expected to recover ${batch.length} inserted job(s) by id range [${firstId}, ${lastId}] but found ${rows.length}`
+      );
+    }
+
+    return rows.map(row => rowToJob(row as Record<string, unknown>));
+  }
+
+  /** Chunks `jobs` (all non-unique) across as many `insertPlainChunk` calls as needed. */
+  private async insertPlainRun(
+    executor: Pool | PoolConnection,
+    jobs: Omit<Job, 'id' | 'insertedAt'>[]
+  ): Promise<{ job: Job; conflict: boolean }[]> {
+    const out: { job: Job; conflict: boolean }[] = [];
+    for (const batch of chunkArray(jobs, INSERT_JOBS_CHUNK_SIZE)) {
+      const inserted = await this.insertPlainChunk(executor, batch);
+      out.push(...inserted.map(job => ({ job, conflict: false })));
+    }
+    return out;
+  }
+
+  async insertJobs(
+    jobs: BulkJobInsert[],
+    tx?: TransactionHandle
+  ): Promise<{ job: Job; conflict: boolean }[]> {
+    if (jobs.length === 0) return [];
+
+    const runs = groupBulkRuns(jobs);
+    const hasUnique = runs.some(run => run.kind === 'unique');
+
+    if (tx !== undefined) {
+      if (hasUnique) {
+        // Same restriction as `insertUnique`: GET_LOCK is connection-scoped,
+        // not transactional, so it cannot be held across the caller's own,
+        // later commit. Releasing it before that commit reopens the race
+        // atomic insertion exists to close -- see `insertUnique` above.
+        throw new Error(
+          'izi-queue: unique jobs cannot be inserted inside a caller-managed transaction on MySQL, ' +
+            'because the advisory lock cannot span the commit. Insert unique jobs outside the ' +
+            'transaction, or use PostgreSQL, where the lock is transaction-scoped.'
+        );
+      }
+      return this.insertPlainRun(this.executor(tx), jobs.map(entry => entry.job));
+    }
+
+    const connection = await this.pool.getConnection();
+    const heldLocks: string[] = [];
+    try {
+      await connection.beginTransaction();
+      const out: { job: Job; conflict: boolean }[] = [];
+
+      for (const run of runs) {
+        if (run.kind === 'plain') {
+          out.push(...await this.insertPlainRun(connection, run.jobs));
+          continue;
+        }
+
+        const { states, period } = this.uniqueLookup(run.unique);
+        const uniqueKey = run.job.uniqueKey ?? computeUniqueKey(run.job, run.unique);
+        // GET_LOCK names are capped at 64 characters; the digest is 32.
+        const lockName = `izi_unique_${uniqueKey}`;
+
+        // Connection-scoped, not transactional, so taking it mid-transaction
+        // does not affect the transaction itself -- it just has to run on
+        // this same connection. Released together with every other lock this
+        // batch took, in `finally`, once the whole batch's outcome (commit or
+        // rollback) is decided -- exactly as long as `insertUnique` holds it
+        // for a single insert.
+        await connection.query('SELECT GET_LOCK(?, ?)', [lockName, 10]);
+        heldLocks.push(lockName);
+
+        const params: unknown[] = period !== null ? [uniqueKey, states, period] : [uniqueKey, states];
+        const [existing] = await connection.query<RowDataPacket[]>(
+          this.uniqueLookupSql(period !== null),
+          params
+        );
+
+        if (existing[0]) {
+          out.push({ job: rowToJob(existing[0] as Record<string, unknown>), conflict: true });
+          continue;
+        }
+
+        const [result] = await connection.query<ResultSetHeader>(SQL.mysql.insertJob, [
+          run.job.state,
+          run.job.queue,
+          run.job.worker,
+          JSON.stringify(run.job.args),
+          JSON.stringify(run.job.meta),
+          JSON.stringify(run.job.tags),
+          JSON.stringify(run.job.errors),
+          run.job.attempt,
+          run.job.maxAttempts,
+          run.job.priority,
+          run.job.scheduledAt,
+          uniqueKey
+        ]);
+
+        const [rows] = await connection.query<RowDataPacket[]>(SQL.mysql.getJob, [result.insertId]);
+        out.push({ job: rowToJob(rows[0] as Record<string, unknown>), conflict: false });
+      }
+
+      await connection.commit();
+      return out;
+    } catch (error) {
+      await connection.rollback().catch(() => {});
+      throw error;
+    } finally {
+      for (const lockName of heldLocks) {
+        await connection.query('SELECT RELEASE_LOCK(?)', [lockName]).catch(() => {});
+      }
       connection.release();
     }
   }

--- a/src/database/postgres.ts
+++ b/src/database/postgres.ts
@@ -1,5 +1,6 @@
 import type { Pool, PoolClient } from 'pg';
 import type {
+  BulkJobInsert,
   Job,
   JobCriteria,
   JobListCriteria,
@@ -13,9 +14,13 @@ import {
   BaseAdapter,
   DEFAULT_BATCH_SIZE,
   DEFAULT_NODE_TTL,
+  INSERT_JOB_COLUMNS,
   SQL,
   buildStateCounts,
+  chunkArray,
   criteriaClause,
+  groupBulkRuns,
+  maxRowsPerStatement,
   orderByClause,
   resolveListLimit,
   resolveListOffset,
@@ -26,6 +31,15 @@ import { telemetry } from '../core/telemetry.js';
 
 /** Arbitrary but fixed: all izi-queue instances must agree on this value. */
 const MIGRATION_LOCK_KEY = '7451092386401173';
+
+/**
+ * PostgreSQL's extended query protocol encodes the bound-parameter count as a
+ * signed 16-bit integer, so a single statement cannot bind more than 65535
+ * parameters. `insertJobs` chunks its multi-row INSERTs to stay under it:
+ * floor(65535 / 12 columns) = 5461 rows per statement.
+ */
+const PG_MAX_BIND_PARAMS = 65535;
+export const INSERT_JOBS_CHUNK_SIZE = maxRowsPerStatement(PG_MAX_BIND_PARAMS);
 
 function uniqueLookupSql(withPeriod: boolean): string {
   return `
@@ -361,29 +375,89 @@ export class PostgresAdapter extends BaseAdapter {
     return result.rows[0] ? rowToJob(result.rows[0]) : null;
   }
 
+  /**
+   * Checks `job`/`options` against pre-existing rows under an advisory lock
+   * and inserts unless one is found. Shared by `insertUnique` (called with
+   * whichever client owns the transaction) and `insertJobs` (called once per
+   * unique run within the batch's transaction).
+   */
+  private async claimUnique(
+    client: Pool | PoolClient,
+    job: Omit<Job, 'id' | 'insertedAt'>,
+    options: UniqueOptions
+  ): Promise<{ job: Job; conflict: boolean }> {
+    const { states, period } = this.uniqueLookup(options);
+    const uniqueKey = job.uniqueKey ?? computeUniqueKey(job, options);
+
+    // Transaction-scoped, so it is held until whoever owns the transaction
+    // commits -- the caller when they supplied one, otherwise us.
+    await client.query('SELECT pg_advisory_xact_lock($1)', [advisoryLockKey(uniqueKey)]);
+
+    const existing = await client.query(
+      uniqueLookupSql(period !== null),
+      period !== null ? [uniqueKey, states, period] : [uniqueKey, states]
+    );
+
+    if (existing.rows[0]) {
+      return { job: rowToJob(existing.rows[0]), conflict: true };
+    }
+
+    const inserted = await client.query(SQL.postgres.insertJob, [
+      job.state,
+      job.queue,
+      job.worker,
+      JSON.stringify(job.args),
+      JSON.stringify(job.meta),
+      job.tags,
+      JSON.stringify(job.errors),
+      job.attempt,
+      job.maxAttempts,
+      job.priority,
+      job.scheduledAt,
+      uniqueKey
+    ]);
+
+    return { job: rowToJob(inserted.rows[0]), conflict: false };
+  }
+
   async insertUnique(
     job: Omit<Job, 'id' | 'insertedAt'>,
     options: UniqueOptions,
     tx?: TransactionHandle
   ): Promise<{ job: Job; conflict: boolean }> {
-    const { states, period } = this.uniqueLookup(options);
-    const uniqueKey = job.uniqueKey ?? computeUniqueKey(job, options);
+    // Inside the caller's transaction: their BEGIN/COMMIT governs atomicity,
+    // and issuing our own would end their transaction early.
+    if (tx !== undefined) {
+      return this.claimUnique(this.executor(tx), job, options);
+    }
 
-    const claim = async (client: Pool | PoolClient): Promise<{ job: Job; conflict: boolean }> => {
-      // Transaction-scoped, so it is held until whoever owns the transaction
-      // commits -- the caller when they supplied one, otherwise us.
-      await client.query('SELECT pg_advisory_xact_lock($1)', [advisoryLockKey(uniqueKey)]);
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+      const result = await this.claimUnique(client, job, options);
+      await client.query('COMMIT');
+      return result;
+    } catch (error) {
+      await client.query('ROLLBACK').catch(() => {});
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
 
-      const existing = await client.query(
-        uniqueLookupSql(period !== null),
-        period !== null ? [uniqueKey, states, period] : [uniqueKey, states]
-      );
+  /** One multi-row `INSERT ... RETURNING *`, sized to stay under the bind-parameter cap. */
+  private async insertPlainChunk(
+    client: Pool | PoolClient,
+    batch: Omit<Job, 'id' | 'insertedAt'>[]
+  ): Promise<Job[]> {
+    const values: string[] = [];
+    const params: unknown[] = [];
 
-      if (existing.rows[0]) {
-        return { job: rowToJob(existing.rows[0]), conflict: true };
-      }
-
-      const inserted = await client.query(SQL.postgres.insertJob, [
+    batch.forEach((job, i) => {
+      const base = i * INSERT_JOB_COLUMNS;
+      const placeholders = Array.from({ length: INSERT_JOB_COLUMNS }, (_, j) => `$${base + j + 1}`);
+      values.push(`(${placeholders.join(', ')})`);
+      params.push(
         job.state,
         job.queue,
         job.worker,
@@ -395,24 +469,67 @@ export class PostgresAdapter extends BaseAdapter {
         job.maxAttempts,
         job.priority,
         job.scheduledAt,
-        uniqueKey
-      ]);
+        job.uniqueKey ?? null
+      );
+    });
 
-      return { job: rowToJob(inserted.rows[0]), conflict: false };
+    const result = await client.query(
+      `
+        INSERT INTO izi_jobs (state, queue, worker, args, meta, tags, errors, attempt, max_attempts, priority, scheduled_at, unique_key)
+        VALUES ${values.join(', ')}
+        RETURNING *
+      `,
+      params
+    );
+
+    return result.rows.map(rowToJob);
+  }
+
+  /** Chunks `jobs` (all non-unique) across as many `insertPlainChunk` calls as needed. */
+  private async insertPlainRun(
+    client: Pool | PoolClient,
+    jobs: Omit<Job, 'id' | 'insertedAt'>[]
+  ): Promise<{ job: Job; conflict: boolean }[]> {
+    const out: { job: Job; conflict: boolean }[] = [];
+    for (const batch of chunkArray(jobs, INSERT_JOBS_CHUNK_SIZE)) {
+      const inserted = await this.insertPlainChunk(client, batch);
+      out.push(...inserted.map(job => ({ job, conflict: false })));
+    }
+    return out;
+  }
+
+  async insertJobs(
+    jobs: BulkJobInsert[],
+    tx?: TransactionHandle
+  ): Promise<{ job: Job; conflict: boolean }[]> {
+    if (jobs.length === 0) return [];
+
+    const runs = groupBulkRuns(jobs);
+
+    const runAll = async (client: Pool | PoolClient): Promise<{ job: Job; conflict: boolean }[]> => {
+      const out: { job: Job; conflict: boolean }[] = [];
+      for (const run of runs) {
+        if (run.kind === 'plain') {
+          out.push(...await this.insertPlainRun(client, run.jobs));
+        } else {
+          out.push(await this.claimUnique(client, run.job, run.unique));
+        }
+      }
+      return out;
     };
 
     // Inside the caller's transaction: their BEGIN/COMMIT governs atomicity,
-    // and issuing our own would end their transaction early.
+    // same as `insertUnique`.
     if (tx !== undefined) {
-      return claim(this.executor(tx));
+      return runAll(this.executor(tx));
     }
 
     const client = await this.pool.connect();
     try {
       await client.query('BEGIN');
-      const result = await claim(client);
+      const out = await runAll(client);
       await client.query('COMMIT');
-      return result;
+      return out;
     } catch (error) {
       await client.query('ROLLBACK').catch(() => {});
       throw error;

--- a/src/database/sqlite.ts
+++ b/src/database/sqlite.ts
@@ -1,5 +1,6 @@
 import type { Database } from 'better-sqlite3';
 import type {
+  BulkJobInsert,
   Job,
   JobCriteria,
   JobListCriteria,
@@ -13,8 +14,12 @@ import {
   BaseAdapter,
   DEFAULT_BATCH_SIZE,
   DEFAULT_NODE_TTL,
+  INSERT_JOB_COLUMNS,
   buildStateCounts,
+  chunkArray,
   criteriaClause,
+  groupBulkRuns,
+  maxRowsPerStatement,
   orderByClause,
   resolveListLimit,
   resolveListOffset,
@@ -22,6 +27,17 @@ import {
 } from './adapter.js';
 import { computeUniqueKey } from '../core/unique.js';
 import { sqliteMigrations } from './migrations.js';
+
+/**
+ * SQLite's `SQLITE_MAX_VARIABLE_NUMBER` has defaulted to 32766 since 3.32.0
+ * (2020). better-sqlite3's supported peer range (^9 - ^13) all bundle SQLite
+ * releases well past that, so 32766 is safe for every version this adapter
+ * supports. `insertJobs` chunks its multi-row INSERTs to stay under it:
+ * floor(32766 / 12 columns) = 2730 rows per statement. A build recompiled
+ * with a lower compile-time limit is responsible for its own chunking.
+ */
+const SQLITE_MAX_BIND_PARAMS = 32766;
+export const INSERT_JOBS_CHUNK_SIZE = maxRowsPerStatement(SQLITE_MAX_BIND_PARAMS);
 
 export class SQLiteAdapter extends BaseAdapter {
   private db: Database;
@@ -411,6 +427,85 @@ export class SQLiteAdapter extends BaseAdapter {
       .prepare('SELECT * FROM izi_jobs WHERE id = ?')
       .get(result.lastInsertRowid) as Record<string, unknown>;
     return rowToJob(row);
+  }
+
+  /** One multi-row `INSERT ... RETURNING *`, sized to stay under the bind-variable cap. */
+  private insertPlainChunk(batch: Omit<Job, 'id' | 'insertedAt'>[]): Job[] {
+    const rowPlaceholder = `(${Array(INSERT_JOB_COLUMNS).fill('?').join(', ')})`;
+    const stmt = this.db.prepare(`
+      INSERT INTO izi_jobs (state, queue, worker, args, meta, tags, errors, attempt, max_attempts, priority, scheduled_at, unique_key)
+      VALUES ${batch.map(() => rowPlaceholder).join(', ')}
+      RETURNING *
+    `);
+
+    const params: unknown[] = [];
+    for (const job of batch) {
+      params.push(
+        job.state,
+        job.queue,
+        job.worker,
+        JSON.stringify(job.args),
+        JSON.stringify(job.meta),
+        JSON.stringify(job.tags),
+        JSON.stringify(job.errors),
+        job.attempt,
+        job.maxAttempts,
+        job.priority,
+        job.scheduledAt.toISOString(),
+        job.uniqueKey ?? null
+      );
+    }
+
+    const rows = stmt.all(...params) as Record<string, unknown>[];
+    return rows.map(rowToJob);
+  }
+
+  async insertJobs(
+    jobs: BulkJobInsert[],
+    tx?: TransactionHandle
+  ): Promise<{ job: Job; conflict: boolean }[]> {
+    this.resolveTx(tx);
+    if (jobs.length === 0) return [];
+
+    const runs = groupBulkRuns(jobs);
+
+    const runAll = (): { job: Job; conflict: boolean }[] => {
+      const out: { job: Job; conflict: boolean }[] = [];
+
+      for (const run of runs) {
+        if (run.kind === 'plain') {
+          for (const batch of chunkArray(run.jobs, INSERT_JOBS_CHUNK_SIZE)) {
+            out.push(...this.insertPlainChunk(batch).map(job => ({ job, conflict: false })));
+          }
+          continue;
+        }
+
+        const { states, period } = this.uniqueLookup(run.unique);
+        const uniqueKey = run.job.uniqueKey ?? computeUniqueKey(run.job, run.unique);
+        const existing = this.findUnique(uniqueKey, states, period);
+
+        if (existing) {
+          out.push({ job: existing, conflict: true });
+        } else {
+          out.push({ job: this.insertJobSync({ ...run.job, uniqueKey }), conflict: false });
+        }
+      }
+
+      return out;
+    };
+
+    // Already inside the caller's transaction (or better-sqlite3's single
+    // connection has one open) -- opening another would fail, and it is what
+    // makes each unique check-and-insert atomic against the rest of the batch.
+    if (tx !== undefined || this.db.inTransaction) {
+      return runAll();
+    }
+
+    // `immediate` takes the write lock up front. A deferred transaction would
+    // start as a reader and only try to upgrade at the first INSERT, which
+    // SQLite refuses outright rather than waiting when another writer got
+    // there first.
+    return this.db.transaction(runAll).immediate();
   }
 
   async close(): Promise<void> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -183,6 +183,22 @@ export interface BackoffOptions {
   jitterPercent?: number;
 }
 
+/**
+ * One job to insert as part of a bulk batch passed to `insertJobs`. `unique`
+ * mirrors `JobInsertOptions.unique` on a single `insert` -- when present the
+ * adapter must check it against pre-existing rows before inserting, exactly
+ * like `insertUnique`, and return the existing row with `conflict: true`
+ * instead of inserting a duplicate.
+ *
+ * Callers must not pass two entries whose `unique` options resolve to the
+ * same key -- `IziQueue.insertAll` deduplicates by key before calling this,
+ * so `insertJobs` only ever has to check a given entry against the database.
+ */
+export interface BulkJobInsert {
+  job: Omit<Job, 'id' | 'insertedAt'>;
+  unique?: UniqueOptions;
+}
+
 export type WorkerResult =
   | { status: 'ok'; value?: unknown }
   | { status: 'error'; error: Error | string }
@@ -375,6 +391,27 @@ export interface DatabaseAdapter {
     options: UniqueOptions,
     tx?: TransactionHandle
   ): Promise<{ job: Job; conflict: boolean }>;
+  /**
+   * Inserts every job in `jobs` in as few round trips as the database's
+   * parameter limits allow, wrapped in one transaction -- the caller's, if
+   * `tx` is given, otherwise one this call opens and commits or rolls back
+   * itself. A failure partway through leaves nothing behind, unlike calling
+   * `insertJob`/`insertUnique` once per job.
+   *
+   * Results are returned in the same order as `jobs`. An entry with no
+   * `unique` is always inserted (`conflict: false`); an entry with `unique`
+   * that matches a pre-existing row comes back with that row and
+   * `conflict: true`, exactly like `insertUnique`.
+   *
+   * Optional so a third-party adapter written before this existed keeps
+   * compiling; `IziQueue.insertAll` falls back to one `insertJob`/
+   * `insertUnique` call per job (i.e. today's non-atomic, N-round-trip
+   * behavior) when an adapter does not implement it.
+   */
+  insertJobs?(
+    jobs: BulkJobInsert[],
+    tx?: TransactionHandle
+  ): Promise<{ job: Job; conflict: boolean }[]>;
   close(): Promise<void>;
   listen?(callback: (event: { queue: string }) => void): Promise<void>;
   /**

--- a/tests/izi-queue.test.ts
+++ b/tests/izi-queue.test.ts
@@ -372,6 +372,208 @@ describe('IziQueue Class', () => {
 
       await queue.shutdown();
     });
+
+    it('preserves input order across a mix of queues', async () => {
+      const queue = createIziQueue({
+        database: adapter,
+        queues: { default: 5, priority: 5 }
+      });
+
+      const jobs = await queue.insertAll('BatchWorker', [
+        { args: { id: 1 }, queue: 'priority' },
+        { args: { id: 2 } },
+        { args: { id: 3 }, queue: 'priority' }
+      ]);
+
+      expect(jobs.map(j => j.args)).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }]);
+      expect(jobs.map(j => j.queue)).toEqual(['priority', 'default', 'priority']);
+
+      await queue.shutdown();
+    });
+
+    it('collapses duplicate unique jobs within the batch before hitting the database', async () => {
+      const queue = createIziQueue({
+        database: adapter,
+        queues: { default: 5 }
+      });
+
+      const results = await queue.insertAllWithResult('BatchWorker', [
+        { args: { userId: 1 }, unique: { period: 60 } },
+        { args: { userId: 1 }, unique: { period: 60 } },
+        { args: { userId: 2 }, unique: { period: 60 } }
+      ]);
+
+      expect(results[0].conflict).toBe(false);
+      expect(results[1].conflict).toBe(true);
+      expect(results[1].job.id).toBe(results[0].job.id);
+      expect(results[2].conflict).toBe(false);
+      expect(results[2].job.id).not.toBe(results[0].job.id);
+
+      const count = (db.prepare('SELECT COUNT(*) AS c FROM izi_jobs').get() as { c: number }).c;
+      expect(count).toBe(2);
+
+      await queue.shutdown();
+    });
+
+    it('reports a conflict with a pre-existing job the same way a single insert does', async () => {
+      const queue = createIziQueue({
+        database: adapter,
+        queues: { default: 5 }
+      });
+
+      const existing = await queue.insert('BatchWorker', {
+        args: { userId: 1 },
+        unique: { period: 60 }
+      });
+
+      const results = await queue.insertAllWithResult('BatchWorker', [
+        { args: { userId: 99 } },
+        { args: { userId: 1 }, unique: { period: 60 } }
+      ]);
+
+      expect(results[0].conflict).toBe(false);
+      expect(results[1].conflict).toBe(true);
+      expect(results[1].job.id).toBe(existing.id);
+
+      const count = (db.prepare('SELECT COUNT(*) AS c FROM izi_jobs').get() as { c: number }).c;
+      expect(count).toBe(2);
+
+      await queue.shutdown();
+    });
+
+    it('rolls back the whole batch when one row fails', async () => {
+      const queue = createIziQueue({
+        database: adapter,
+        queues: { default: 5 }
+      });
+
+      await expect(
+        queue.insertAll('BatchWorker', [
+          { args: { id: 1 } },
+          // A unique job breaks the otherwise-contiguous run of plain jobs
+          // into separate statements, so the batch spans more than one SQL
+          // statement inside its transaction rather than failing atomically
+          // as a single multi-row INSERT.
+          { args: { id: 2 }, unique: { period: 60 } },
+          // A BigInt cannot be JSON.stringify'd, so this throws while
+          // building the third statement -- after the first two have already
+          // been written inside the (uncommitted) transaction.
+          { args: { bad: 10n } }
+        ])
+      ).rejects.toThrow();
+
+      const count = (db.prepare('SELECT COUNT(*) AS c FROM izi_jobs').get() as { c: number }).c;
+      expect(count).toBe(0);
+
+      await queue.shutdown();
+    });
+
+    it('sends at most one wake-up notification per queue in the batch', async () => {
+      const queue = createIziQueue({
+        database: adapter,
+        queues: { default: 5, priority: 5 }
+      });
+      await queue.start();
+
+      const notify = jest.fn(async (_queue: string, _tx?: unknown) => {});
+      // SQLiteAdapter has no built-in notify (it relies on polling); attach a
+      // stub since `notify` is an optional part of the adapter interface, and
+      // this is the only way to count wake-ups precisely.
+      (adapter as unknown as { notify: typeof notify }).notify = notify;
+
+      await queue.insertAll('BatchWorker', [
+        { args: { id: 1 } },
+        { args: { id: 2 }, queue: 'priority' },
+        { args: { id: 3 } },
+        { args: { id: 4 }, queue: 'priority' }
+      ]);
+
+      expect(notify).toHaveBeenCalledTimes(2);
+      expect(notify.mock.calls.map(call => call[0]).sort()).toEqual(['default', 'priority']);
+
+      await queue.shutdown();
+    });
+
+    it('does not wake a queue whose only batch entries were conflicts', async () => {
+      const queue = createIziQueue({
+        database: adapter,
+        queues: { default: 5 }
+      });
+      await queue.start();
+
+      await queue.insert('BatchWorker', { args: { userId: 1 }, unique: { period: 60 } });
+
+      const notify = jest.fn(async (_queue: string, _tx?: unknown) => {});
+      (adapter as unknown as { notify: typeof notify }).notify = notify;
+
+      await queue.insertAll('BatchWorker', [
+        { args: { userId: 1 }, unique: { period: 60 } }
+      ]);
+
+      expect(notify).not.toHaveBeenCalled();
+
+      await queue.shutdown();
+    });
+
+    it('rejects a batch whose entries disagree on which transaction to use', async () => {
+      const queue = createIziQueue({
+        database: adapter,
+        queues: { default: 5 }
+      });
+
+      const otherDb = new (await import('better-sqlite3')).default(':memory:');
+      try {
+        await expect(
+          queue.insertAll('BatchWorker', [
+            { args: { id: 1 }, tx: db },
+            { args: { id: 2 }, tx: otherDb }
+          ])
+        ).rejects.toThrow(/same transaction handle/i);
+      } finally {
+        otherDb.close();
+      }
+
+      await queue.shutdown();
+    });
+
+    it('rejects a batch where only some entries carry a transaction', async () => {
+      const queue = createIziQueue({
+        database: adapter,
+        queues: { default: 5 }
+      });
+
+      await expect(
+        queue.insertAll('BatchWorker', [
+          { args: { id: 1 }, tx: db },
+          { args: { id: 2 } }
+        ])
+      ).rejects.toThrow(/same transaction handle/i);
+
+      await queue.shutdown();
+    });
+
+    it('rolls back with the caller-supplied transaction', async () => {
+      const queue = createIziQueue({
+        database: adapter,
+        queues: { default: 5 }
+      });
+
+      db.exec('BEGIN');
+      try {
+        await queue.insertAll('BatchWorker', [
+          { args: { id: 1 }, tx: db },
+          { args: { id: 2 }, tx: db }
+        ]);
+        throw new Error('business logic failed');
+      } catch {
+        db.exec('ROLLBACK');
+      }
+
+      const count = (db.prepare('SELECT COUNT(*) AS c FROM izi_jobs').get() as { c: number }).c;
+      expect(count).toBe(0);
+
+      await queue.shutdown();
+    });
   });
 
   describe('getJob', () => {

--- a/tests/mysql-adapter.test.ts
+++ b/tests/mysql-adapter.test.ts
@@ -1,6 +1,6 @@
 import mysql from 'mysql2/promise';
-import { createMySQLAdapter, MySQLAdapter } from '../src/database/mysql.js';
-import type { Job } from '../src/types.js';
+import { createMySQLAdapter, MySQLAdapter, INSERT_JOBS_CHUNK_SIZE } from '../src/database/mysql.js';
+import type { BulkJobInsert, Job } from '../src/types.js';
 
 /**
  * These tests need a real MySQL server (8.0.1+ for FOR UPDATE SKIP LOCKED).
@@ -421,6 +421,144 @@ describeMySQL('MySQLAdapter', () => {
       const second = await adapter.insertUnique(jobData({ args: { userId: 1 } }), unique);
 
       expect(second.conflict).toBe(false);
+    });
+  });
+
+  describe('insertJobs', () => {
+    it('returns an empty array for an empty batch', async () => {
+      expect(await adapter.insertJobs([])).toEqual([]);
+    });
+
+    it('inserts every job in one call, in order', async () => {
+      const entries: BulkJobInsert[] = [
+        { job: jobData({ args: { id: 1 } }) },
+        { job: jobData({ args: { id: 2 } }) },
+        { job: jobData({ args: { id: 3 } }) },
+      ];
+
+      const results = await adapter.insertJobs(entries);
+
+      expect(results.map((r) => r.conflict)).toEqual([false, false, false]);
+      expect(results.map((r) => (r.job.args as { id: number }).id)).toEqual([1, 2, 3]);
+
+      const [rows] = await pool.query<mysql.RowDataPacket[]>('SELECT COUNT(*) AS c FROM izi_jobs');
+      expect(Number(rows[0].c)).toBe(3);
+    });
+
+    it('round-trips a batch spanning multiple chunks, recovering ids by range', async () => {
+      // One row past two full chunks, to prove the chunk boundary itself does
+      // not drop or misorder a row, and that the id-range recovery lines up
+      // with the VALUES order across statements.
+      const total = INSERT_JOBS_CHUNK_SIZE * 2 + 1;
+      const entries: BulkJobInsert[] = Array.from({ length: total }, (_, i) => ({
+        job: jobData({ args: { i } }),
+      }));
+
+      const results = await adapter.insertJobs(entries);
+
+      expect(results).toHaveLength(total);
+      expect(results.map((r) => (r.job.args as { i: number }).i)).toEqual(
+        Array.from({ length: total }, (_, i) => i)
+      );
+
+      const [rows] = await pool.query<mysql.RowDataPacket[]>('SELECT COUNT(*) AS c FROM izi_jobs');
+      expect(Number(rows[0].c)).toBe(total);
+    }, 60000);
+
+    it('checks a unique entry against a pre-existing row and reports a conflict', async () => {
+      const existing = await adapter.insertUnique(
+        jobData({ worker: 'UniqueWorker', args: { userId: 1 } }),
+        { period: 60 }
+      );
+
+      const results = await adapter.insertJobs([
+        { job: jobData({ args: { plain: true } }) },
+        { job: jobData({ worker: 'UniqueWorker', args: { userId: 1 } }), unique: { period: 60 } },
+      ]);
+
+      expect(results[0].conflict).toBe(false);
+      expect(results[1].conflict).toBe(true);
+      expect(results[1].job.id).toBe(existing.job.id);
+
+      const [rows] = await pool.query<mysql.RowDataPacket[]>('SELECT COUNT(*) AS c FROM izi_jobs');
+      expect(Number(rows[0].c)).toBe(2);
+    });
+
+    it('does not conflate distinct unique entries inserted in the same batch', async () => {
+      const results = await adapter.insertJobs([
+        { job: jobData({ worker: 'UniqueWorker', args: { userId: 1 } }), unique: { period: 60 } },
+        { job: jobData({ worker: 'UniqueWorker', args: { userId: 2 } }), unique: { period: 60 } },
+      ]);
+
+      expect(results.every((r) => !r.conflict)).toBe(true);
+      expect(results[0].job.id).not.toBe(results[1].job.id);
+    });
+
+    it('rolls back the whole batch when a later statement fails', async () => {
+      const entries: BulkJobInsert[] = [
+        { job: jobData({ args: { id: 1 } }) },
+        { job: jobData({ worker: 'UniqueWorker', args: { userId: 1 } }), unique: { period: 60 } },
+        // A circular reference cannot be JSON.stringify'd, so this fails
+        // while the third statement is being built -- after the first two
+        // have already been written inside the (uncommitted) transaction.
+        { job: jobData({ args: (() => { const a: Record<string, unknown> = {}; a.self = a; return a; })() }) },
+      ];
+
+      await expect(adapter.insertJobs(entries)).rejects.toThrow();
+
+      const [rows] = await pool.query<mysql.RowDataPacket[]>('SELECT COUNT(*) AS c FROM izi_jobs');
+      expect(Number(rows[0].c)).toBe(0);
+    });
+
+    it('commits together with the caller-supplied transaction (no unique entries)', async () => {
+      const conn = await pool.getConnection();
+      try {
+        await conn.beginTransaction();
+        const results = await adapter.insertJobs(
+          [{ job: jobData({ args: { id: 1 } }) }, { job: jobData({ args: { id: 2 } }) }],
+          conn
+        );
+        expect(results).toHaveLength(2);
+        await conn.commit();
+      } finally {
+        conn.release();
+      }
+
+      const [rows] = await pool.query<mysql.RowDataPacket[]>('SELECT COUNT(*) AS c FROM izi_jobs');
+      expect(Number(rows[0].c)).toBe(2);
+    });
+
+    it('rolls back together with the caller-supplied transaction (no unique entries)', async () => {
+      const conn = await pool.getConnection();
+      try {
+        await conn.beginTransaction();
+        await adapter.insertJobs(
+          [{ job: jobData({ args: { id: 1 } }) }, { job: jobData({ args: { id: 2 } }) }],
+          conn
+        );
+        await conn.rollback();
+      } finally {
+        conn.release();
+      }
+
+      const [rows] = await pool.query<mysql.RowDataPacket[]>('SELECT COUNT(*) AS c FROM izi_jobs');
+      expect(Number(rows[0].c)).toBe(0);
+    });
+
+    it('refuses a batch with a unique entry inside a caller transaction', async () => {
+      const conn = await pool.getConnection();
+      try {
+        await conn.beginTransaction();
+        await expect(
+          adapter.insertJobs(
+            [{ job: jobData({ args: { userId: 1 } }), unique: { period: 60 } }],
+            conn
+          )
+        ).rejects.toThrow(/unique/i);
+        await conn.rollback();
+      } finally {
+        conn.release();
+      }
     });
   });
 

--- a/tests/postgres-adapter.test.ts
+++ b/tests/postgres-adapter.test.ts
@@ -1,8 +1,8 @@
 import pg from 'pg';
 import { randomBytes } from 'crypto';
 import { waitFor } from './helpers/wait.js';
-import { createPostgresAdapter, PostgresAdapter } from '../src/database/postgres.js';
-import type { Job, Logger } from '../src/types.js';
+import { createPostgresAdapter, PostgresAdapter, INSERT_JOBS_CHUNK_SIZE } from '../src/database/postgres.js';
+import type { BulkJobInsert, Job, Logger } from '../src/types.js';
 
 /**
  * These tests need a real PostgreSQL server; the dialect differences that matter
@@ -404,6 +404,130 @@ describePostgres('PostgresAdapter', () => {
       const job = await adapter.insertJob(jobData({ args: { blob } }));
 
       expect(job.id).toBeGreaterThan(0);
+    });
+  });
+
+  describe('insertJobs', () => {
+    it('returns an empty array for an empty batch', async () => {
+      expect(await adapter.insertJobs([])).toEqual([]);
+    });
+
+    it('inserts every job in one call, in order', async () => {
+      const entries: BulkJobInsert[] = [
+        { job: jobData({ args: { id: 1 } }) },
+        { job: jobData({ args: { id: 2 } }) },
+        { job: jobData({ args: { id: 3 } }) },
+      ];
+
+      const results = await adapter.insertJobs(entries);
+
+      expect(results.map((r) => r.conflict)).toEqual([false, false, false]);
+      expect(results.map((r) => (r.job.args as { id: number }).id)).toEqual([1, 2, 3]);
+
+      const { rows } = await pool.query('SELECT COUNT(*)::int AS count FROM izi_jobs');
+      expect(rows[0].count).toBe(3);
+    });
+
+    it('round-trips a batch spanning multiple chunks', async () => {
+      // One row past two full chunks, to prove the chunk boundary itself
+      // does not drop or misorder a row.
+      const total = INSERT_JOBS_CHUNK_SIZE * 2 + 1;
+      const entries: BulkJobInsert[] = Array.from({ length: total }, (_, i) => ({
+        job: jobData({ args: { i } }),
+      }));
+
+      const results = await adapter.insertJobs(entries);
+
+      expect(results).toHaveLength(total);
+      expect(results.map((r) => (r.job.args as { i: number }).i)).toEqual(
+        Array.from({ length: total }, (_, i) => i)
+      );
+
+      const { rows } = await pool.query('SELECT COUNT(*)::int AS count FROM izi_jobs');
+      expect(rows[0].count).toBe(total);
+    }, 60000);
+
+    it('checks a unique entry against a pre-existing row and reports a conflict', async () => {
+      const existing = await adapter.insertUnique(
+        jobData({ worker: 'UniqueWorker', args: { userId: 1 } }),
+        { period: 60 }
+      );
+
+      const results = await adapter.insertJobs([
+        { job: jobData({ args: { plain: true } }) },
+        { job: jobData({ worker: 'UniqueWorker', args: { userId: 1 } }), unique: { period: 60 } },
+      ]);
+
+      expect(results[0].conflict).toBe(false);
+      expect(results[1].conflict).toBe(true);
+      expect(results[1].job.id).toBe(existing.job.id);
+
+      const { rows } = await pool.query('SELECT COUNT(*)::int AS count FROM izi_jobs');
+      expect(rows[0].count).toBe(2);
+    });
+
+    it('does not conflate distinct unique entries inserted in the same batch', async () => {
+      const results = await adapter.insertJobs([
+        { job: jobData({ worker: 'UniqueWorker', args: { userId: 1 } }), unique: { period: 60 } },
+        { job: jobData({ worker: 'UniqueWorker', args: { userId: 2 } }), unique: { period: 60 } },
+      ]);
+
+      expect(results.every((r) => !r.conflict)).toBe(true);
+      expect(results[0].job.id).not.toBe(results[1].job.id);
+    });
+
+    it('rolls back the whole batch when a later statement fails', async () => {
+      const entries: BulkJobInsert[] = [
+        { job: jobData({ args: { id: 1 } }) },
+        { job: jobData({ worker: 'UniqueWorker', args: { userId: 1 } }), unique: { period: 60 } },
+        // A circular reference cannot be JSON.stringify'd, so this fails
+        // while the third statement is being built -- after the first two
+        // have already been written inside the (uncommitted) transaction.
+        { job: jobData({ args: (() => { const a: Record<string, unknown> = {}; a.self = a; return a; })() }) },
+      ];
+
+      await expect(adapter.insertJobs(entries)).rejects.toThrow();
+
+      const { rows } = await pool.query('SELECT COUNT(*)::int AS count FROM izi_jobs');
+      expect(rows[0].count).toBe(0);
+    });
+
+    it('commits together with the caller-supplied transaction, including a unique entry', async () => {
+      const client = await pool.connect();
+      try {
+        await client.query('BEGIN');
+        const results = await adapter.insertJobs(
+          [
+            { job: jobData({ args: { id: 1 } }) },
+            { job: jobData({ worker: 'UniqueWorker', args: { userId: 1 } }), unique: { period: 60 } },
+          ],
+          client
+        );
+        expect(results).toHaveLength(2);
+        await client.query('COMMIT');
+      } finally {
+        client.release();
+      }
+
+      const { rows } = await pool.query('SELECT COUNT(*)::int AS count FROM izi_jobs');
+      expect(rows[0].count).toBe(2);
+    });
+
+    it('rolls back together with the caller-supplied transaction', async () => {
+      const client = await pool.connect();
+      try {
+        await client.query('BEGIN');
+        await adapter.insertJobs(
+          [{ job: jobData({ args: { id: 1 } }) }, { job: jobData({ args: { id: 2 } }) }],
+          client
+        );
+        await client.query('ROLLBACK');
+      } finally {
+        client.release();
+      }
+
+      const { rows } = await pool.query('SELECT COUNT(*)::int AS count FROM izi_jobs');
+      expect(rows[0].count).toBe(0);
     });
   });
 

--- a/tests/sqlite-adapter.test.ts
+++ b/tests/sqlite-adapter.test.ts
@@ -1,6 +1,6 @@
 import Database from 'better-sqlite3';
-import { createSQLiteAdapter } from '../src/database/sqlite.js';
-import type { Job, JobState, UniqueOptions } from '../src/types.js';
+import { createSQLiteAdapter, INSERT_JOBS_CHUNK_SIZE } from '../src/database/sqlite.js';
+import type { BulkJobInsert, Job, JobState, UniqueOptions } from '../src/types.js';
 
 describe('SQLiteAdapter', () => {
   let db: Database.Database;
@@ -802,6 +802,110 @@ describe('SQLiteAdapter', () => {
 
       expect(result.conflict).toBe(false);
       expect(((await adapter.getJob(result.job.id))?.args as { blob: string }).blob).toHaveLength(20000);
+    });
+  });
+
+  describe('insertJobs', () => {
+    it('returns an empty array for an empty batch', async () => {
+      expect(await adapter.insertJobs([])).toEqual([]);
+    });
+
+    it('inserts every job in one call, in order', async () => {
+      const entries: BulkJobInsert[] = [
+        { job: createJobData({ args: { id: 1 } }) },
+        { job: createJobData({ args: { id: 2 } }) },
+        { job: createJobData({ args: { id: 3 } }) }
+      ];
+
+      const results = await adapter.insertJobs(entries);
+
+      expect(results.map(r => r.conflict)).toEqual([false, false, false]);
+      expect(results.map(r => (r.job.args as { id: number }).id)).toEqual([1, 2, 3]);
+
+      const count = (db.prepare('SELECT COUNT(*) AS c FROM izi_jobs').get() as { c: number }).c;
+      expect(count).toBe(3);
+    });
+
+    it('round-trips a batch spanning multiple chunks', async () => {
+      // One row past two full chunks, to prove the chunk boundary itself
+      // does not drop or misorder a row.
+      const total = INSERT_JOBS_CHUNK_SIZE * 2 + 1;
+      const entries: BulkJobInsert[] = Array.from({ length: total }, (_, i) => ({
+        job: createJobData({ args: { i } })
+      }));
+
+      const results = await adapter.insertJobs(entries);
+
+      expect(results).toHaveLength(total);
+      expect(results.map(r => (r.job.args as { i: number }).i)).toEqual(
+        Array.from({ length: total }, (_, i) => i)
+      );
+
+      const count = (db.prepare('SELECT COUNT(*) AS c FROM izi_jobs').get() as { c: number }).c;
+      expect(count).toBe(total);
+    }, 30000);
+
+    it('checks a unique entry against a pre-existing row and reports a conflict', async () => {
+      const existing = await adapter.insertUnique(
+        createJobData({ worker: 'UniqueWorker', args: { userId: 1 } }),
+        { period: 60 }
+      );
+
+      const results = await adapter.insertJobs([
+        { job: createJobData({ args: { plain: true } }) },
+        {
+          job: createJobData({ worker: 'UniqueWorker', args: { userId: 1 } }),
+          unique: { period: 60 }
+        }
+      ]);
+
+      expect(results[0].conflict).toBe(false);
+      expect(results[1].conflict).toBe(true);
+      expect(results[1].job.id).toBe(existing.job.id);
+
+      const count = (db.prepare('SELECT COUNT(*) AS c FROM izi_jobs').get() as { c: number }).c;
+      expect(count).toBe(2);
+    });
+
+    it('rolls back the whole batch when a later statement fails', async () => {
+      const entries: BulkJobInsert[] = [
+        { job: createJobData({ args: { id: 1 } }) },
+        { job: createJobData({ worker: 'UniqueWorker', args: { userId: 1 } }), unique: { period: 60 } },
+        // JSON.stringify throws on a BigInt, so this fails while the third
+        // statement is being built -- after the first two already wrote to
+        // the (uncommitted) transaction.
+        { job: createJobData({ args: { bad: 10n } }) }
+      ];
+
+      await expect(adapter.insertJobs(entries)).rejects.toThrow();
+
+      const count = (db.prepare('SELECT COUNT(*) AS c FROM izi_jobs').get() as { c: number }).c;
+      expect(count).toBe(0);
+    });
+
+    it('commits together with the caller-supplied transaction', async () => {
+      db.exec('BEGIN');
+      const results = await adapter.insertJobs(
+        [{ job: createJobData({ args: { id: 1 } }) }, { job: createJobData({ args: { id: 2 } }) }],
+        db
+      );
+      db.exec('COMMIT');
+
+      expect(results).toHaveLength(2);
+      const count = (db.prepare('SELECT COUNT(*) AS c FROM izi_jobs').get() as { c: number }).c;
+      expect(count).toBe(2);
+    });
+
+    it('rolls back together with the caller-supplied transaction', async () => {
+      db.exec('BEGIN');
+      await adapter.insertJobs(
+        [{ job: createJobData({ args: { id: 1 } }) }, { job: createJobData({ args: { id: 2 } }) }],
+        db
+      );
+      db.exec('ROLLBACK');
+
+      const count = (db.prepare('SELECT COUNT(*) AS c FROM izi_jobs').get() as { c: number }).c;
+      expect(count).toBe(0);
     });
   });
 


### PR DESCRIPTION
Closes #32.

## Problem

`insertAll` was `Promise.all(jobs.map(insert))`: N round trips, N notifications, no atomicity (halfway failure leaves a partial batch), pool exhaustion on large batches, and unique jobs never checked against their batch siblings.

## Change

Modeled on `Oban.insert_all/2`:

- New optional `DatabaseAdapter.insertJobs` (third-party adapters keep compiling; per-row fallback preserved for them):
  - **Postgres**: multi-row `INSERT … RETURNING *`, chunked at 5461 rows (`floor(65535/12 cols)`), one transaction.
  - **MySQL**: multi-row INSERT + row recovery via `insertId..insertId+affectedRows-1` — the consecutive-id guarantee for a single simple insert holds under every `innodb_autoinc_lock_mode` (reasoning documented in code, verified against real MySQL 8). Unique entries take `GET_LOCK` inside the shared transaction; refused inside a caller-supplied `tx` where the lock can't span the commit.
  - **SQLite**: multi-row `INSERT … RETURNING` chunked at 2730 rows (`floor(32766/12)`), immediate transaction.
- **Atomic**: each batch commits or rolls back as a unit; joins the caller's `tx` like single `insert`. All entries must carry the **same** tx handle or none — mixed tx/no-tx is rejected (a tx-less entry would otherwise silently vanish with a rollback it never opted into; found in review, test added).
- **In-batch unique dedup** before the DB: later duplicates resolve to the first occurrence's job as `conflict: true`, mirroring single-insert conflict semantics, with `job:unique_conflict` telemetry.
- **One wake-up per distinct queue per batch** instead of one per job.
- New `insertAllWithResult` exposes per-entry `{ job, conflict }`; `insertAll` keeps its `Job[]` shape (backwards compatible).

## Testing

TDD per adapter + IziQueue level: chunk-boundary round-trips (~10.9k rows through 2 chunks), mid-batch failure rolls back everything, unique-vs-preexisting conflicts, in-batch dedup, one-notify-per-queue, matching/mismatched/mixed caller transactions. **409/409 tests against real Postgres 16 and MySQL 8** (id-recovery and GET_LOCK paths exercised on real servers). Build and lint clean.