### PR TITLE
feat(core): leader election so one node stages and runs plugins (#26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,43 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 While the version is below 1.0.0, breaking changes are released as minor versions.
 
+## [Unreleased]
+
+### Added
+
+- **Leader election.** One node per cluster is elected leader, and only the
+  leader stages jobs and runs the built-in plugins. Previously every node ran
+  every plugin and its own stager, so N nodes issued N copies of the same
+  `UPDATE`/`DELETE` against `izi_jobs` on every tick -- wasted work at small
+  scale, row-lock contention and deadlock risk at larger ones. The lease lives
+  in a new `izi_peers` table (one row per scope) and is renewed with a single
+  renew-or-take-over statement that the database arbitrates; a leader that
+  stops renewing is replaced `ttl` seconds later, and a clean shutdown hands
+  the lease back immediately. Configure with `leadership: { name?, interval?,
+  ttl? }`, inspect with `IziQueue.isLeader()` / `getLeader()` (and a new
+  `isLeader` field on `getQueueStatus`), and observe with the new
+  `peer:elected`, `peer:lost` and `peer:error` telemetry events. Followers
+  keep polling, fetching and executing jobs exactly as before, and `drain()`
+  still stages regardless of leadership. Set `leadership: false` for the old
+  behavior; adapters that do not implement `acquireLeadership` get it
+  automatically. ([#26])
+- `DatabaseAdapter.acquireLeadership`, `releaseLeadership` and `getLeader`,
+  all optional so third-party adapters keep compiling.
+- `PluginContext.isLeader` and `BasePlugin.isLeader()`, for gating a custom
+  plugin's cluster-wide work the way `LifelinePlugin` and `PrunerPlugin` now
+  gate theirs.
+
+### Changed
+
+- `getQueueStatus`/`getAllQueueStatus` gained an `isLeader` field. Code
+  comparing the returned object with `toEqual` needs updating; property
+  access is unaffected.
+
+### Migrations
+
+- PostgreSQL v8, MySQL v7, SQLite v7 create `izi_peers`. They run
+  automatically on `migrate()`.
+
 ## [0.8.0] - 2026-08-17
 
 ### Changed
@@ -395,6 +432,7 @@ production. Anyone running 0.3.0 or earlier should upgrade.
 [#32]: https://github.com/iagocavalcante/izi-queue/issues/32
 [#34]: https://github.com/iagocavalcante/izi-queue/issues/34
 [#40]: https://github.com/iagocavalcante/izi-queue/issues/40
+[#26]: https://github.com/iagocavalcante/izi-queue/issues/26
 [0.4.0]: https://github.com/iagocavalcante/izi-queue/compare/v0.3.0...v0.4.0
 [0.4.1]: https://github.com/iagocavalcante/izi-queue/compare/v0.4.0...v0.4.1
 [0.5.0]: https://github.com/iagocavalcante/izi-queue/compare/v0.4.1...v0.5.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ src/
 │   ├── izi-queue.ts      # Main IziQueue class (orchestrator)
 │   ├── queue.ts          # Queue class (worker execution)
 │   ├── job.ts            # Job state machine & backoff
+│   ├── peer.ts           # Leader election (izi_peers lease)
 │   ├── unique.ts         # Uniqueness digest & advisory lock keys
 │   ├── worker.ts         # Worker registry & execution
 │   ├── telemetry.ts      # Event system
@@ -39,6 +40,7 @@ src/
 │   ├── index.ts
 │   ├── adapter.ts        # BaseAdapter interface
 │   ├── postgres.ts       # PostgreSQL implementation
+│   ├── mysql.ts          # MySQL implementation
 │   ├── sqlite.ts         # SQLite implementation
 │   └── migrations.ts     # Migration definitions
 └── plugins/
@@ -202,6 +204,12 @@ export abstract class BasePlugin implements Plugin {
 
 **To create a plugin:** Extend `BasePlugin`, implement `onStart()`.
 
+**Gate cluster-wide work on `this.isLeader()`.** A plugin tick that writes rows
+other nodes can also see runs N times over on an N-node cluster otherwise. Only
+node-local work belongs outside the gate. `PluginContext.isLeader` is absent on
+a hand-built context, which `BasePlugin.isLeader()` reads as "leading", so a
+plugin can never quietly stop doing its work because a harness forgot it.
+
 ### 7. Observable Pattern (Telemetry)
 
 Event-based system for monitoring and debugging.
@@ -320,6 +328,15 @@ CREATE TABLE izi_nodes (
   heartbeat_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
+-- Leadership lease, one row per scope. Only the holder stages jobs and runs
+-- the maintenance plugins.
+CREATE TABLE izi_peers (
+  name VARCHAR(255) PRIMARY KEY,
+  node VARCHAR(255) NOT NULL,
+  elected_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  expires_at TIMESTAMPTZ NOT NULL
+);
+
 -- Critical indexes
 CREATE INDEX izi_jobs_queue_state_idx ON izi_jobs (queue, state);
 CREATE INDEX izi_jobs_stageable_idx ON izi_jobs (scheduled_at)
@@ -330,6 +347,26 @@ CREATE INDEX izi_jobs_unique_key_idx ON izi_jobs (unique_key) WHERE unique_key I
 **Never index `args` directly.** A btree entry is capped at ~2704 bytes and a
 JSONB value that does not compress below it fails the insert outright. That is
 why uniqueness is keyed on a digest.
+
+### Leader Election
+
+`izi_peers` holds one lease row per scope. Acquisition is a renew-or-take-over
+`UPDATE` whose `WHERE` matches only for the incumbent or, once the lease lapses,
+whoever wins the race — followed by a conflict-tolerant `INSERT` when no row
+exists yet, and then a read-back to settle the outcome.
+
+**The read-back is not optional.** MySQL reports *matched* rather than *changed*
+rows once the driver negotiates `CLIENT_FOUND_ROWS`, which mysql2 does by
+default, so a losing `INSERT ... ON DUPLICATE KEY UPDATE` is indistinguishable
+from a winning insert by row count alone. Twenty nodes racing all came away
+believing they led. `BaseAdapter.electLeader` encodes the whole sequence once so
+the three adapters cannot drift on the one operation whose entire purpose is
+that every node agrees.
+
+MySQL also evaluates a multi-column `SET` left to right, letting later
+expressions see values assigned by earlier ones — so `renewLeadership` computes
+`elected_at` *before* overwriting `node`, or every renewal would look like a
+handover.
 
 ### Concurrency Control
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A minimal, reliable, database-backed job queue for Node.js inspired by [Oban](ht
   - [Unique Jobs](#unique-jobs)
   - [Worker Isolation](#worker-isolation)
   - [Plugins](#plugins)
+  - [Leader Election](#leader-election)
   - [Telemetry](#telemetry)
 - [Managing Jobs](#managing-jobs)
 - [Transactional Inserts](#transactional-inserts)
@@ -300,9 +301,76 @@ backlog takes to scan. Staging (moving due `scheduled`/`retryable` jobs to
 `available`, which runs automatically -- no plugin needed) batches the same
 way; tune it with `stageBatchSize` on `IziQueue`'s config.
 
-> Every node runs every plugin: there is no leader election yet
-> ([#26](https://github.com/iagocavalcante/izi-queue/issues/26)). With several
-> nodes this duplicates maintenance work against the same rows.
+Both plugins run on the elected leader only, so a five-node deployment prunes
+and rescues once per cycle rather than five times over the same rows. See
+[Leader Election](#leader-election).
+
+### Leader Election
+
+One node in a cluster is elected leader, and only the leader stages jobs and
+runs the built-in plugins. Without it, N nodes issue N copies of the same
+`UPDATE`/`DELETE` against the hottest table in the system on every tick — pure
+lock contention that grows with the cluster.
+
+It is on by default and needs no configuration. On a single node the only
+candidate always wins, so nothing changes.
+
+```typescript
+const queue = new IziQueue({
+  database: adapter,
+  queues: { default: 10 },
+  node: 'worker-1',
+  leadership: {
+    name: 'default',   // leadership scope; one leader is elected per name
+    interval: 10000,   // how often the lease is renewed, in ms
+    ttl: 30,           // how long a lease is good for, in seconds
+  },
+});
+
+queue.isLeader();            // true if this node is currently leading
+await queue.getLeader();     // { node, electedAt, expiresAt } | null
+queue.getQueueStatus('default')?.isLeader;
+```
+
+The lease lives in `izi_peers`, one row per scope, and every node runs the same
+renew-or-take-over statement on `interval`. The database decides who wins — the
+race is between nodes, so it cannot be settled in JavaScript. A leader that
+stops renewing (crash, partition, a process wedged past the TTL) is replaced
+`ttl` seconds after its last successful renewal; a clean shutdown hands the
+lease back immediately instead of waiting that out.
+
+What followers keep doing: polling, fetching, and executing jobs, exactly as
+before. Only cluster-wide maintenance is gated. `drain()` also stages
+regardless of leadership, since it is an explicit request from the caller.
+
+Two knobs worth understanding:
+
+- `ttl` is the worst-case pause in staging after a leader dies, so a longer
+  lease trades faster failover for fewer renewals. It must be at least twice
+  `interval`, or a single slow renewal would hand leadership away from a
+  healthy node; izi-queue rejects a configuration where it is not.
+- `name` scopes the election. Two deployments sharing one database each need
+  their own name, or they will elect a single leader between them.
+
+Leadership is advisory, not a fence: a leader stalled past its TTL can still
+believe it leads while a successor is elected. Everything gated on it is
+idempotent, so a brief overlap costs at most the duplicated work that used to
+happen unconditionally.
+
+Set `leadership: false` to restore the old behavior where every node stages
+and runs every plugin. A custom adapter that does not implement
+`acquireLeadership` behaves that way too, since it cannot elect anyone.
+
+Writing a plugin? Gate any tick that writes rows other nodes can see:
+
+```typescript
+class MyPlugin extends BasePlugin {
+  private async tick() {
+    if (!this.isLeader()) return;
+    // ... cluster-wide maintenance
+  }
+}
+```
 
 ### Telemetry
 
@@ -331,10 +399,14 @@ queue.on('*', ({ event, job }) => {
 - `queue:start`, `queue:stop`, `queue:pause`, `queue:resume`
 - `thread:spawn`, `thread:exit`
 - `plugin:start`, `plugin:stop`, `plugin:error`
+- `peer:elected`, `peer:lost`, `peer:error`
 
 `job:transition_refused` fires when a result could not be written because the
 job had already moved on — cancelled by an operator, or rescued onto another
-node. `jobs:pruned` and `job:rescue` carry `result`, not `job`.
+node. `jobs:pruned` and `job:rescue` carry `result`, not `job`. The `peer:*`
+events carry `node`: `peer:elected` and `peer:lost` fire only on a change of
+leadership, not on every renewal, and `peer:error` means an election round
+could not reach the database — the node stands down until one succeeds.
 
 ## Managing Jobs
 
@@ -447,11 +519,13 @@ const queue = new IziQueue({
 });
 ```
 
+Staging and the built-in plugins run on one elected node rather than on all of
+them — see [Leader Election](#leader-election).
+
 Two caveats when scaling out:
 
 - Concurrency limits are **per node**. Five nodes with `{ default: 10 }` run up
   to 50 jobs at once ([#37](https://github.com/iagocavalcante/izi-queue/issues/37)).
-- Every node runs every plugin ([#26](https://github.com/iagocavalcante/izi-queue/issues/26)).
 - A worker that blocks the event loop for longer than the node TTL stops the
   heartbeat and may be treated as dead. Use isolated workers for CPU-bound work.
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,4 +1,11 @@
-export { IziQueue, createIziQueue, type IziQueueFullConfig, type InsertResult } from './izi-queue.js';
+export {
+  IziQueue,
+  createIziQueue,
+  type IziQueueFullConfig,
+  type InsertResult,
+  type QueueStatus
+} from './izi-queue.js';
+export { Peer } from './peer.js';
 export { Queue } from './queue.js';
 export {
   createJob,

--- a/src/core/izi-queue.ts
+++ b/src/core/izi-queue.ts
@@ -9,6 +9,7 @@ import type {
   JobInsertOptions,
   JobListCriteria,
   JobStateCounts,
+  LeaderInfo,
   TransactionHandle,
   QueueConfig,
   TelemetryEvent,
@@ -18,6 +19,7 @@ import type {
 import type { Plugin, PluginContext } from '../plugins/plugin.js';
 import { createJob } from './job.js';
 import { computeUniqueKey } from './unique.js';
+import { Peer } from './peer.js';
 import { Queue } from './queue.js';
 import { telemetry } from './telemetry.js';
 import { consoleLogger } from './logger.js';
@@ -63,6 +65,16 @@ export interface InsertResult<T = Record<string, unknown>> {
   conflict: boolean;
 }
 
+/** One queue's runtime state, as reported by `getQueueStatus`. */
+export interface QueueStatus {
+  name: string;
+  state: string;
+  limit: number;
+  running: number;
+  /** Whether this node holds the leadership lease -- node-wide, not per queue. */
+  isLeader: boolean;
+}
+
 export class IziQueue {
   private config: Required<Omit<IziQueueFullConfig, 'queues' | 'plugins' | 'isolation'>> & {
     queues: QueueConfig[];
@@ -70,6 +82,7 @@ export class IziQueue {
     isolation?: IsolationConfig;
   };
   private queues: Map<string, Queue> = new Map();
+  private readonly peer: Peer;
   private stageTimer?: ReturnType<typeof setInterval>;
   private heartbeatTimer?: ReturnType<typeof setInterval>;
   private started = false;
@@ -95,8 +108,19 @@ export class IziQueue {
       heartbeatInterval: config.heartbeatInterval ?? 15000,
       pollInterval: config.pollInterval ?? 1000,
       isolation: config.isolation,
+      leadership: config.leadership ?? true,
       logger: config.logger ?? consoleLogger
     };
+
+    // Constructed here rather than in `start()` so a misconfigured lease
+    // (a TTL shorter than the renewal interval, say) is rejected while the
+    // caller is still wiring things up, alongside plugin validation below.
+    this.peer = new Peer(
+      this.config.database,
+      this.config.node,
+      this.config.leadership,
+      this.config.logger
+    );
 
     if (this.config.isolation) {
       initializeIsolatedWorkers(this.config.isolation);
@@ -122,6 +146,27 @@ export class IziQueue {
 
   get isStarted(): boolean {
     return this.started;
+  }
+
+  /**
+   * Whether this node currently holds the leadership lease and is therefore
+   * the one staging jobs and running the built-in plugins (#26).
+   *
+   * Always true when `leadership` is disabled, or when the configured adapter
+   * predates `acquireLeadership` -- in both cases every node behaves as
+   * leader, which is the pre-#26 behavior.
+   */
+  isLeader(): boolean {
+    return this.peer.isLeader();
+  }
+
+  /**
+   * Reads the current lease holder from the database, which may be another
+   * node. Returns null when leadership is disabled, unsupported by the
+   * adapter, or genuinely vacant (every node's lease has lapsed).
+   */
+  async getLeader(): Promise<LeaderInfo | null> {
+    return this.peer.getLeader();
   }
 
   async migrate(): Promise<void> {
@@ -153,13 +198,19 @@ export class IziQueue {
       this.config.heartbeatInterval
     );
 
+    // Before the stage timer and the plugins, both of which are leader-gated:
+    // starting the peer first means a single-node deployment is already
+    // leading by the time its first tick fires, rather than idling through
+    // one interval.
+    await this.peer.start();
+
     for (const queueConfig of this.config.queues) {
       const queue = new Queue(queueConfig, this.config.database, this.config.node, this.config.logger);
       this.queues.set(queueConfig.name, queue);
     }
 
     this.stageTimer = setInterval(
-      () => this.stageJobs(),
+      () => this.stageJobsIfLeader(),
       this.config.stageInterval
     );
 
@@ -177,7 +228,8 @@ export class IziQueue {
       database: this.config.database,
       node: this.config.node,
       queues: Array.from(this.queues.keys()),
-      nodeTtl: this.nodeTtl
+      nodeTtl: this.nodeTtl,
+      isLeader: () => this.peer.isLeader()
     };
 
     for (const plugin of this.config.plugins) {
@@ -203,6 +255,11 @@ export class IziQueue {
       clearInterval(this.heartbeatTimer);
       this.heartbeatTimer = undefined;
     }
+
+    // Released before the drain, not after: this node has already stopped
+    // staging and running plugins, so holding the lease for the length of the
+    // grace period would only stall whichever node takes over.
+    await this.peer.stop();
 
     await Promise.all(
       Array.from(this.queues.values()).map(q =>
@@ -634,39 +691,46 @@ export class IziQueue {
     this.queues.get(name)?.scale(limit);
   }
 
-  getQueueStatus(name: string): {
-    name: string;
-    state: string;
-    limit: number;
-    running: number;
-  } | null {
+  getQueueStatus(name: string): QueueStatus | null {
     const queue = this.queues.get(name);
     if (!queue) return null;
 
+    return this.statusOf(queue);
+  }
+
+  getAllQueueStatus(): QueueStatus[] {
+    return Array.from(this.queues.values()).map(queue => this.statusOf(queue));
+  }
+
+  /**
+   * `isLeader` rides along on every queue's status because that is what a
+   * `/health` endpoint already dumps -- without it, telling "this node is
+   * idle because there is no work" apart from "this node is idle because
+   * another node is leading" means a second call.
+   */
+  private statusOf(queue: Queue): QueueStatus {
     return {
       name: queue.name,
       state: queue.currentState,
       limit: queue.limit,
-      running: queue.runningCount
+      running: queue.runningCount,
+      isLeader: this.peer.isLeader()
     };
-  }
-
-  getAllQueueStatus(): Array<{
-    name: string;
-    state: string;
-    limit: number;
-    running: number;
-  }> {
-    return Array.from(this.queues.values()).map(queue => ({
-      name: queue.name,
-      state: queue.currentState,
-      limit: queue.limit,
-      running: queue.runningCount
-    }));
   }
 
   on(event: TelemetryEvent | '*', handler: TelemetryHandler): () => void {
     return telemetry.on(event, handler);
+  }
+
+  /**
+   * The stage timer's tick. Leader-only: N nodes issuing the same
+   * `UPDATE ... WHERE state IN ('scheduled', 'retryable')` every second is
+   * pure lock contention on the hottest table in the system (#26). Followers
+   * still poll their queues, so they pick the staged jobs up as usual.
+   */
+  private async stageJobsIfLeader(): Promise<void> {
+    if (!this.peer.isLeader()) return;
+    await this.stageJobs();
   }
 
   private async stageJobs(): Promise<void> {

--- a/src/core/peer.ts
+++ b/src/core/peer.ts
@@ -1,0 +1,193 @@
+import type { DatabaseAdapter, LeaderInfo, LeadershipConfig, Logger } from '../types.js';
+import {
+  DEFAULT_LEADER_NAME,
+  DEFAULT_LEADERSHIP_INTERVAL,
+  DEFAULT_LEADERSHIP_TTL
+} from '../database/adapter.js';
+import { telemetry } from './telemetry.js';
+
+/**
+ * Holds -- or competes for -- a single leadership lease, so that exactly one
+ * node in a cluster stages jobs and runs the maintenance plugins (#26).
+ *
+ * The lease lives in `izi_peers` as one row per scope name, carrying the
+ * holder and an expiry. Every node runs the same statement on the same
+ * interval: renew the row if we already hold it, take it over if it has
+ * lapsed, and otherwise leave it alone. The database arbitrates, exactly as it
+ * does for job state transitions -- the race is between nodes, so it cannot be
+ * settled in JavaScript.
+ *
+ * Leadership is *advisory*, not a fence: a leader whose process stalls past
+ * the TTL can still believe it leads while a successor is elected. Everything
+ * gated on it is therefore idempotent (staging, pruning, rescuing) or
+ * separately deduplicated (cron inserts), so the worst case of a brief overlap
+ * is the duplicated work that existed unconditionally before this landed.
+ */
+export class Peer {
+  private readonly database: DatabaseAdapter;
+  private readonly node: string;
+  private readonly logger: Logger;
+  private readonly enabled: boolean;
+  private readonly name: string;
+  private readonly interval: number;
+  private readonly ttl: number;
+
+  private timer?: ReturnType<typeof setInterval>;
+  private running = false;
+  private electing = false;
+  private leader = false;
+
+  constructor(
+    database: DatabaseAdapter,
+    node: string,
+    config: boolean | LeadershipConfig | undefined,
+    logger: Logger
+  ) {
+    this.database = database;
+    this.node = node;
+    this.logger = logger;
+
+    const options: LeadershipConfig = typeof config === 'object' ? config : {};
+    this.name = options.name ?? DEFAULT_LEADER_NAME;
+    this.interval = options.interval ?? DEFAULT_LEADERSHIP_INTERVAL;
+    this.ttl = options.ttl ?? DEFAULT_LEADERSHIP_TTL;
+
+    // An adapter without `acquireLeadership` cannot elect anyone. Rather than
+    // leaving such a cluster leaderless -- which would stop staging entirely --
+    // every node acts as leader, which is exactly the pre-#26 behavior.
+    this.enabled = config !== false && typeof database.acquireLeadership === 'function';
+
+    if (this.enabled) {
+      this.validate();
+    } else {
+      this.leader = true;
+    }
+  }
+
+  private validate(): void {
+    if (this.interval < 1000) {
+      throw new Error(
+        `izi-queue: leadership.interval must be at least 1000ms, got ${this.interval}`
+      );
+    }
+
+    // Renewing at least twice per lease means a single slow or failed renewal
+    // cannot hand leadership to another node while this one is still healthy.
+    if (this.ttl * 1000 < this.interval * 2) {
+      throw new Error(
+        `izi-queue: leadership.ttl (${this.ttl}s) must be at least twice leadership.interval ` +
+          `(${this.interval}ms), otherwise the lease expires faster than it is renewed`
+      );
+    }
+  }
+
+  get isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  get scope(): string {
+    return this.name;
+  }
+
+  isLeader(): boolean {
+    return this.leader;
+  }
+
+  async start(): Promise<void> {
+    if (this.running) return;
+    this.running = true;
+
+    if (!this.enabled) return;
+
+    // Elected before returning, so a queue that starts and immediately stages
+    // does not have to wait out a full interval to find out whether it may.
+    await this.elect();
+
+    this.timer = setInterval(() => {
+      void this.elect();
+    }, this.interval);
+  }
+
+  async stop(): Promise<void> {
+    if (!this.running) return;
+    this.running = false;
+
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = undefined;
+    }
+
+    if (!this.enabled) return;
+
+    // Handing the lease back on a clean shutdown lets a successor take over
+    // now instead of waiting out the TTL with nothing staging jobs.
+    if (this.leader) {
+      try {
+        await this.database.releaseLeadership?.(this.name, this.node);
+      } catch (error) {
+        this.logger.error('Error releasing leadership', { error, node: this.node });
+      }
+      this.demote();
+    }
+  }
+
+  /** The unexpired lease holder, or null. Always a fresh read. */
+  async getLeader(): Promise<LeaderInfo | null> {
+    if (!this.enabled || !this.database.getLeader) return null;
+    return this.database.getLeader(this.name);
+  }
+
+  /**
+   * One election round: acquire or renew, and reconcile local state with the
+   * answer. Overlapping rounds are skipped rather than queued -- if a round is
+   * still in flight when the next tick fires, the database is slow enough that
+   * piling on another statement would only make it worse.
+   */
+  private async elect(): Promise<void> {
+    if (!this.running || this.electing) return;
+
+    const acquire = this.database.acquireLeadership;
+    if (!acquire) return;
+
+    this.electing = true;
+
+    try {
+      const acquired = await acquire.call(this.database, this.name, this.node, this.ttl);
+
+      // A round that lands after stop() must not resurrect leadership.
+      if (!this.running) return;
+
+      if (acquired) {
+        this.promote();
+      } else {
+        this.demote();
+      }
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      this.logger.error('Error acquiring leadership', { error: err, node: this.node });
+      telemetry.emit('peer:error', { node: this.node, error: err });
+
+      // Fail closed. A lease we cannot prove we hold is one another node may
+      // already have taken, so standing down is the only safe reading -- and
+      // the work being gated is maintenance, which the next healthy leader
+      // picks up.
+      this.demote();
+    } finally {
+      this.electing = false;
+    }
+  }
+
+  private promote(): void {
+    if (this.leader) return;
+    this.leader = true;
+    this.logger.info('Node elected leader', { node: this.node, leadership: this.name });
+    telemetry.emit('peer:elected', { node: this.node, result: { name: this.name } });
+  }
+
+  private demote(): void {
+    if (!this.leader) return;
+    this.leader = false;
+    this.logger.info('Node lost leadership', { node: this.node, leadership: this.name });
+    telemetry.emit('peer:lost', { node: this.node, result: { name: this.name } });
+  }
+}

--- a/src/core/peer.ts
+++ b/src/core/peer.ts
@@ -103,6 +103,11 @@ export class Peer {
     // does not have to wait out a full interval to find out whether it may.
     await this.elect();
 
+    // stop() may have run while that first election was in flight -- it had no
+    // timer to clear yet, so installing one now would leave an interval alive
+    // for the life of the process with nothing left to clear it.
+    if (!this.running) return;
+
     this.timer = setInterval(() => {
       void this.elect();
     }, this.interval);

--- a/src/database/adapter.ts
+++ b/src/database/adapter.ts
@@ -30,6 +30,22 @@ export const DEFAULT_NODE_TTL = 60;
 export const DEFAULT_BATCH_SIZE = 5000;
 
 /**
+ * Leadership scope used when none is configured. One leader is elected per
+ * scope, so two logically separate deployments sharing a database stay
+ * independent by giving each its own name.
+ */
+export const DEFAULT_LEADER_NAME = 'default';
+
+/**
+ * How often the leader renews its lease, in ms, and how long the lease is
+ * good for, in seconds. Three missed renewals before another node may take
+ * over -- the same "four missed beats" shape as `DEFAULT_NODE_TTL`, but
+ * shorter, because nothing stages jobs while the lease sits expired.
+ */
+export const DEFAULT_LEADERSHIP_INTERVAL = 10000;
+export const DEFAULT_LEADERSHIP_TTL = 30;
+
+/**
  * Repeatedly calls `operation(limit)` -- which should perform at most `limit`
  * rows of work and return how many it actually touched -- until a call
  * touches fewer than `limit` rows, i.e. the backlog is exhausted. Yields to
@@ -236,7 +252,28 @@ export const SQL = {
       WHERE worker = $1
         AND state = ANY($2)
         AND inserted_at > NOW() - INTERVAL '1 second' * $3
-    `
+    `,
+    // Renews our own lease, or takes over an expired one, in a single
+    // statement -- the `WHERE` is what makes it safe to run concurrently on
+    // every node: only the incumbent (or, once it lapses, whichever node
+    // wins the race) matches. A non-zero row count means we hold the lease.
+    renewLeadership: `
+      UPDATE izi_peers
+      SET node = $2,
+          elected_at = CASE WHEN node = $2 THEN elected_at ELSE NOW() END,
+          expires_at = NOW() + INTERVAL '1 second' * $3
+      WHERE name = $1 AND (node = $2 OR expires_at <= NOW())
+    `,
+    // Only reached when no row exists yet. `DO NOTHING` turns the race
+    // between two nodes booting at once into a row count rather than a
+    // primary-key violation one of them has to catch.
+    claimLeadership: `
+      INSERT INTO izi_peers (name, node, expires_at)
+      VALUES ($1, $2, NOW() + INTERVAL '1 second' * $3)
+      ON CONFLICT (name) DO NOTHING
+    `,
+    releaseLeadership: 'DELETE FROM izi_peers WHERE name = $1 AND node = $2',
+    getLeader: 'SELECT node, elected_at, expires_at FROM izi_peers WHERE name = $1 AND expires_at > NOW()'
   },
 
   mysql: {
@@ -349,7 +386,28 @@ export const SQL = {
       WHERE worker = ?
         AND state IN (?)
         AND inserted_at > DATE_SUB(NOW(), INTERVAL ? SECOND)
-    `
+    `,
+    // MySQL evaluates a multi-column SET left to right, and later expressions
+    // see the values assigned by earlier ones -- so `elected_at` has to be
+    // computed before `node` is overwritten, or it would always compare a
+    // node against itself.
+    renewLeadership: `
+      UPDATE izi_peers
+      SET elected_at = CASE WHEN node = ? THEN elected_at ELSE NOW(6) END,
+          node = ?,
+          expires_at = DATE_ADD(NOW(6), INTERVAL ? SECOND)
+      WHERE name = ? AND (node = ? OR expires_at <= NOW(6))
+    `,
+    // `ON DUPLICATE KEY UPDATE name = name` rather than `INSERT IGNORE`: it
+    // reports the same zero affected rows on conflict without also
+    // downgrading unrelated errors to warnings.
+    claimLeadership: `
+      INSERT INTO izi_peers (name, node, expires_at)
+      VALUES (?, ?, DATE_ADD(NOW(6), INTERVAL ? SECOND))
+      ON DUPLICATE KEY UPDATE name = name
+    `,
+    releaseLeadership: 'DELETE FROM izi_peers WHERE name = ? AND node = ?',
+    getLeader: 'SELECT node, elected_at, expires_at FROM izi_peers WHERE name = ? AND expires_at > NOW(6)'
   },
 
   sqlite: {
@@ -462,6 +520,24 @@ export const SQL = {
       WHERE worker = ?
         AND state IN (SELECT value FROM json_each(?))
         AND datetime(inserted_at) > datetime('now', '-' || ? || ' seconds')
+    `,
+    // SQLite evaluates every SET expression against the pre-update row, so
+    // unlike MySQL the assignment order here carries no meaning.
+    renewLeadership: `
+      UPDATE izi_peers
+      SET node = ?,
+          elected_at = CASE WHEN node = ? THEN elected_at ELSE datetime('now') END,
+          expires_at = datetime('now', '+' || ? || ' seconds')
+      WHERE name = ? AND (node = ? OR datetime(expires_at) <= datetime('now'))
+    `,
+    claimLeadership: `
+      INSERT OR IGNORE INTO izi_peers (name, node, expires_at)
+      VALUES (?, ?, datetime('now', '+' || ? || ' seconds'))
+    `,
+    releaseLeadership: 'DELETE FROM izi_peers WHERE name = ? AND node = ?',
+    getLeader: `
+      SELECT node, elected_at, expires_at FROM izi_peers
+      WHERE name = ? AND datetime(expires_at) > datetime('now')
     `
   }
 };
@@ -693,6 +769,39 @@ export abstract class BaseAdapter implements DatabaseAdapter {
   abstract stageJobs(limit?: number): Promise<number>;
   abstract cancelJobs(criteria: import('../types.js').JobCriteria): Promise<number>;
   abstract rescueStuckJobs(rescueAfter: number, nodeTtl?: number): Promise<number>;
+
+  /**
+   * The leader-election algorithm every adapter shares, so the three of them
+   * cannot drift apart on the one operation whose whole purpose is that all
+   * nodes agree.
+   *
+   * `renew` runs the atomic renew-or-take-over statement and reports how many
+   * rows it matched: a non-zero count is definitive, because its `WHERE` only
+   * matches when this node either already holds the lease or may take it.
+   *
+   * Zero means either that no row exists yet or that a live lease belongs to
+   * somebody else, so `claim` (a conflict-tolerant insert) runs and `read`
+   * settles it. Deliberately *not* decided on the claim's row count: MySQL
+   * reports matched rather than changed rows when the driver negotiates
+   * `CLIENT_FOUND_ROWS` -- which mysql2 does by default -- so a losing
+   * `ON DUPLICATE KEY UPDATE` looks identical to a winning insert. Reading
+   * the row back is unambiguous on every dialect and driver.
+   *
+   * The read is a separate statement from the write, so it can only be stale
+   * in the safe direction: seeing another node means standing down, and
+   * seeing our own name means we held the lease as of that read.
+   */
+  protected async electLeader(
+    node: string,
+    renew: () => Promise<number>,
+    claim: () => Promise<void>,
+    read: () => Promise<import('../types.js').LeaderInfo | null>
+  ): Promise<boolean> {
+    if ((await renew()) > 0) return true;
+
+    await claim();
+    return (await read())?.node === node;
+  }
 
   /** Shared predicate for locating an existing unique job. */
   protected uniqueLookup(options: import('../types.js').UniqueOptions): {

--- a/src/database/migrations.ts
+++ b/src/database/migrations.ts
@@ -126,6 +126,21 @@ export const postgresMigrations: Migration[] = [
       `DROP INDEX IF EXISTS izi_jobs_unique_key_idx`,
       `ALTER TABLE izi_jobs DROP COLUMN IF EXISTS unique_key`
     ]
+  },
+  {
+    version: 8,
+    name: 'create_izi_peers_table',
+    up: [
+      `CREATE TABLE IF NOT EXISTS izi_peers (
+        name VARCHAR(255) PRIMARY KEY,
+        node VARCHAR(255) NOT NULL,
+        elected_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+        expires_at TIMESTAMP WITH TIME ZONE NOT NULL
+      )`
+    ],
+    down: [
+      `DROP TABLE IF EXISTS izi_peers`
+    ]
   }
 ];
 
@@ -224,6 +239,21 @@ export const sqliteMigrations: Migration[] = [
     down: [
       `DROP INDEX IF EXISTS izi_jobs_unique_key_idx`
     ]
+  },
+  {
+    version: 7,
+    name: 'create_izi_peers_table',
+    up: [
+      `CREATE TABLE IF NOT EXISTS izi_peers (
+        name TEXT PRIMARY KEY,
+        node TEXT NOT NULL,
+        elected_at TEXT NOT NULL DEFAULT (datetime('now')),
+        expires_at TEXT NOT NULL
+      )`
+    ],
+    down: [
+      `DROP TABLE IF EXISTS izi_peers`
+    ]
   }
 ];
 
@@ -319,6 +349,21 @@ export const mysqlMigrations: Migration[] = [
     ],
     down: [
       `DROP INDEX izi_jobs_unique_key_idx ON izi_jobs`
+    ]
+  },
+  {
+    version: 7,
+    name: 'create_izi_peers_table',
+    up: [
+      `CREATE TABLE IF NOT EXISTS izi_peers (
+        name VARCHAR(255) PRIMARY KEY,
+        node VARCHAR(255) NOT NULL,
+        elected_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+        expires_at TIMESTAMP(6) NOT NULL
+      )`
+    ],
+    down: [
+      `DROP TABLE IF EXISTS izi_peers`
     ]
   }
 ];

--- a/src/database/mysql.ts
+++ b/src/database/mysql.ts
@@ -30,6 +30,7 @@ import type {
   JobListCriteria,
   JobState,
   JobStateCounts,
+  LeaderInfo,
   Logger,
   TransactionHandle,
   UniqueOptions
@@ -371,6 +372,48 @@ export class MySQLAdapter extends BaseAdapter {
 
   async removeNode(node: string): Promise<void> {
     await this.pool.query(SQL.mysql.removeNode, [node]);
+  }
+
+  /**
+   * See `BaseAdapter.electLeader`. The renewal's row count is trustworthy on
+   * either of MySQL's accountings -- it matches only when this node may hold
+   * the lease, and it always moves `expires_at` forward when it does -- but
+   * the claim's is not, which is why the outcome is read back instead.
+   */
+  async acquireLeadership(name: string, node: string, ttlSeconds: number): Promise<boolean> {
+    return this.electLeader(
+      node,
+      async () => {
+        const [renewed] = await this.pool.query<ResultSetHeader>(SQL.mysql.renewLeadership, [
+          node,
+          node,
+          ttlSeconds,
+          name,
+          node
+        ]);
+        return renewed.affectedRows;
+      },
+      async () => {
+        await this.pool.query(SQL.mysql.claimLeadership, [name, node, ttlSeconds]);
+      },
+      () => this.getLeader(name)
+    );
+  }
+
+  async releaseLeadership(name: string, node: string): Promise<void> {
+    await this.pool.query(SQL.mysql.releaseLeadership, [name, node]);
+  }
+
+  async getLeader(name: string): Promise<LeaderInfo | null> {
+    const [rows] = await this.pool.query<RowDataPacket[]>(SQL.mysql.getLeader, [name]);
+    const row = rows[0];
+    if (!row) return null;
+
+    return {
+      node: row.node as string,
+      electedAt: new Date(row.elected_at as string),
+      expiresAt: new Date(row.expires_at as string)
+    };
   }
 
   private uniqueLookupSql(withPeriod: boolean): string {

--- a/src/database/postgres.ts
+++ b/src/database/postgres.ts
@@ -6,6 +6,7 @@ import type {
   JobListCriteria,
   JobState,
   JobStateCounts,
+  LeaderInfo,
   Logger,
   TransactionHandle,
   UniqueOptions
@@ -363,6 +364,37 @@ export class PostgresAdapter extends BaseAdapter {
 
   async removeNode(node: string): Promise<void> {
     await this.pool.query(SQL.postgres.removeNode, [node]);
+  }
+
+  /** See `BaseAdapter.electLeader` for why this is shaped the way it is. */
+  async acquireLeadership(name: string, node: string, ttlSeconds: number): Promise<boolean> {
+    return this.electLeader(
+      node,
+      async () => {
+        const renewed = await this.pool.query(SQL.postgres.renewLeadership, [name, node, ttlSeconds]);
+        return renewed.rowCount ?? 0;
+      },
+      async () => {
+        await this.pool.query(SQL.postgres.claimLeadership, [name, node, ttlSeconds]);
+      },
+      () => this.getLeader(name)
+    );
+  }
+
+  async releaseLeadership(name: string, node: string): Promise<void> {
+    await this.pool.query(SQL.postgres.releaseLeadership, [name, node]);
+  }
+
+  async getLeader(name: string): Promise<LeaderInfo | null> {
+    const result = await this.pool.query(SQL.postgres.getLeader, [name]);
+    const row = result.rows[0];
+    if (!row) return null;
+
+    return {
+      node: row.node as string,
+      electedAt: new Date(row.elected_at as string),
+      expiresAt: new Date(row.expires_at as string)
+    };
   }
 
   async checkUnique(options: UniqueOptions, job: Omit<Job, 'id' | 'insertedAt'>): Promise<Job | null> {

--- a/src/database/sqlite.ts
+++ b/src/database/sqlite.ts
@@ -6,6 +6,7 @@ import type {
   JobListCriteria,
   JobState,
   JobStateCounts,
+  LeaderInfo,
   Logger,
   TransactionHandle,
   UniqueOptions
@@ -15,6 +16,7 @@ import {
   DEFAULT_BATCH_SIZE,
   DEFAULT_NODE_TTL,
   INSERT_JOB_COLUMNS,
+  SQL,
   buildStateCounts,
   chunkArray,
   criteriaClause,
@@ -38,6 +40,16 @@ import { sqliteMigrations } from './migrations.js';
  */
 const SQLITE_MAX_BIND_PARAMS = 32766;
 export const INSERT_JOBS_CHUNK_SIZE = maxRowsPerStatement(SQLITE_MAX_BIND_PARAMS);
+
+/**
+ * SQLite has no timestamp type: `datetime('now')` writes `YYYY-MM-DD HH:MM:SS`
+ * in UTC, and `new Date()` reads that space-separated form as *local* time.
+ * Normalising to ISO 8601 with an explicit `Z` is what keeps a leadership
+ * expiry from appearing hours out on any machine that is not on UTC.
+ */
+function parseSqliteTimestamp(value: string): Date {
+  return new Date(`${value.replace(' ', 'T')}Z`);
+}
 
 export class SQLiteAdapter extends BaseAdapter {
   private db: Database;
@@ -350,6 +362,41 @@ export class SQLiteAdapter extends BaseAdapter {
 
   async removeNode(node: string): Promise<void> {
     this.db.prepare('DELETE FROM izi_nodes WHERE name = ?').run(node);
+  }
+
+  /**
+   * See `BaseAdapter.electLeader`. Single-process SQLite has no real election
+   * to run, but implementing it keeps `leadership` behaving identically
+   * across adapters instead of silently degrading to "everyone leads" on the
+   * one adapter people develop against.
+   */
+  async acquireLeadership(name: string, node: string, ttlSeconds: number): Promise<boolean> {
+    return this.electLeader(
+      node,
+      async () =>
+        this.db.prepare(SQL.sqlite.renewLeadership).run(node, node, ttlSeconds, name, node).changes,
+      async () => {
+        this.db.prepare(SQL.sqlite.claimLeadership).run(name, node, ttlSeconds);
+      },
+      () => this.getLeader(name)
+    );
+  }
+
+  async releaseLeadership(name: string, node: string): Promise<void> {
+    this.db.prepare(SQL.sqlite.releaseLeadership).run(name, node);
+  }
+
+  async getLeader(name: string): Promise<LeaderInfo | null> {
+    const row = this.db.prepare(SQL.sqlite.getLeader).get(name) as
+      | { node: string; elected_at: string; expires_at: string }
+      | undefined;
+    if (!row) return null;
+
+    return {
+      node: row.node,
+      electedAt: parseSqliteTimestamp(row.elected_at),
+      expiresAt: parseSqliteTimestamp(row.expires_at)
+    };
   }
 
   private findUnique(uniqueKey: string, states: string[], period: number | null): Job | null {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,15 @@
 // Main entry point
-export { IziQueue, createIziQueue, type IziQueueFullConfig, type InsertResult } from './core/izi-queue.js';
+export {
+  IziQueue,
+  createIziQueue,
+  type IziQueueFullConfig,
+  type InsertResult,
+  type QueueStatus
+} from './core/izi-queue.js';
 
 // Core exports
 export {
+  Peer,
   Queue,
   createJob,
   calculateBackoff,
@@ -51,7 +58,10 @@ export {
 export {
   DEFAULT_LIST_LIMIT,
   MAX_LIST_LIMIT,
-  JOB_STATES
+  JOB_STATES,
+  DEFAULT_LEADER_NAME,
+  DEFAULT_LEADERSHIP_INTERVAL,
+  DEFAULT_LEADERSHIP_TTL
 } from './database/adapter.js';
 
 // Plugins
@@ -79,6 +89,8 @@ export type {
   JobOrderBy,
   JobOrderByField,
   JobStateCounts,
+  LeaderInfo,
+  LeadershipConfig,
   UniqueOptions,
   WorkerResult,
   WorkerDefinition,

--- a/src/plugins/lifeline.ts
+++ b/src/plugins/lifeline.ts
@@ -38,6 +38,10 @@ export class LifelinePlugin extends BasePlugin {
   private async rescue(): Promise<void> {
     if (!this.context || !this.running) return;
 
+    // Rescuing is cluster-wide: every node would otherwise issue the same
+    // UPDATE over the same abandoned rows on every tick.
+    if (!this.isLeader()) return;
+
     try {
       const rescued = await this.context.database.rescueStuckJobs(
         this.config.rescueAfter,

--- a/src/plugins/plugin.ts
+++ b/src/plugins/plugin.ts
@@ -10,6 +10,19 @@ export interface PluginContext {
   queues: string[];
   /** Seconds without a heartbeat after which a node is presumed dead. */
   nodeTtl?: number;
+  /**
+   * Whether the owning node currently holds the leadership lease. Maintenance
+   * work belongs behind this: with N nodes, an ungated plugin does its work N
+   * times over, against the same rows (#26).
+   *
+   * Always true when leadership is disabled or the adapter does not support
+   * it, so gating on it never leaves the work undone.
+   *
+   * Optional purely so a hand-built context (a test, a bespoke harness) still
+   * type-checks; `IziQueue` always supplies it, and `BasePlugin.isLeader()`
+   * treats an absent one as leader.
+   */
+  isLeader?: () => boolean;
 }
 
 export interface Plugin {
@@ -45,6 +58,15 @@ export abstract class BasePlugin implements Plugin {
   protected abstract onStart(): Promise<void>;
 
   protected async onStop(): Promise<void> {}
+
+  /**
+   * Whether this node may do cluster-wide maintenance work right now. Gate
+   * every periodic tick that writes rows other nodes also see on it; leave
+   * node-local work ungated.
+   */
+  protected isLeader(): boolean {
+    return this.context?.isLeader?.() ?? true;
+  }
 
   validate(): string[] {
     return [];

--- a/src/plugins/pruner.ts
+++ b/src/plugins/pruner.ts
@@ -45,6 +45,10 @@ export class PrunerPlugin extends BasePlugin {
   private async prune(): Promise<void> {
     if (!this.context || !this.running) return;
 
+    // N nodes each running a large DELETE over the same range is the exact
+    // contention leader election exists to remove.
+    if (!this.isLeader()) return;
+
     try {
       const database = this.context.database;
       const pruned = await runInBatches(

--- a/src/types.ts
+++ b/src/types.ts
@@ -113,6 +113,45 @@ export interface JobListCriteria extends JobCriteria {
 export type JobStateCounts = Record<JobState, number>;
 
 /**
+ * Who currently holds a leadership lease, as reported by
+ * `DatabaseAdapter.getLeader`/`IziQueue.getLeader`.
+ */
+export interface LeaderInfo {
+  /** The node name holding the lease. */
+  node: string;
+  /** When that node most recently *took over* -- not when it last renewed. */
+  electedAt: Date;
+  /** When the lease lapses unless renewed before then. */
+  expiresAt: Date;
+}
+
+/**
+ * Tuning for leader election. One leader is elected per `name`, and only the
+ * leader stages jobs and runs the built-in plugins -- see
+ * `IziQueueConfig.leadership`.
+ */
+export interface LeadershipConfig {
+  /**
+   * The leadership scope. Two deployments sharing one database but wanting
+   * their own leader (say, a staging and a production app pointed at the same
+   * server) must set different names. Defaults to `'default'`.
+   */
+  name?: string;
+  /**
+   * How often the lease is renewed / an election is attempted, in ms.
+   * Defaults to 10000.
+   */
+  interval?: number;
+  /**
+   * How long a lease is good for, in seconds. A leader that stops renewing is
+   * replaced this long after its last successful renewal, which is also the
+   * worst-case pause in staging and plugin work after a leader dies. Must be
+   * comfortably longer than `interval`. Defaults to 30.
+   */
+  ttl?: number;
+}
+
+/**
  * A caller-managed transaction handle, passed straight through to the adapter.
  * Adapter-specific by nature, so the shared type stays open and each adapter
  * validates what it is given:
@@ -376,6 +415,29 @@ export interface DatabaseAdapter {
   /** Removes a node's liveness record on graceful shutdown. */
   removeNode?(node: string): Promise<void>;
   /**
+   * Acquires the leadership lease for `name`, or renews it if this node
+   * already holds it, and reports whether `node` holds it afterwards. Must be
+   * atomic: every node calls this on the same interval, and at most one of
+   * them may come away with `true`.
+   *
+   * A lease that has not been renewed within `ttlSeconds` is up for grabs by
+   * any node.
+   *
+   * Optional so third-party adapters predating leader election keep
+   * compiling. An adapter that does not implement it makes every node behave
+   * as leader -- the pre-#26 behavior -- rather than leaving the cluster with
+   * no leader at all.
+   */
+  acquireLeadership?(name: string, node: string, ttlSeconds: number): Promise<boolean>;
+  /**
+   * Gives up the lease for `name` if `node` holds it, so a successor can take
+   * over immediately instead of waiting out the TTL. A no-op when this node is
+   * not the leader.
+   */
+  releaseLeadership?(name: string, node: string): Promise<void>;
+  /** Returns the unexpired lease holder for `name`, or null if there is none. */
+  getLeader?(name: string): Promise<LeaderInfo | null>;
+  /**
    * @deprecated Superseded by `insertUnique`, which is atomic. Retained so
    * third-party adapters keep working; the check-then-insert it supports races
    * between concurrent callers.
@@ -449,6 +511,21 @@ export interface IziQueueConfig {
   pollInterval?: number;
   isolation?: IsolationConfig;
   /**
+   * Leader election. Only the leader stages jobs and runs the built-in
+   * plugins, so a horizontally scaled deployment does that work once rather
+   * than once per node (#26).
+   *
+   * Enabled by default. On a single node this changes nothing -- the only
+   * candidate always wins -- and it is what stops N nodes from issuing N
+   * concurrent `UPDATE`s over the same scheduled rows every tick.
+   *
+   * Set to `false` to restore the pre-#26 behavior where every node stages
+   * and runs every plugin. An adapter that does not implement
+   * `acquireLeadership` behaves that way regardless, since it cannot elect
+   * anyone.
+   */
+  leadership?: boolean | LeadershipConfig;
+  /**
    * Where izi-queue reports its own operational logging (staging/fetch
    * errors, node heartbeat failures, ...). Defaults to `consoleLogger`, which
    * preserves the pre-#40 behavior of writing to `console.*`.
@@ -488,7 +565,10 @@ export type TelemetryEvent =
   | 'thread:exit'
   | 'plugin:start'
   | 'plugin:stop'
-  | 'plugin:error';
+  | 'plugin:error'
+  | 'peer:elected'
+  | 'peer:lost'
+  | 'peer:error';
 
 export interface TelemetryPayload {
   event: TelemetryEvent;
@@ -500,6 +580,8 @@ export interface TelemetryPayload {
   timestamp: Date;
   threadId?: number;
   isolated?: boolean;
+  /** The node a `peer:*` event concerns. */
+  node?: string;
 }
 
 export type TelemetryHandler = (payload: TelemetryPayload) => void;

--- a/tests/izi-queue.test.ts
+++ b/tests/izi-queue.test.ts
@@ -957,7 +957,9 @@ describe('IziQueue Class', () => {
         name: 'default',
         state: 'running',
         limit: 5,
-        running: 0
+        running: 0,
+        // Single node, so it is always the leader.
+        isLeader: true
       });
 
       await queue.shutdown();

--- a/tests/leadership.test.ts
+++ b/tests/leadership.test.ts
@@ -1,0 +1,267 @@
+import Database from 'better-sqlite3';
+import {
+  createIziQueue,
+  createLifelinePlugin,
+  createPrunerPlugin,
+  createSQLiteAdapter,
+  clearWorkers
+} from '../src/index.js';
+import { DEFAULT_BATCH_SIZE } from '../src/database/adapter.js';
+import type { PluginContext } from '../src/plugins/plugin.js';
+import { stayFalse, waitFor } from './helpers/wait.js';
+
+/**
+ * Leader-gating as the rest of the system sees it: who stages, who runs the
+ * maintenance plugins, and what a follower must still keep doing (#26).
+ */
+describe('Leadership', () => {
+  let db: Database.Database;
+  let adapter: ReturnType<typeof createSQLiteAdapter>;
+
+  /** A job that became due a minute ago and is waiting on the stager. */
+  function insertOverdueJob(worker = 'DueWorker'): void {
+    db.prepare(`
+      INSERT INTO izi_jobs (state, queue, worker, args, scheduled_at)
+      VALUES ('scheduled', 'default', ?, '{}', datetime('now', '-1 minute'))
+    `).run(worker);
+  }
+
+  function stateOf(worker: string): string {
+    return (db.prepare('SELECT state FROM izi_jobs WHERE worker = ?').get(worker) as { state: string }).state;
+  }
+
+  beforeEach(async () => {
+    db = new Database(':memory:');
+    adapter = createSQLiteAdapter(db);
+    await adapter.migrate();
+    clearWorkers();
+  });
+
+  afterEach(async () => {
+    await adapter.close();
+  });
+
+  describe('election across instances', () => {
+    it('elects exactly one of two instances sharing a database', async () => {
+      const a = createIziQueue({ database: adapter, queues: { default: 1 }, node: 'node-a' });
+      const b = createIziQueue({ database: adapter, queues: { default: 1 }, node: 'node-b' });
+
+      await a.start();
+      await b.start();
+
+      expect([a, b].filter(q => q.isLeader())).toHaveLength(1);
+      expect((await a.getLeader())?.node).toBe('node-a');
+
+      await a.stop();
+      await b.stop();
+    });
+
+    it('reports leadership through queue status', async () => {
+      const queue = createIziQueue({ database: adapter, queues: { default: 1 }, node: 'node-a' });
+      await queue.start();
+
+      expect(queue.getQueueStatus('default')?.isLeader).toBe(true);
+      expect(queue.getAllQueueStatus()[0].isLeader).toBe(true);
+
+      await queue.stop();
+    });
+
+    it('hands the lease back on shutdown so the next instance leads', async () => {
+      const a = createIziQueue({ database: adapter, queues: { default: 1 }, node: 'node-a' });
+      await a.start();
+      await a.stop();
+
+      const b = createIziQueue({ database: adapter, queues: { default: 1 }, node: 'node-b' });
+      await b.start();
+
+      expect(b.isLeader()).toBe(true);
+      await b.stop();
+    });
+  });
+
+  describe('staging', () => {
+    it('stages due jobs on the leader', async () => {
+      insertOverdueJob();
+
+      const leader = createIziQueue({
+        database: adapter,
+        queues: { default: 1 },
+        node: 'node-a',
+        stageInterval: 1000
+      });
+      await leader.start();
+
+      // Staging nudges the queue to poll immediately, so the job may already
+      // have been claimed by the time this observes it -- what matters is that
+      // it left `scheduled`, which only the stager can do.
+      await waitFor(async () => stateOf('DueWorker') !== 'scheduled', {
+        describe: 'the leader to stage the overdue job'
+      });
+
+      await leader.stop();
+    });
+
+    it('does not stage on a follower', async () => {
+      // Another node already holds the lease with plenty of time left, so the
+      // instance under test can only ever come up as a follower.
+      await adapter.acquireLeadership('default', 'someone-else', 300);
+      insertOverdueJob();
+
+      const follower = createIziQueue({
+        database: adapter,
+        queues: { default: 1 },
+        node: 'node-b',
+        stageInterval: 20
+      });
+      await follower.start();
+      expect(follower.isLeader()).toBe(false);
+
+      await stayFalse(async () => stateOf('DueWorker') !== 'scheduled', { duration: 300 });
+
+      await follower.stop();
+    });
+
+    it('stages on every node when leadership is disabled', async () => {
+      await adapter.acquireLeadership('default', 'someone-else', 300);
+      insertOverdueJob();
+
+      const queue = createIziQueue({
+        database: adapter,
+        queues: { default: 1 },
+        node: 'node-b',
+        stageInterval: 20,
+        leadership: false
+      });
+      await queue.start();
+      expect(queue.isLeader()).toBe(true);
+
+      await waitFor(async () => stateOf('DueWorker') !== 'scheduled', {
+        describe: 'staging with leadership disabled'
+      });
+
+      await queue.stop();
+    });
+
+    it('still stages inside drain() on a follower', async () => {
+      // drain() is an explicit, synchronous request from the caller -- gating
+      // it on leadership would make it silently do nothing on a follower.
+      await adapter.acquireLeadership('default', 'someone-else', 300);
+      insertOverdueJob();
+
+      const follower = createIziQueue({
+        database: adapter,
+        queues: { default: 1 },
+        node: 'node-b',
+        stageInterval: 60000
+      });
+      await follower.start();
+      expect(follower.isLeader()).toBe(false);
+
+      await follower.drain('default');
+
+      // No worker is registered, so the job is discarded rather than completed
+      // -- what matters is that it was staged and fetched at all.
+      expect(stateOf('DueWorker')).toBe('discarded');
+
+      await follower.stop();
+    });
+
+    it('keeps fetching jobs on a follower', async () => {
+      await adapter.acquireLeadership('default', 'someone-else', 300);
+
+      const follower = createIziQueue({
+        database: adapter,
+        queues: { default: 1 },
+        node: 'node-b',
+        pollInterval: 20
+      });
+      follower.register({
+        name: 'FollowerWorker',
+        perform: async () => undefined
+      });
+      await follower.start();
+
+      await follower.insert('FollowerWorker', { args: {} });
+
+      await waitFor(async () => stateOf('FollowerWorker') === 'completed', {
+        describe: 'a follower to execute an available job'
+      });
+
+      await follower.stop();
+    });
+  });
+
+  describe('plugin gating', () => {
+    function contextFor(isLeader: boolean): PluginContext {
+      return {
+        database: adapter,
+        node: 'node-a',
+        queues: ['default'],
+        isLeader: () => isLeader
+      };
+    }
+
+    it('prunes on the leader and not on a follower', async () => {
+      db.prepare(`
+        INSERT INTO izi_jobs (state, queue, worker, args, completed_at)
+        VALUES ('completed', 'default', 'OldWorker', '{}', datetime('now', '-10 days'))
+      `).run();
+
+      const follower = createPrunerPlugin({ interval: 60000, maxAge: 86400 });
+      (follower as unknown as { config: unknown }).config = {
+        interval: 20,
+        maxAge: 86400,
+        batchSize: DEFAULT_BATCH_SIZE
+      };
+      await follower.start(contextFor(false));
+      await stayFalse(
+        async () => db.prepare('SELECT * FROM izi_jobs WHERE worker = ?').all('OldWorker').length === 0,
+        { duration: 200 }
+      );
+      await follower.stop();
+
+      const leader = createPrunerPlugin({ interval: 60000, maxAge: 86400 });
+      (leader as unknown as { config: unknown }).config = {
+        interval: 20,
+        maxAge: 86400,
+        batchSize: DEFAULT_BATCH_SIZE
+      };
+      await leader.start(contextFor(true));
+      await waitFor(
+        async () => db.prepare('SELECT * FROM izi_jobs WHERE worker = ?').all('OldWorker').length === 0,
+        { describe: 'the leader to prune the old job' }
+      );
+      await leader.stop();
+    });
+
+    it('rescues on the leader and not on a follower', async () => {
+      db.prepare(`
+        INSERT INTO izi_jobs (state, queue, worker, args, attempted_at)
+        VALUES ('executing', 'default', 'StuckWorker', '{}', datetime('now', '-10 minutes'))
+      `).run();
+
+      const follower = createLifelinePlugin({ interval: 60000, rescueAfter: 300 });
+      await follower.start(contextFor(false));
+      expect(stateOf('StuckWorker')).toBe('executing');
+      await follower.stop();
+
+      const leader = createLifelinePlugin({ interval: 60000, rescueAfter: 300 });
+      await leader.start(contextFor(true));
+      expect(stateOf('StuckWorker')).toBe('available');
+      await leader.stop();
+    });
+
+    it('treats a context without isLeader as leading', async () => {
+      db.prepare(`
+        INSERT INTO izi_jobs (state, queue, worker, args, attempted_at)
+        VALUES ('executing', 'default', 'StuckWorker', '{}', datetime('now', '-10 minutes'))
+      `).run();
+
+      const plugin = createLifelinePlugin({ interval: 60000, rescueAfter: 300 });
+      await plugin.start({ database: adapter, node: 'node-a', queues: ['default'] });
+
+      expect(stateOf('StuckWorker')).toBe('available');
+      await plugin.stop();
+    });
+  });
+});

--- a/tests/mysql-adapter.test.ts
+++ b/tests/mysql-adapter.test.ts
@@ -49,13 +49,14 @@ describeMySQL('MySQLAdapter', () => {
   });
 
   afterAll(async () => {
-    await pool.query('DROP TABLE IF EXISTS izi_jobs, izi_nodes, izi_migrations');
+    await pool.query('DROP TABLE IF EXISTS izi_jobs, izi_nodes, izi_peers, izi_migrations');
     await pool.end();
   });
 
   beforeEach(async () => {
     await pool.query('DELETE FROM izi_jobs');
     await pool.query('DELETE FROM izi_nodes');
+    await pool.query('DELETE FROM izi_peers');
   });
 
   async function countByState(): Promise<Record<string, number>> {
@@ -646,6 +647,105 @@ describeMySQL('MySQLAdapter', () => {
       } finally {
         conn.release();
       }
+    });
+  });
+
+  describe('leadership', () => {
+    /**
+     * MySQL evaluates a multi-column SET left to right and lets later
+     * expressions see values assigned by earlier ones, which is why
+     * `renewLeadership` computes `elected_at` before it overwrites `node`.
+     * Get that order wrong and every renewal looks like a handover -- these
+     * assertions are what catch it.
+     */
+    const expire = () =>
+      pool.query('UPDATE izi_peers SET expires_at = DATE_SUB(NOW(6), INTERVAL 1 MINUTE)');
+
+    it('acquires a vacant lease', async () => {
+      expect(await adapter.acquireLeadership('default', 'node-a', 30)).toBe(true);
+      expect((await adapter.getLeader('default'))?.node).toBe('node-a');
+    });
+
+    it('renews its own lease without resetting when it was elected', async () => {
+      await adapter.acquireLeadership('default', 'node-a', 30);
+      const first = await adapter.getLeader('default');
+
+      await new Promise(resolve => setTimeout(resolve, 20));
+      expect(await adapter.acquireLeadership('default', 'node-a', 30)).toBe(true);
+      const renewed = await adapter.getLeader('default');
+
+      expect(renewed?.node).toBe('node-a');
+      expect(renewed?.electedAt.getTime()).toBe(first?.electedAt.getTime());
+      expect(renewed!.expiresAt.getTime()).toBeGreaterThan(first!.expiresAt.getTime());
+    });
+
+    it('refuses a lease another node still holds', async () => {
+      await adapter.acquireLeadership('default', 'node-a', 30);
+      expect(await adapter.acquireLeadership('default', 'node-b', 30)).toBe(false);
+      expect((await adapter.getLeader('default'))?.node).toBe('node-a');
+    });
+
+    it('takes over an expired lease and records the handover', async () => {
+      await adapter.acquireLeadership('default', 'node-a', 30);
+      const before = await adapter.getLeader('default');
+      await expire();
+
+      expect(await adapter.acquireLeadership('default', 'node-b', 30)).toBe(true);
+      const after = await adapter.getLeader('default');
+
+      expect(after?.node).toBe('node-b');
+      expect(after!.electedAt.getTime()).toBeGreaterThanOrEqual(before!.electedAt.getTime());
+    });
+
+    it('reports no leader once the lease lapses', async () => {
+      await adapter.acquireLeadership('default', 'node-a', 30);
+      await expire();
+
+      expect(await adapter.getLeader('default')).toBeNull();
+    });
+
+    it('releases the lease it holds', async () => {
+      await adapter.acquireLeadership('default', 'node-a', 300);
+      await adapter.releaseLeadership('default', 'node-a');
+
+      expect(await adapter.getLeader('default')).toBeNull();
+      expect(await adapter.acquireLeadership('default', 'node-b', 30)).toBe(true);
+    });
+
+    it('will not release a lease held by another node', async () => {
+      await adapter.acquireLeadership('default', 'node-a', 300);
+      await adapter.releaseLeadership('default', 'node-b');
+
+      expect((await adapter.getLeader('default'))?.node).toBe('node-a');
+    });
+
+    it('keeps separate scopes independent', async () => {
+      expect(await adapter.acquireLeadership('app', 'node-a', 30)).toBe(true);
+      expect(await adapter.acquireLeadership('worker', 'node-b', 30)).toBe(true);
+
+      expect((await adapter.getLeader('app'))?.node).toBe('node-a');
+      expect((await adapter.getLeader('worker'))?.node).toBe('node-b');
+    });
+
+    it('elects exactly one node when twenty race for a vacant lease', async () => {
+      const results = await Promise.all(
+        Array.from({ length: 20 }, (_, i) => adapter.acquireLeadership('default', `node-${i}`, 30))
+      );
+
+      expect(results.filter(Boolean)).toHaveLength(1);
+      expect(await adapter.getLeader('default')).not.toBeNull();
+    });
+
+    it('elects exactly one node when twenty race for an expired lease', async () => {
+      await adapter.acquireLeadership('default', 'incumbent', 30);
+      await expire();
+
+      const results = await Promise.all(
+        Array.from({ length: 20 }, (_, i) => adapter.acquireLeadership('default', `node-${i}`, 30))
+      );
+
+      expect(results.filter(Boolean)).toHaveLength(1);
+      expect((await adapter.getLeader('default'))?.node).not.toBe('incumbent');
     });
   });
 });

--- a/tests/peer.test.ts
+++ b/tests/peer.test.ts
@@ -189,6 +189,9 @@ describe('Peer (leader election)', () => {
       await starting;
 
       expect(a.isLeader()).toBe(false);
+      // The renewal timer must not be installed after the fact either: nothing
+      // would ever clear it, and it would hold the process open forever.
+      expect((a as unknown as { timer?: unknown }).timer).toBeUndefined();
     });
   });
 

--- a/tests/peer.test.ts
+++ b/tests/peer.test.ts
@@ -1,0 +1,346 @@
+import Database from 'better-sqlite3';
+import { Peer } from '../src/core/peer.js';
+import { createSQLiteAdapter } from '../src/index.js';
+import { telemetry } from '../src/core/telemetry.js';
+import type {
+  DatabaseAdapter,
+  LeadershipConfig,
+  Logger,
+  TelemetryPayload
+} from '../src/types.js';
+import { waitFor } from './helpers/wait.js';
+
+/**
+ * A class instance's methods live on its prototype, so spreading one into an
+ * object literal drops every method it has. Overriding through a proxy keeps
+ * the rest of the adapter intact, which is what makes these fakes exercise
+ * the real SQL underneath.
+ */
+function adapterWith(
+  adapter: DatabaseAdapter,
+  overrides: Partial<Record<keyof DatabaseAdapter, unknown>>
+): DatabaseAdapter {
+  return new Proxy(adapter, {
+    get(target, prop, receiver) {
+      if (prop in overrides) return overrides[prop as keyof DatabaseAdapter];
+      const value = Reflect.get(target, prop, receiver);
+      return typeof value === 'function' ? value.bind(target) : value;
+    }
+  });
+}
+
+const silentLogger: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {}
+};
+
+describe('Peer (leader election)', () => {
+  let db: Database.Database;
+  let adapter: ReturnType<typeof createSQLiteAdapter>;
+  const peers: Peer[] = [];
+
+  function peer(node: string, config?: boolean | LeadershipConfig): Peer {
+    const created = new Peer(adapter, node, config, silentLogger);
+    peers.push(created);
+    return created;
+  }
+
+  beforeEach(async () => {
+    db = new Database(':memory:');
+    adapter = createSQLiteAdapter(db);
+    await adapter.migrate();
+  });
+
+  afterEach(async () => {
+    await Promise.all(peers.splice(0).map(p => p.stop()));
+    await adapter.close();
+  });
+
+  describe('election', () => {
+    it('elects the only candidate', async () => {
+      const only = peer('node-a', { interval: 1000, ttl: 30 });
+      await only.start();
+
+      expect(only.isLeader()).toBe(true);
+    });
+
+    it('elects exactly one of several candidates', async () => {
+      const a = peer('node-a', { interval: 1000, ttl: 30 });
+      const b = peer('node-b', { interval: 1000, ttl: 30 });
+      const c = peer('node-c', { interval: 1000, ttl: 30 });
+
+      await Promise.all([a.start(), b.start(), c.start()]);
+
+      expect([a, b, c].filter(p => p.isLeader())).toHaveLength(1);
+    });
+
+    it('renews its own lease rather than standing down', async () => {
+      const a = peer('node-a', { interval: 1000, ttl: 30 });
+      await a.start();
+
+      // Three more rounds through the same statement every node runs.
+      for (let i = 0; i < 3; i++) {
+        expect(await adapter.acquireLeadership('default', 'node-a', 30)).toBe(true);
+      }
+
+      expect(a.isLeader()).toBe(true);
+    });
+
+    it('reports the lease holder through getLeader', async () => {
+      const a = peer('node-a', { interval: 1000, ttl: 30 });
+      await a.start();
+
+      const leader = await a.getLeader();
+      expect(leader?.node).toBe('node-a');
+      expect(leader?.expiresAt.getTime()).toBeGreaterThan(Date.now());
+    });
+
+    it('leaves an unexpired lease alone', async () => {
+      const a = peer('node-a', { interval: 1000, ttl: 30 });
+      await a.start();
+
+      expect(await adapter.acquireLeadership('default', 'node-b', 30)).toBe(false);
+      expect((await a.getLeader())?.node).toBe('node-a');
+    });
+
+    it('hands leadership to another node once the lease expires', async () => {
+      const a = peer('node-a', { interval: 1000, ttl: 30 });
+      await a.start();
+      expect(a.isLeader()).toBe(true);
+
+      // Standing in for a node that stopped renewing -- a crash, a partition,
+      // a process wedged long enough to miss every renewal.
+      db.prepare(`UPDATE izi_peers SET expires_at = datetime('now', '-1 minute')`).run();
+
+      expect(await adapter.acquireLeadership('default', 'node-b', 30)).toBe(true);
+      expect((await a.getLeader())?.node).toBe('node-b');
+    });
+
+    it('records when leadership changed hands, not when it was last renewed', async () => {
+      await adapter.acquireLeadership('default', 'node-a', 30);
+      const first = await adapter.getLeader('default');
+
+      await adapter.acquireLeadership('default', 'node-a', 30);
+      const renewed = await adapter.getLeader('default');
+      expect(renewed?.electedAt.getTime()).toBe(first?.electedAt.getTime());
+
+      db.prepare(`UPDATE izi_peers SET expires_at = datetime('now', '-1 minute'), elected_at = datetime('now', '-1 hour')`).run();
+      await adapter.acquireLeadership('default', 'node-b', 30);
+      const takeover = await adapter.getLeader('default');
+
+      expect(takeover?.node).toBe('node-b');
+      expect(takeover?.electedAt.getTime()).toBeGreaterThan(first!.electedAt.getTime() - 3600_000);
+    });
+
+    it('treats a lapsed lease as vacant', async () => {
+      await adapter.acquireLeadership('default', 'node-a', 30);
+      db.prepare(`UPDATE izi_peers SET expires_at = datetime('now', '-1 minute')`).run();
+
+      expect(await adapter.getLeader('default')).toBeNull();
+    });
+
+    it('keeps separate scopes independent', async () => {
+      const a = peer('node-a', { interval: 1000, ttl: 30, name: 'app' });
+      const b = peer('node-b', { interval: 1000, ttl: 30, name: 'worker' });
+
+      await a.start();
+      await b.start();
+
+      expect(a.isLeader()).toBe(true);
+      expect(b.isLeader()).toBe(true);
+    });
+  });
+
+  describe('stopping', () => {
+    it('releases the lease so a successor takes over immediately', async () => {
+      const a = peer('node-a', { interval: 1000, ttl: 300 });
+      await a.start();
+      await a.stop();
+
+      expect(a.isLeader()).toBe(false);
+      expect(await adapter.getLeader('default')).toBeNull();
+      expect(await adapter.acquireLeadership('default', 'node-b', 30)).toBe(true);
+    });
+
+    it('does not release a lease held by another node', async () => {
+      await adapter.acquireLeadership('default', 'node-a', 300);
+
+      const b = peer('node-b', { interval: 1000, ttl: 300 });
+      await b.start();
+      expect(b.isLeader()).toBe(false);
+      await b.stop();
+
+      expect((await adapter.getLeader('default'))?.node).toBe('node-a');
+    });
+
+    it('ignores an election round that lands after stop', async () => {
+      let release!: (value: boolean) => void;
+      const slow = adapterWith(adapter, {
+        acquireLeadership: () => new Promise<boolean>(resolve => { release = resolve; })
+      });
+
+      const a = new Peer(slow, 'node-a', { interval: 1000, ttl: 30 }, silentLogger);
+      const starting = a.start();
+      await a.stop();
+
+      release(true);
+      await starting;
+
+      expect(a.isLeader()).toBe(false);
+    });
+  });
+
+  describe('telemetry', () => {
+    it('emits peer:elected on taking leadership', async () => {
+      const events: TelemetryPayload[] = [];
+      const unsubscribe = telemetry.on('peer:elected', p => events.push(p));
+
+      const a = peer('node-a', { interval: 1000, ttl: 30 });
+      await a.start();
+
+      expect(events).toHaveLength(1);
+      expect(events[0].node).toBe('node-a');
+
+      unsubscribe();
+    });
+
+    it('emits peer:lost when standing down', async () => {
+      const events: TelemetryPayload[] = [];
+      const unsubscribe = telemetry.on('peer:lost', p => events.push(p));
+
+      const a = peer('node-a', { interval: 1000, ttl: 30 });
+      await a.start();
+      await a.stop();
+
+      expect(events).toHaveLength(1);
+      expect(events[0].node).toBe('node-a');
+
+      unsubscribe();
+    });
+
+    it('does not re-emit peer:elected while it keeps leading', async () => {
+      const events: TelemetryPayload[] = [];
+      const unsubscribe = telemetry.on('peer:elected', p => events.push(p));
+
+      const a = peer('node-a', { interval: 1000, ttl: 30 });
+      await a.start();
+      await (a as unknown as { elect(): Promise<void> }).elect();
+      await (a as unknown as { elect(): Promise<void> }).elect();
+
+      expect(events).toHaveLength(1);
+
+      unsubscribe();
+    });
+  });
+
+  describe('failure handling', () => {
+    it('stands down when it cannot prove it still holds the lease', async () => {
+      const errors: TelemetryPayload[] = [];
+      const unsubscribeError = telemetry.on('peer:error', p => errors.push(p));
+      const lost: TelemetryPayload[] = [];
+      const unsubscribeLost = telemetry.on('peer:lost', p => lost.push(p));
+
+      let fail = false;
+      const flaky = adapterWith(adapter, {
+        acquireLeadership: async (name: string, node: string, ttl: number) => {
+          if (fail) throw new Error('connection reset');
+          return adapter.acquireLeadership(name, node, ttl);
+        }
+      });
+
+      const a = new Peer(flaky, 'node-a', { interval: 1000, ttl: 30 }, silentLogger);
+      await a.start();
+      expect(a.isLeader()).toBe(true);
+
+      fail = true;
+      await (a as unknown as { elect(): Promise<void> }).elect();
+
+      expect(a.isLeader()).toBe(false);
+      expect(errors).toHaveLength(1);
+      expect(lost).toHaveLength(1);
+
+      unsubscribeError();
+      unsubscribeLost();
+      await a.stop();
+    });
+
+    it('re-takes leadership once the database recovers', async () => {
+      let fail = true;
+      const flaky = adapterWith(adapter, {
+        acquireLeadership: async (name: string, node: string, ttl: number) => {
+          if (fail) throw new Error('connection reset');
+          return adapter.acquireLeadership(name, node, ttl);
+        }
+      });
+
+      const a = new Peer(flaky, 'node-a', { interval: 1000, ttl: 30 }, silentLogger);
+      await a.start();
+      expect(a.isLeader()).toBe(false);
+
+      fail = false;
+      await (a as unknown as { elect(): Promise<void> }).elect();
+
+      expect(a.isLeader()).toBe(true);
+      await a.stop();
+    });
+  });
+
+  describe('configuration', () => {
+    it('leads unconditionally when leadership is disabled', async () => {
+      const a = peer('node-a', false);
+      const b = peer('node-b', false);
+
+      await a.start();
+      await b.start();
+
+      expect(a.isLeader()).toBe(true);
+      expect(b.isLeader()).toBe(true);
+      expect(db.prepare('SELECT COUNT(*) AS n FROM izi_peers').get()).toEqual({ n: 0 });
+    });
+
+    it('leads unconditionally when the adapter cannot elect', async () => {
+      const unsupported = adapterWith(adapter, { acquireLeadership: undefined });
+
+      const a = new Peer(unsupported, 'node-a', { interval: 1000, ttl: 30 }, silentLogger);
+      await a.start();
+
+      expect(a.isEnabled).toBe(false);
+      expect(a.isLeader()).toBe(true);
+      await a.stop();
+    });
+
+    it('rejects an interval below a second', () => {
+      expect(() => new Peer(adapter, 'node-a', { interval: 500 }, silentLogger)).toThrow(
+        /interval must be at least 1000ms/
+      );
+    });
+
+    it('rejects a lease that expires faster than it is renewed', () => {
+      expect(() => new Peer(adapter, 'node-a', { interval: 20000, ttl: 30 }, silentLogger)).toThrow(
+        /must be at least twice/
+      );
+    });
+  });
+
+  describe('renewal loop', () => {
+    it('keeps the lease alive across ticks', async () => {
+      const a = peer('node-a', { interval: 1000, ttl: 30 });
+      await a.start();
+
+      const first = await adapter.getLeader('default');
+
+      const extended = await waitFor(
+        async () => {
+          const leader = await adapter.getLeader('default');
+          return leader && leader.expiresAt.getTime() > first!.expiresAt.getTime() ? leader : null;
+        },
+        { timeout: 5000, describe: 'the lease to be renewed' }
+      );
+
+      expect(extended?.node).toBe('node-a');
+      expect(a.isLeader()).toBe(true);
+    });
+  });
+});

--- a/tests/postgres-adapter.test.ts
+++ b/tests/postgres-adapter.test.ts
@@ -49,12 +49,12 @@ describePostgres('PostgresAdapter', () => {
   });
 
   afterAll(async () => {
-    await pool.query('DROP TABLE IF EXISTS izi_jobs, izi_nodes, izi_migrations');
+    await pool.query('DROP TABLE IF EXISTS izi_jobs, izi_nodes, izi_peers, izi_migrations');
     await pool.end();
   });
 
   beforeEach(async () => {
-    await pool.query('TRUNCATE izi_jobs, izi_nodes');
+    await pool.query('TRUNCATE izi_jobs, izi_nodes, izi_peers');
   });
 
   it('applies every migration', async () => {
@@ -808,5 +808,96 @@ describePostgres('PostgresAdapter', () => {
         await reconnectPool.end();
       }
     }, 20000);
+  });
+
+  describe('leadership', () => {
+    it('acquires a vacant lease', async () => {
+      expect(await adapter.acquireLeadership('default', 'node-a', 30)).toBe(true);
+      expect((await adapter.getLeader('default'))?.node).toBe('node-a');
+    });
+
+    it('renews its own lease without resetting when it was elected', async () => {
+      await adapter.acquireLeadership('default', 'node-a', 30);
+      const first = await adapter.getLeader('default');
+
+      await new Promise(resolve => setTimeout(resolve, 20));
+      expect(await adapter.acquireLeadership('default', 'node-a', 30)).toBe(true);
+      const renewed = await adapter.getLeader('default');
+
+      expect(renewed?.electedAt.getTime()).toBe(first?.electedAt.getTime());
+      expect(renewed!.expiresAt.getTime()).toBeGreaterThan(first!.expiresAt.getTime());
+    });
+
+    it('refuses a lease another node still holds', async () => {
+      await adapter.acquireLeadership('default', 'node-a', 30);
+      expect(await adapter.acquireLeadership('default', 'node-b', 30)).toBe(false);
+      expect((await adapter.getLeader('default'))?.node).toBe('node-a');
+    });
+
+    it('takes over an expired lease and records the handover', async () => {
+      await adapter.acquireLeadership('default', 'node-a', 30);
+      const before = await adapter.getLeader('default');
+      await pool.query("UPDATE izi_peers SET expires_at = NOW() - INTERVAL '1 minute'");
+
+      expect(await adapter.acquireLeadership('default', 'node-b', 30)).toBe(true);
+      const after = await adapter.getLeader('default');
+
+      expect(after?.node).toBe('node-b');
+      expect(after!.electedAt.getTime()).toBeGreaterThan(before!.electedAt.getTime() - 1);
+    });
+
+    it('reports no leader once the lease lapses', async () => {
+      await adapter.acquireLeadership('default', 'node-a', 30);
+      await pool.query("UPDATE izi_peers SET expires_at = NOW() - INTERVAL '1 minute'");
+
+      expect(await adapter.getLeader('default')).toBeNull();
+    });
+
+    it('releases the lease it holds', async () => {
+      await adapter.acquireLeadership('default', 'node-a', 300);
+      await adapter.releaseLeadership('default', 'node-a');
+
+      expect(await adapter.getLeader('default')).toBeNull();
+      expect(await adapter.acquireLeadership('default', 'node-b', 30)).toBe(true);
+    });
+
+    it('will not release a lease held by another node', async () => {
+      await adapter.acquireLeadership('default', 'node-a', 300);
+      await adapter.releaseLeadership('default', 'node-b');
+
+      expect((await adapter.getLeader('default'))?.node).toBe('node-a');
+    });
+
+    it('keeps separate scopes independent', async () => {
+      expect(await adapter.acquireLeadership('app', 'node-a', 30)).toBe(true);
+      expect(await adapter.acquireLeadership('worker', 'node-b', 30)).toBe(true);
+
+      expect((await adapter.getLeader('app'))?.node).toBe('node-a');
+      expect((await adapter.getLeader('worker'))?.node).toBe('node-b');
+    });
+
+    // The point of the whole exercise: without the database arbitrating, a
+    // cluster booting at once produces several nodes all convinced they lead.
+    it('elects exactly one node when twenty race for a vacant lease', async () => {
+      const results = await Promise.all(
+        Array.from({ length: 20 }, (_, i) => adapter.acquireLeadership('default', `node-${i}`, 30))
+      );
+
+      expect(results.filter(Boolean)).toHaveLength(1);
+      const leader = await adapter.getLeader('default');
+      expect(leader).not.toBeNull();
+    });
+
+    it('elects exactly one node when twenty race for an expired lease', async () => {
+      await adapter.acquireLeadership('default', 'incumbent', 30);
+      await pool.query("UPDATE izi_peers SET expires_at = NOW() - INTERVAL '1 minute'");
+
+      const results = await Promise.all(
+        Array.from({ length: 20 }, (_, i) => adapter.acquireLeadership('default', `node-${i}`, 30))
+      );
+
+      expect(results.filter(Boolean)).toHaveLength(1);
+      expect((await adapter.getLeader('default'))?.node).not.toBe('incumbent');
+    });
   });
 });


### PR DESCRIPTION
Closes #26.

## The problem

`IziQueue.start()` started the stage timer and every plugin unconditionally on every instance. With N nodes that is:

- N × `stageJobs()` per second, all issuing `UPDATE izi_jobs SET state='available' WHERE state IN ('scheduled','retryable')` against the same rows
- N × `pruneJobs()` — N concurrent large `DELETE`s over the same range
- N × `rescueStuckJobs()`

Wasted work at small scale; row-lock contention and deadlock risk on the hottest table in the system at larger ones.

## The fix

One node per cluster is elected leader. Staging and the built-in plugins are gated on it.

The lease lives in a new `izi_peers` table, one row per scope (`name`, `node`, `elected_at`, `expires_at`). Every node runs the same renew-or-take-over `UPDATE` on `interval`; its `WHERE` matches only for the incumbent or, once the lease lapses, whoever wins the race. The database arbitrates, exactly as it already does for job state transitions.

```typescript
const queue = new IziQueue({
  database: adapter,
  queues: { default: 10 },
  leadership: { name: 'default', interval: 10000, ttl: 30 },  // all optional
});

queue.isLeader();                                  // boolean
await queue.getLeader();                           // { node, electedAt, expiresAt } | null
queue.getQueueStatus('default')?.isLeader;
queue.on('peer:elected', ({ node }) => { ... });   // also peer:lost, peer:error
```

## The MySQL bug this turned up

The first implementation decided the claim from its row count. Against a real MySQL server, **twenty nodes racing for one vacant lease all came away believing they led.**

mysql2 negotiates `CLIENT_FOUND_ROWS` by default, so MySQL reports *matched* rather than *changed* rows — a losing `INSERT ... ON DUPLICATE KEY UPDATE` is then indistinguishable from a winning insert. SQLite and PostgreSQL passed clean throughout; this only ever reproduced against MySQL.

`acquireLeadership` now settles the claim by reading the row back, which is unambiguous on every dialect and driver. `BaseAdapter.electLeader` holds the sequence once so the three adapters cannot drift on the one operation whose entire purpose is that all nodes agree.

Second MySQL-only trap, handled in the SQL: MySQL evaluates a multi-column `SET` left to right and lets later expressions see earlier assignments, so `renewLeadership` computes `elected_at` *before* overwriting `node` — otherwise every renewal would look like a handover.

## What does not change

- Followers keep polling, fetching and executing jobs exactly as before. Only cluster-wide maintenance is gated.
- `drain()` stages regardless of leadership — it is an explicit request from the caller, and gating it would make it silently do nothing on a follower.
- Single-node deployments: the only candidate always wins.
- `leadership: false` restores the old behavior, as does any custom adapter that does not implement `acquireLeadership` (it cannot elect anyone, so every node leads rather than the cluster going leaderless).

## Failure behaviour

- A leader that stops renewing (crash, partition, a process wedged past the TTL) is replaced `ttl` seconds after its last successful renewal. That is the worst-case pause in staging, which is why the default TTL is 30s rather than the 60s used for node liveness.
- A clean shutdown releases the lease so a successor takes over immediately.
- An election round that cannot reach the database **fails closed**: a lease this node cannot prove it holds is one another node may already have taken. It emits `peer:error` and stands down until a round succeeds.
- `ttl` must be at least twice `interval`, or a single slow renewal could hand leadership away from a healthy node. A configuration that violates this is rejected in the constructor, alongside plugin validation.

Leadership is advisory, not a fence. A leader stalled past its TTL can still believe it leads while a successor is elected — so everything gated on it is idempotent, and a brief overlap costs at most the duplicated work that used to happen unconditionally.

## Migrations

PostgreSQL v8, MySQL v7, SQLite v7 create `izi_peers`. They run automatically on `migrate()`.

## Breaking

`getQueueStatus`/`getAllQueueStatus` gained an `isLeader` field. Code comparing the returned object with `toEqual` needs updating; property access is unaffected.

## Testing

578 tests pass against **PostgreSQL 18, MySQL 8 and SQLite** together. New coverage: `tests/peer.test.ts` (22), `tests/leadership.test.ts` (11), plus per-adapter leadership suites on Postgres and MySQL including the twenty-way races for a vacant and an expired lease.

https://claude.ai/code/session_01QTMkU47YPxu1D3Y24SNY3d