### PR TITLE
feat(plugins): cron plugin for periodic jobs (#27)

### DIFF
--- a/.claude/skills/creating-plugins.md
+++ b/.claude/skills/creating-plugins.md
@@ -39,13 +39,19 @@ export class MyPlugin extends BasePlugin {
   private async tick(): Promise<void> {
     if (!this.context || !this.running) return;
 
+    // Cluster-wide work belongs behind the leader gate: without it, an N-node
+    // deployment does this N times over against the same rows.
+    if (!this.isLeader()) return;
+
     try {
       // Your periodic logic here
       // Access database via this.context.database
+      // Enqueue jobs via this.context.insert (never database.insertJob --
+      // that skips worker defaults, uniqueness and the queue wake-up)
       // Access node ID via this.context.node
       // Access queue names via this.context.queues
     } catch (error) {
-      console.error(`[${this.name}] Error:`, error);
+      this.log.error(`${this.name} tick failed`, { error });
     }
   }
 }
@@ -60,8 +66,22 @@ interface PluginContext {
   database: DatabaseAdapter;  // Database operations
   node: string;               // Current node identifier
   queues: string[];           // List of queue names
+  nodeTtl?: number;           // Seconds before a silent node is presumed dead
+  isLeader?: () => boolean;   // Whether this node holds the leadership lease
+  insert?: (worker, options) => Promise<{ job: Job; conflict: boolean }>;
+  logger?: Logger;            // The owning queue's logger
 }
 ```
+
+The optional members are optional only so a hand-built context still
+type-checks; `IziQueue` always supplies all of them. Read them through
+`BasePlugin`'s helpers rather than directly: `this.isLeader()` treats an absent
+one as leading (so a plugin never quietly stops working because a harness
+forgot it), and `this.log` falls back to a no-op logger.
+
+A plugin that genuinely cannot work without one — the cron plugin needs
+`insert` — should say so by throwing from `onStart` with a message naming what
+is missing.
 
 ## Built-in Plugin Examples
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,11 +26,35 @@ While the version is below 1.0.0, breaking changes are released as minor version
   still stages regardless of leadership. Set `leadership: false` for the old
   behavior; adapters that do not implement `acquireLeadership` get it
   automatically. ([#26])
+- **Cron plugin.** `CronPlugin({ crontab, timezone?, interval?,
+  maxCatchUpMinutes? })` runs jobs on a schedule, the equivalent of
+  `Oban.Plugins.Cron`. Standard five-field expressions with ranges, lists,
+  steps and names, plus the `@hourly`/`@daily`/`@midnight`/`@weekly`/
+  `@monthly`/`@yearly`/`@annually` aliases; per-entry `args`, `queue`,
+  `priority`, `maxAttempts`, `tags` and IANA `timezone`. Evaluation is
+  leader-only *and* every insert is unique on `(entry, minute)`, so a
+  leadership handover cannot duplicate a run and a fast-finishing job cannot
+  be reinserted by the next node to evaluate that minute. A tick delayed past
+  its minute catches up on what it skipped, bounded by `maxCatchUpMinutes`.
+  Invalid expressions and timezones are rejected when the queue is
+  constructed, naming the entry at fault. The parser is also exported on its
+  own as `parseCron`/`matchesCron`/`fieldsInTimezone`. No new dependencies.
+  ([#27])
+- **`unique.scope`**, an opaque discriminator folded into the uniqueness
+  digest, so two otherwise identical jobs are only "the same" within the same
+  scope -- a tenant, a billing period, a scheduled minute. Exact where a
+  `period` window is approximate. Digests computed without a scope are
+  unchanged, so unique jobs already in the database keep deduplicating.
 - `DatabaseAdapter.acquireLeadership`, `releaseLeadership` and `getLeader`,
   all optional so third-party adapters keep compiling.
 - `PluginContext.isLeader` and `BasePlugin.isLeader()`, for gating a custom
   plugin's cluster-wide work the way `LifelinePlugin` and `PrunerPlugin` now
   gate theirs.
+- `PluginContext.insert`, so a plugin can enqueue jobs through the owning
+  queue's own insert path -- worker defaults, uniqueness and queue wake-up
+  included -- rather than reaching past it to `database.insertJob`.
+- `PluginContext.logger` and `BasePlugin.log`, so a plugin reports through the
+  same sink as the rest of izi-queue instead of `console`.
 
 ### Changed
 
@@ -433,6 +457,7 @@ production. Anyone running 0.3.0 or earlier should upgrade.
 [#34]: https://github.com/iagocavalcante/izi-queue/issues/34
 [#40]: https://github.com/iagocavalcante/izi-queue/issues/40
 [#26]: https://github.com/iagocavalcante/izi-queue/issues/26
+[#27]: https://github.com/iagocavalcante/izi-queue/issues/27
 [0.4.0]: https://github.com/iagocavalcante/izi-queue/compare/v0.3.0...v0.4.0
 [0.4.1]: https://github.com/iagocavalcante/izi-queue/compare/v0.4.0...v0.4.1
 [0.5.0]: https://github.com/iagocavalcante/izi-queue/compare/v0.4.1...v0.5.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,9 @@ src/
     ├── index.ts
     ├── plugin.ts         # BasePlugin abstract class
     ├── lifeline.ts       # Rescue stuck jobs
-    └── pruner.ts         # Cleanup old jobs
+    ├── pruner.ts         # Cleanup old jobs
+    ├── cron.ts           # Scheduled jobs
+    └── cron-expression.ts # Cron parsing & timezone evaluation
 
 tests/
 ├── *.test.ts             # Unit tests
@@ -561,8 +563,26 @@ Jobs ordered by: `priority ASC, scheduled_at ASC`
 1. Create `src/plugins/myplugin.ts`
 2. Extend `BasePlugin`
 3. Implement `onStart()` with your interval logic
-4. Export from `src/plugins/index.ts`
-5. Add tests in `tests/plugins.test.ts`
+4. Gate any cluster-wide work on `this.isLeader()`
+5. Enqueue through `this.context.insert`, never `database.insertJob` --
+   the latter skips worker defaults, uniqueness and the queue wake-up
+6. Export from `src/plugins/index.ts`
+7. Add tests in `tests/plugins.test.ts`
+
+### Scheduling correctness (cron)
+
+Two mechanisms, and both are load-bearing:
+
+- **Leader-only evaluation** stops N nodes from evaluating the crontab N times.
+- **A unique key scoped to `(entry, minute)`** is what makes it *correct*, since
+  a leadership handover can legitimately have two nodes evaluate the same
+  minute. It spans every job state and uses no period window: a cron job that
+  completes in 10ms would otherwise be reinserted by the next node to look at
+  that minute, and a time-window guard cannot separate two runs a minute apart
+  that land milliseconds apart in wall-clock terms.
+
+Test schedules with `jest.useFakeTimers({ now })` and `jest.setSystemTime`.
+Stubbing `Date.now` directly hangs the run -- jest's own timing reads it.
 
 ### Adding a Worker Feature
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A minimal, reliable, database-backed job queue for Node.js inspired by [Oban](ht
   - [Unique Jobs](#unique-jobs)
   - [Worker Isolation](#worker-isolation)
   - [Plugins](#plugins)
+  - [Cron / Periodic Jobs](#cron--periodic-jobs)
   - [Leader Election](#leader-election)
   - [Telemetry](#telemetry)
 - [Managing Jobs](#managing-jobs)
@@ -208,6 +209,7 @@ await queue.insert('send_digest', {
     keys: ['userId'],           // Or compare only these keys within args
     period: 3600,               // Only one per hour (in seconds), or 'infinity'
     states: ['scheduled', 'available', 'executing'],
+    scope: 'tenant-42',         // Fold an extra discriminator into the digest
   },
 });
 ```
@@ -230,6 +232,11 @@ one job. Two notes on the semantics:
   enqueued.
 - **Argument order does not matter.** `{ a: 1, b: 2 }` and `{ b: 2, a: 1 }` are
   the same job on every adapter.
+- **`scope` keys uniqueness on something that is not part of the job** — a
+  tenant, a billing period, a scheduled minute. It is exact where a `period`
+  window is approximate: two inserts sharing a scope always collapse, and two
+  in different scopes never do, however close together they land. The
+  [cron plugin](#cron--periodic-jobs) uses it to key each run on its minute.
 
 ### Worker Isolation
 
@@ -301,9 +308,68 @@ backlog takes to scan. Staging (moving due `scheduled`/`retryable` jobs to
 `available`, which runs automatically -- no plugin needed) batches the same
 way; tune it with `stageBatchSize` on `IziQueue`'s config.
 
-Both plugins run on the elected leader only, so a five-node deployment prunes
-and rescues once per cycle rather than five times over the same rows. See
-[Leader Election](#leader-election).
+All three built-in plugins run on the elected leader only, so a five-node
+deployment prunes, rescues and evaluates the crontab once per cycle rather than
+five times over the same rows. See [Leader Election](#leader-election).
+
+### Cron / Periodic Jobs
+
+Run jobs on a schedule, the equivalent of `Oban.Plugins.Cron`:
+
+```typescript
+import { CronPlugin } from 'izi-queue';
+
+const queue = new IziQueue({
+  database: adapter,
+  queues: { default: 10, reports: 2 },
+  plugins: [
+    new CronPlugin({
+      timezone: 'America/Sao_Paulo',   // default for entries below; defaults to UTC
+      crontab: [
+        { expression: '0 * * * *', worker: 'HourlyWorker' },
+        { expression: '@daily', worker: 'DailyDigest', args: { scope: 'all' } },
+        { expression: '*/15 9-17 * * 1-5', worker: 'PollWorker', queue: 'reports' },
+        { expression: '0 3 * * *', worker: 'Backup', timezone: 'UTC' },
+      ],
+    }),
+  ],
+});
+```
+
+Standard five-field expressions (`minute hour day-of-month month day-of-week`)
+with ranges, lists, steps and names — `*/15`, `9-17`, `0,30`, `mon-fri`,
+`jan,jul`, `5/10` — plus the `@hourly`, `@daily`, `@midnight`, `@weekly`,
+`@monthly`, `@yearly` and `@annually` aliases. `7` is accepted as a second
+spelling of Sunday. Cron's day rule applies: when *both* day fields are
+restricted, a date matches if *either* does, so `0 0 13 * 5` means "the 13th,
+and every Friday".
+
+Each entry takes `args`, `queue`, `priority`, `maxAttempts`, `tags` and its own
+`timezone`; anything omitted falls back to the worker's own defaults. Inserted
+jobs carry `meta: { cron: true, cronExpression, cronMinute }`, so they are easy
+to pick out of `listJobs`.
+
+An invalid expression or timezone is rejected when the queue is constructed,
+naming the crontab entry at fault — a typo cannot become a job that silently
+never runs.
+
+**Exactly-once, per minute.** Evaluation is leader-only, and every insert is
+also unique on `(entry, minute)`. Both matter: leadership keeps the cluster
+from evaluating the crontab N times over, and the unique key is what makes the
+result correct rather than merely usually correct, since a leadership handover
+can legitimately have two nodes evaluate the same minute. The guard spans every
+job state, so a cron job that finishes in milliseconds is not reinserted by the
+next node to look at that minute.
+
+A tick delayed past its minute — a stalled event loop, a long GC pause — catches
+up on what it skipped rather than dropping those runs, bounded by
+`maxCatchUpMinutes` (default 5, maximum 60). A node that has just taken over
+leadership starts from the minute it was elected in instead of replaying
+everything the previous leader was handling perfectly well.
+
+Timezones are IANA names, resolved through `Intl`, so DST is handled the way
+cron conventionally handles it: a local hour that a spring-forward removes is
+skipped, and one that a fall-back repeats matches twice.
 
 ### Leader Election
 

--- a/src/core/izi-queue.ts
+++ b/src/core/izi-queue.ts
@@ -229,7 +229,9 @@ export class IziQueue {
       node: this.config.node,
       queues: Array.from(this.queues.keys()),
       nodeTtl: this.nodeTtl,
-      isLeader: () => this.peer.isLeader()
+      isLeader: () => this.peer.isLeader(),
+      insert: (worker, options) => this.insertWithResult(worker, options),
+      logger: this.config.logger
     };
 
     for (const plugin of this.config.plugins) {

--- a/src/core/unique.ts
+++ b/src/core/unique.ts
@@ -53,6 +53,12 @@ export function computeUniqueKey<T = Record<string, unknown>>(
   const fields = options.fields ?? DEFAULT_UNIQUE_FIELDS;
   const parts: Array<[string, unknown]> = [];
 
+  // Pushed only when given, so digests computed without a scope are byte-for-
+  // byte what they were before scopes existed.
+  if (options.scope !== undefined) {
+    parts.push(['scope', options.scope]);
+  }
+
   if (fields.includes('worker')) {
     parts.push(['worker', job.worker]);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,11 +71,20 @@ export {
   createLifelinePlugin,
   PrunerPlugin,
   createPrunerPlugin,
+  CronPlugin,
+  createCronPlugin,
+  parseCron,
+  matchesCron,
+  fieldsInTimezone,
   type Plugin,
   type PluginConfig,
   type PluginContext,
   type LifelineConfig,
-  type PrunerConfig
+  type PrunerConfig,
+  type CronConfig,
+  type CronEntry,
+  type CronSchedule,
+  type CronFields
 } from './plugins/index.js';
 
 // Types

--- a/src/plugins/cron-expression.ts
+++ b/src/plugins/cron-expression.ts
@@ -1,0 +1,271 @@
+/**
+ * Standard five-field cron parsing, plus the `@hourly`/`@daily`/... aliases.
+ *
+ * Deliberately hand-rolled rather than pulled in as a dependency: izi-queue
+ * has no runtime dependencies at all, and the grammar below is the whole of
+ * what a scheduler needs. Timezone handling is `Intl`'s, which is where the
+ * genuinely hard part (DST) already lives.
+ */
+
+/** A parsed expression: which values each field admits. */
+export interface CronSchedule {
+  /** The expression this was parsed from, normalised. */
+  expression: string;
+  minutes: ReadonlySet<number>;
+  hours: ReadonlySet<number>;
+  daysOfMonth: ReadonlySet<number>;
+  months: ReadonlySet<number>;
+  daysOfWeek: ReadonlySet<number>;
+  /**
+   * Whether each day field was narrowed from `*`. Cron's oddest rule: when
+   * *both* day-of-month and day-of-week are restricted, a date matches if
+   * *either* does -- `0 0 13 * 5` is "the 13th, and every Friday", not "Friday
+   * the 13th". When only one is restricted it must match.
+   */
+  dayOfMonthRestricted: boolean;
+  dayOfWeekRestricted: boolean;
+}
+
+/** The calendar fields of an instant, in some timezone. */
+export interface CronFields {
+  minute: number;
+  hour: number;
+  dayOfMonth: number;
+  month: number;
+  dayOfWeek: number;
+}
+
+const MONTH_NAMES: Record<string, number> = {
+  jan: 1, feb: 2, mar: 3, apr: 4, may: 5, jun: 6,
+  jul: 7, aug: 8, sep: 9, oct: 10, nov: 11, dec: 12
+};
+
+const DAY_NAMES: Record<string, number> = {
+  sun: 0, mon: 1, tue: 2, wed: 3, thu: 4, fri: 5, sat: 6
+};
+
+const ALIASES: Record<string, string> = {
+  '@yearly': '0 0 1 1 *',
+  '@annually': '0 0 1 1 *',
+  '@monthly': '0 0 1 * *',
+  '@weekly': '0 0 * * 0',
+  '@daily': '0 0 * * *',
+  '@midnight': '0 0 * * *',
+  '@hourly': '0 * * * *'
+};
+
+interface FieldSpec {
+  label: string;
+  min: number;
+  max: number;
+  names?: Record<string, number>;
+  /** Maps an out-of-range but legal alias onto its canonical value (Sunday as 7). */
+  normalise?: (value: number) => number;
+}
+
+const FIELDS: FieldSpec[] = [
+  { label: 'minute', min: 0, max: 59 },
+  { label: 'hour', min: 0, max: 23 },
+  { label: 'day-of-month', min: 1, max: 31 },
+  { label: 'month', min: 1, max: 12, names: MONTH_NAMES },
+  // 7 is a second spelling of Sunday, accepted by every cron implementation.
+  { label: 'day-of-week', min: 0, max: 7, names: DAY_NAMES, normalise: value => value % 7 }
+];
+
+function fail(expression: string, reason: string): never {
+  throw new Error(`izi-queue: invalid cron expression "${expression}" -- ${reason}`);
+}
+
+function parseValue(token: string, spec: FieldSpec, expression: string): number {
+  const named = spec.names?.[token.toLowerCase()];
+  if (named !== undefined) return named;
+
+  if (!/^\d+$/.test(token)) {
+    fail(expression, `"${token}" is not a valid ${spec.label}`);
+  }
+
+  const value = Number(token);
+  if (value < spec.min || value > spec.max) {
+    fail(expression, `${spec.label} ${value} is outside ${spec.min}-${spec.max}`);
+  }
+
+  return value;
+}
+
+function parseStep(token: string, spec: FieldSpec, expression: string): number {
+  if (!/^\d+$/.test(token) || Number(token) === 0) {
+    fail(expression, `"${token}" is not a valid ${spec.label} step`);
+  }
+  return Number(token);
+}
+
+/** One comma-separated term: `*`, `a`, `a-b`, and any of those with `/step`. */
+function parseTerm(term: string, spec: FieldSpec, expression: string, into: Set<number>): void {
+  const [range, stepToken, ...extra] = term.split('/');
+  if (extra.length > 0) {
+    fail(expression, `"${term}" has more than one step in a ${spec.label}`);
+  }
+
+  const step = stepToken === undefined ? 1 : parseStep(stepToken, spec, expression);
+
+  let from: number;
+  let to: number;
+
+  if (range === '*') {
+    from = spec.min;
+    to = spec.max;
+  } else if (range.includes('-')) {
+    const [startToken, endToken, ...rest] = range.split('-');
+    if (rest.length > 0) {
+      fail(expression, `"${term}" is not a valid ${spec.label} range`);
+    }
+    from = parseValue(startToken, spec, expression);
+    to = parseValue(endToken, spec, expression);
+    if (to < from) {
+      fail(expression, `${spec.label} range ${range} runs backwards`);
+    }
+  } else {
+    from = parseValue(range, spec, expression);
+    // `a/n` means "from a to the end of the field, every n" -- a bare `a`
+    // with no step is just itself.
+    to = stepToken === undefined ? from : spec.max;
+  }
+
+  for (let value = from; value <= to; value += step) {
+    into.add(spec.normalise ? spec.normalise(value) : value);
+  }
+}
+
+function parseField(field: string, spec: FieldSpec, expression: string): Set<number> {
+  const values = new Set<number>();
+
+  for (const term of field.split(',')) {
+    if (term === '') {
+      fail(expression, `${spec.label} has an empty term`);
+    }
+    parseTerm(term, spec, expression, values);
+  }
+
+  return values;
+}
+
+/**
+ * Parses a five-field expression or a supported alias. Throws with the field
+ * and token at fault, so a typo in a crontab surfaces at configuration time
+ * rather than as a job that silently never runs.
+ */
+export function parseCron(expression: string): CronSchedule {
+  const trimmed = expression.trim();
+
+  if (trimmed === '') {
+    fail(expression, 'it is empty');
+  }
+
+  if (trimmed.startsWith('@')) {
+    const alias = ALIASES[trimmed.toLowerCase()];
+    if (!alias) {
+      fail(
+        expression,
+        `"${trimmed}" is not a supported alias (${Object.keys(ALIASES).join(', ')})`
+      );
+    }
+    return { ...parseCron(alias), expression: trimmed.toLowerCase() };
+  }
+
+  const fields = trimmed.split(/\s+/);
+  if (fields.length !== 5) {
+    fail(
+      expression,
+      `expected 5 fields (minute hour day-of-month month day-of-week), got ${fields.length}`
+    );
+  }
+
+  const [minutes, hours, daysOfMonth, months, daysOfWeek] = fields.map((field, i) =>
+    parseField(field, FIELDS[i], expression)
+  );
+
+  return {
+    expression: fields.join(' '),
+    minutes,
+    hours,
+    daysOfMonth,
+    months,
+    daysOfWeek,
+    dayOfMonthRestricted: fields[2] !== '*',
+    dayOfWeekRestricted: fields[4] !== '*'
+  };
+}
+
+/** Whether `fields` -- an instant's calendar values -- satisfy `schedule`. */
+export function matchesCron(schedule: CronSchedule, fields: CronFields): boolean {
+  if (!schedule.minutes.has(fields.minute)) return false;
+  if (!schedule.hours.has(fields.hour)) return false;
+  if (!schedule.months.has(fields.month)) return false;
+
+  const dayOfMonth = schedule.daysOfMonth.has(fields.dayOfMonth);
+  const dayOfWeek = schedule.daysOfWeek.has(fields.dayOfWeek);
+
+  if (schedule.dayOfMonthRestricted && schedule.dayOfWeekRestricted) {
+    return dayOfMonth || dayOfWeek;
+  }
+
+  return dayOfMonth && dayOfWeek;
+}
+
+const WEEKDAY_INDEX: Record<string, number> = {
+  Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6
+};
+
+const formatters = new Map<string, Intl.DateTimeFormat>();
+
+function formatterFor(timezone: string): Intl.DateTimeFormat {
+  const cached = formatters.get(timezone);
+  if (cached) return cached;
+
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    hourCycle: 'h23',
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+    weekday: 'short'
+  });
+
+  formatters.set(timezone, formatter);
+  return formatter;
+}
+
+/**
+ * The calendar fields of `instant` as seen in `timezone`.
+ *
+ * `Intl` is doing the work deliberately: it carries the IANA database, so DST
+ * transitions and historical offset changes are already right. A schedule is
+ * evaluated by asking "does this instant's local time match", which gives the
+ * conventional cron behaviour on both transitions -- a local hour that does
+ * not occur is skipped, and one that occurs twice matches twice (the second
+ * being deduplicated by the cron plugin's per-minute unique key).
+ */
+export function fieldsInTimezone(instant: Date, timezone: string): CronFields {
+  const parts = formatterFor(timezone).formatToParts(instant);
+  const lookup = (type: Intl.DateTimeFormatPartTypes): string =>
+    parts.find(part => part.type === type)?.value ?? '';
+
+  return {
+    minute: Number(lookup('minute')),
+    hour: Number(lookup('hour')),
+    dayOfMonth: Number(lookup('day')),
+    month: Number(lookup('month')),
+    dayOfWeek: WEEKDAY_INDEX[lookup('weekday')] ?? 0
+  };
+}
+
+/** Throws unless `timezone` is an IANA zone this runtime knows. */
+export function assertTimezone(timezone: string): void {
+  try {
+    formatterFor(timezone);
+  } catch {
+    throw new Error(`izi-queue: unknown timezone "${timezone}"`);
+  }
+}

--- a/src/plugins/cron.ts
+++ b/src/plugins/cron.ts
@@ -1,0 +1,288 @@
+import { BasePlugin } from './plugin.js';
+import { telemetry } from '../core/telemetry.js';
+import { hasWorker } from '../core/worker.js';
+import { JOB_STATES } from '../database/adapter.js';
+import {
+  assertTimezone,
+  fieldsInTimezone,
+  matchesCron,
+  parseCron,
+  type CronSchedule
+} from './cron-expression.js';
+import type { WorkerDefinition } from '../types.js';
+
+/** One line of the crontab. */
+export interface CronEntry<T = Record<string, unknown>> {
+  /** A five-field cron expression, or one of `@hourly`/`@daily`/`@midnight`/`@weekly`/`@monthly`/`@yearly`/`@annually`. */
+  expression: string;
+  /** The worker to run, by name or by definition. */
+  worker: string | WorkerDefinition<T>;
+  /** Args for every run. Defaults to `{}`. */
+  args?: T;
+  /** Overrides the worker's queue. */
+  queue?: string;
+  /** Overrides the worker's priority. */
+  priority?: number;
+  /** Overrides the worker's `maxAttempts`. */
+  maxAttempts?: number;
+  tags?: string[];
+  /** IANA timezone the expression is evaluated in. Defaults to the plugin's. */
+  timezone?: string;
+}
+
+export interface CronConfig {
+  crontab: CronEntry[];
+  /**
+   * How often the schedule is evaluated, in ms. Defaults to 60000 -- cron's
+   * granularity is a minute, and evaluating more often is harmless (a minute
+   * is only ever evaluated once) but buys nothing.
+   */
+  interval?: number;
+  /** Default timezone for entries that do not set one. Defaults to `'UTC'`. */
+  timezone?: string;
+  /**
+   * How many missed minutes a single evaluation will catch up on, at most.
+   *
+   * A tick delayed past its minute -- a stalled event loop, a long GC pause --
+   * would otherwise drop that minute's runs on the floor. Catching up is safe
+   * because every insert is keyed on the minute it belongs to, so a minute
+   * another node already ran collapses into that job rather than duplicating
+   * it. Bounded so that a long stall cannot produce an unbounded burst, and
+   * capped at 60 so it can never reach past the pruner's default retention,
+   * beyond which the deduplicating rows no longer exist.
+   *
+   * Defaults to 5. Set to 0 to only ever evaluate the current minute.
+   */
+  maxCatchUpMinutes?: number;
+}
+
+const MINUTE_MS = 60_000;
+const MAX_CATCH_UP_MINUTES = 60;
+
+/** The UTC minute an instant falls in, as `2026-08-23T14:05Z`. */
+function minuteKey(instant: number): string {
+  return `${new Date(Math.floor(instant / MINUTE_MS) * MINUTE_MS).toISOString().slice(0, 16)}Z`;
+}
+
+interface CompiledEntry {
+  entry: CronEntry;
+  schedule: CronSchedule;
+  timezone: string;
+  worker: string;
+}
+
+/**
+ * Runs jobs on a schedule, the equivalent of `Oban.Plugins.Cron`.
+ *
+ * Evaluation is per whole minute and leader-only, and every insert is unique
+ * on `(entry, minute)` -- belt and braces, in that order. Leadership keeps the
+ * cluster from evaluating the crontab N times over; the unique key is what
+ * makes the result *correct* rather than merely usually correct, since a
+ * leadership handover can legitimately have two nodes evaluate the same minute.
+ * Neither mechanism alone is enough: without the key, a handover duplicates
+ * runs; without leadership, every node pays for an insert that all but one of
+ * them will lose.
+ */
+export class CronPlugin extends BasePlugin {
+  readonly name = 'cron';
+  private config: Required<CronConfig>;
+  private compiled: CompiledEntry[] = [];
+  private compileErrors: string[] = [];
+  /** The last minute fully evaluated, as an epoch-ms minute boundary. */
+  private lastEvaluated: number | null = null;
+
+  constructor(config: CronConfig) {
+    super();
+    this.config = {
+      crontab: config.crontab ?? [],
+      interval: config.interval ?? 60_000,
+      timezone: config.timezone ?? 'UTC',
+      maxCatchUpMinutes: config.maxCatchUpMinutes ?? 5
+    };
+
+    this.compile();
+  }
+
+  /**
+   * Parses every entry up front so a typo surfaces through `validate()` at
+   * construction -- where `IziQueue` refuses to start -- rather than as a job
+   * that quietly never runs.
+   */
+  private compile(): void {
+    this.config.crontab.forEach((entry, index) => {
+      const label = `crontab[${index}]`;
+      const worker = typeof entry.worker === 'string' ? entry.worker : entry.worker?.name;
+
+      if (!worker) {
+        this.compileErrors.push(`${label} has no worker`);
+        return;
+      }
+
+      const timezone = entry.timezone ?? this.config.timezone;
+
+      try {
+        assertTimezone(timezone);
+      } catch (error) {
+        this.compileErrors.push(`${label}: ${(error as Error).message}`);
+        return;
+      }
+
+      try {
+        this.compiled.push({
+          entry,
+          schedule: parseCron(entry.expression),
+          timezone,
+          worker
+        });
+      } catch (error) {
+        this.compileErrors.push(`${label}: ${(error as Error).message}`);
+      }
+    });
+  }
+
+  validate(): string[] {
+    const errors = [...this.compileErrors];
+
+    if (this.config.interval < 1000) {
+      errors.push('Cron interval must be at least 1000ms');
+    }
+
+    // A gap longer than a minute between evaluations relies entirely on
+    // catch-up to not drop minutes, which is a worse default than simply
+    // ticking often enough.
+    if (this.config.interval > 60_000) {
+      errors.push('Cron interval must be at most 60000ms, or whole minutes would be skipped');
+    }
+
+    if (
+      !Number.isInteger(this.config.maxCatchUpMinutes) ||
+      this.config.maxCatchUpMinutes < 0 ||
+      this.config.maxCatchUpMinutes > MAX_CATCH_UP_MINUTES
+    ) {
+      errors.push(`Cron maxCatchUpMinutes must be an integer between 0 and ${MAX_CATCH_UP_MINUTES}`);
+    }
+
+    return errors;
+  }
+
+  protected async onStart(): Promise<void> {
+    if (!this.context) return;
+
+    if (!this.context.insert) {
+      throw new Error(
+        'izi-queue: the cron plugin needs a plugin context that can insert jobs. ' +
+          'IziQueue supplies one; a hand-built context must too.'
+      );
+    }
+
+    // Registration normally happens before start, so an unknown worker here is
+    // a real mistake -- but it is not fatal, since `register` may legitimately
+    // come later.
+    for (const { worker } of this.compiled) {
+      if (!hasWorker(worker)) {
+        this.log.warn('Cron entry references an unregistered worker', { worker });
+      }
+    }
+
+    telemetry.emit('plugin:start', { queue: this.name });
+
+    await this.tick();
+    this.timer = setInterval(() => this.tick(), this.config.interval);
+  }
+
+  protected async onStop(): Promise<void> {
+    this.lastEvaluated = null;
+    telemetry.emit('plugin:stop', { queue: this.name });
+  }
+
+  private async tick(): Promise<void> {
+    if (!this.context || !this.running) return;
+
+    // A follower that later takes over should start from the minute it was
+    // elected in, not replay everything it missed while the previous leader
+    // was handling those minutes perfectly well.
+    if (!this.isLeader()) {
+      this.lastEvaluated = null;
+      return;
+    }
+
+    try {
+      for (const minute of this.minutesToEvaluate(Date.now())) {
+        await this.evaluate(minute);
+        this.lastEvaluated = minute;
+      }
+    } catch (error) {
+      telemetry.emit('plugin:error', {
+        queue: this.name,
+        error: error instanceof Error ? error : new Error(String(error))
+      });
+    }
+  }
+
+  /**
+   * The minute boundaries this evaluation is responsible for: the current one,
+   * plus up to `maxCatchUpMinutes` that a delayed tick skipped over. Empty
+   * when the current minute has already been evaluated, which is what makes a
+   * sub-minute `interval` idempotent rather than a source of duplicate work.
+   */
+  private minutesToEvaluate(now: number): number[] {
+    const current = Math.floor(now / MINUTE_MS) * MINUTE_MS;
+
+    if (this.lastEvaluated === null) return [current];
+    // Also covers a clock stepping backwards: there is nothing to replay.
+    if (current <= this.lastEvaluated) return [];
+
+    const missed = (current - this.lastEvaluated) / MINUTE_MS - 1;
+    const catchUp = Math.min(missed, this.config.maxCatchUpMinutes);
+
+    const minutes: number[] = [];
+    for (let i = catchUp; i >= 0; i--) {
+      minutes.push(current - i * MINUTE_MS);
+    }
+    return minutes;
+  }
+
+  private async evaluate(minute: number): Promise<void> {
+    const key = minuteKey(minute);
+    const at = new Date(minute);
+
+    for (const compiled of this.compiled) {
+      if (!matchesCron(compiled.schedule, fieldsInTimezone(at, compiled.timezone))) continue;
+      await this.enqueue(compiled, key);
+    }
+  }
+
+  private async enqueue(compiled: CompiledEntry, minute: string): Promise<void> {
+    const { entry, schedule, timezone, worker } = compiled;
+
+    const insert = this.context?.insert;
+    if (!insert) return;
+
+    await insert(worker, {
+      args: entry.args ?? {},
+      queue: entry.queue,
+      priority: entry.priority,
+      maxAttempts: entry.maxAttempts,
+      tags: entry.tags,
+      meta: { cron: true, cronExpression: schedule.expression, cronMinute: minute },
+      // Scoped on the entry and the minute, so every node evaluating this
+      // minute converges on one job, while the next minute's run is never
+      // mistaken for a duplicate of this one -- which a time-window `period`
+      // cannot promise, since two runs a minute apart can land milliseconds
+      // apart in wall-clock terms.
+      //
+      // Every state, and no period, because the guard has to hold even once
+      // the job has finished: a cron job that completes in 10ms would
+      // otherwise be reinserted by the next node to evaluate the same minute.
+      unique: {
+        scope: `cron:${timezone}:${schedule.expression}:${minute}`,
+        states: JOB_STATES,
+        period: 'infinity'
+      }
+    });
+  }
+}
+
+export function createCronPlugin(config: CronConfig): CronPlugin {
+  return new CronPlugin(config);
+}

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -1,3 +1,11 @@
 export { BasePlugin, type Plugin, type PluginConfig, type PluginContext } from './plugin.js';
 export { LifelinePlugin, createLifelinePlugin, type LifelineConfig } from './lifeline.js';
 export { PrunerPlugin, createPrunerPlugin, type PrunerConfig } from './pruner.js';
+export { CronPlugin, createCronPlugin, type CronConfig, type CronEntry } from './cron.js';
+export {
+  parseCron,
+  matchesCron,
+  fieldsInTimezone,
+  type CronSchedule,
+  type CronFields
+} from './cron-expression.js';

--- a/src/plugins/plugin.ts
+++ b/src/plugins/plugin.ts
@@ -1,8 +1,15 @@
-import type { DatabaseAdapter } from '../types.js';
+import type { DatabaseAdapter, Job, JobInsertOptions, Logger } from '../types.js';
 
 export interface PluginConfig {
   name: string;
 }
+
+const NO_OP_LOGGER: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {}
+};
 
 export interface PluginContext {
   database: DatabaseAdapter;
@@ -23,6 +30,25 @@ export interface PluginContext {
    * treats an absent one as leader.
    */
   isLeader?: () => boolean;
+  /**
+   * Inserts a job through the owning `IziQueue`, taking the same path as
+   * `IziQueue.insert` -- worker defaults, uniqueness, queue wake-up and all.
+   * A plugin that needs to enqueue work should use this rather than reaching
+   * for `database.insertJob`, which would bypass every one of those.
+   *
+   * Optional for the same reason as `isLeader`: a hand-built context should
+   * still type-check. A plugin that requires it says so on `start`.
+   */
+  insert?: (
+    worker: string,
+    options: JobInsertOptions
+  ) => Promise<{ job: Job; conflict: boolean }>;
+  /**
+   * The owning queue's logger, so a plugin reports operational problems
+   * through the same sink as the rest of izi-queue instead of `console`.
+   * Optional alongside the rest; `BasePlugin.log` falls back to a no-op.
+   */
+  logger?: Logger;
 }
 
 export interface Plugin {
@@ -66,6 +92,11 @@ export abstract class BasePlugin implements Plugin {
    */
   protected isLeader(): boolean {
     return this.context?.isLeader?.() ?? true;
+  }
+
+  /** The owning queue's logger, or a no-op when the context has none. */
+  protected get log(): Logger {
+    return this.context?.logger ?? NO_OP_LOGGER;
   }
 
   validate(): string[] {

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,20 @@ export interface UniqueOptions {
   keys?: string[];
   period?: number | 'infinity';
   states?: JobState[];
+  /**
+   * An opaque discriminator folded into the uniqueness digest, so two jobs
+   * that are otherwise identical are only "the same" within the same scope.
+   *
+   * This is what lets uniqueness be keyed on something that is not part of
+   * the job -- the scheduled minute, a tenant, a billing period. The cron
+   * plugin uses it to key each run on its minute, which is exact where a
+   * `period` window is not: two nodes evaluating the same minute a second
+   * apart collapse to one job, while consecutive minutes never collide no
+   * matter how close together the inserts land.
+   *
+   * Omitting it leaves the digest exactly as it was before this existed.
+   */
+  scope?: string;
 }
 
 export interface JobCriteria {

--- a/tests/cron-expression.test.ts
+++ b/tests/cron-expression.test.ts
@@ -1,0 +1,203 @@
+import {
+  fieldsInTimezone,
+  matchesCron,
+  parseCron,
+  assertTimezone
+} from '../src/plugins/cron-expression.js';
+
+/** `2026-08-23T14:05Z` and friends, as instants. */
+function utc(iso: string): Date {
+  return new Date(iso);
+}
+
+function matchesAt(expression: string, iso: string, timezone = 'UTC'): boolean {
+  return matchesCron(parseCron(expression), fieldsInTimezone(utc(iso), timezone));
+}
+
+describe('cron expressions', () => {
+  describe('parsing fields', () => {
+    it('expands a wildcard to the whole range', () => {
+      const schedule = parseCron('* * * * *');
+      expect(schedule.minutes.size).toBe(60);
+      expect(schedule.hours.size).toBe(24);
+      expect(schedule.daysOfMonth.size).toBe(31);
+      expect(schedule.months.size).toBe(12);
+      expect(schedule.daysOfWeek.size).toBe(7);
+    });
+
+    it('parses a single value', () => {
+      expect([...parseCron('30 * * * *').minutes]).toEqual([30]);
+    });
+
+    it('parses a list', () => {
+      expect([...parseCron('0,15,30,45 * * * *').minutes]).toEqual([0, 15, 30, 45]);
+    });
+
+    it('parses a range', () => {
+      expect([...parseCron('* 9-12 * * *').hours]).toEqual([9, 10, 11, 12]);
+    });
+
+    it('parses a step over a wildcard', () => {
+      expect([...parseCron('*/15 * * * *').minutes]).toEqual([0, 15, 30, 45]);
+    });
+
+    it('parses a step over a range', () => {
+      expect([...parseCron('0-30/10 * * * *').minutes]).toEqual([0, 10, 20, 30]);
+    });
+
+    it('reads a bare value with a step as running to the end of the field', () => {
+      expect([...parseCron('5/10 * * * *').minutes]).toEqual([5, 15, 25, 35, 45, 55]);
+    });
+
+    it('parses month names', () => {
+      expect([...parseCron('0 0 1 jan,jul *').months]).toEqual([1, 7]);
+      expect([...parseCron('0 0 1 MAR-MAY *').months]).toEqual([3, 4, 5]);
+    });
+
+    it('parses day names', () => {
+      expect([...parseCron('0 0 * * mon-fri').daysOfWeek]).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it('accepts 7 as a second spelling of Sunday', () => {
+      expect([...parseCron('0 0 * * 7').daysOfWeek]).toEqual([0]);
+      expect([...parseCron('0 0 * * 0').daysOfWeek]).toEqual([0]);
+    });
+
+    it('normalises whitespace in the stored expression', () => {
+      expect(parseCron('  0   9  *  *  1  ').expression).toBe('0 9 * * 1');
+    });
+  });
+
+  describe('aliases', () => {
+    it.each([
+      ['@hourly', '0 * * * *'],
+      ['@daily', '0 0 * * *'],
+      ['@midnight', '0 0 * * *'],
+      ['@weekly', '0 0 * * 0'],
+      ['@monthly', '0 0 1 * *'],
+      ['@yearly', '0 0 1 1 *'],
+      ['@annually', '0 0 1 1 *']
+    ])('%s expands like %s', (alias, equivalent) => {
+      const aliased = parseCron(alias);
+      const spelled = parseCron(equivalent);
+
+      expect([...aliased.minutes]).toEqual([...spelled.minutes]);
+      expect([...aliased.hours]).toEqual([...spelled.hours]);
+      expect([...aliased.daysOfMonth]).toEqual([...spelled.daysOfMonth]);
+      expect([...aliased.months]).toEqual([...spelled.months]);
+      expect([...aliased.daysOfWeek]).toEqual([...spelled.daysOfWeek]);
+      expect(aliased.expression).toBe(alias);
+    });
+
+    it('is case-insensitive', () => {
+      expect(parseCron('@DAILY').expression).toBe('@daily');
+    });
+  });
+
+  describe('rejecting bad expressions', () => {
+    it.each([
+      ['', /is empty/],
+      ['* * * *', /expected 5 fields/],
+      ['* * * * * *', /expected 5 fields/],
+      ['60 * * * *', /minute 60 is outside 0-59/],
+      ['* 24 * * *', /hour 24 is outside 0-23/],
+      ['* * 0 * *', /day-of-month 0 is outside 1-31/],
+      ['* * * 13 *', /month 13 is outside 1-12/],
+      ['* * * * 8', /day-of-week 8 is outside 0-7/],
+      ['30-10 * * * *', /runs backwards/],
+      ['*/0 * * * *', /not a valid minute step/],
+      ['*/a * * * *', /not a valid minute step/],
+      ['abc * * * *', /"abc" is not a valid minute/],
+      ['0,,30 * * * *', /empty term/],
+      ['*/2/3 * * * *', /more than one step/],
+      ['@reboot', /not a supported alias/],
+      ['@nope', /not a supported alias/]
+    ])('rejects %p', (expression, message) => {
+      expect(() => parseCron(expression)).toThrow(message);
+    });
+
+    it('names the expression it rejected', () => {
+      expect(() => parseCron('99 * * * *')).toThrow(/invalid cron expression "99 \* \* \* \*"/);
+    });
+  });
+
+  describe('matching', () => {
+    it('matches every minute for a full wildcard', () => {
+      expect(matchesAt('* * * * *', '2026-08-23T14:05:00Z')).toBe(true);
+    });
+
+    it('matches only on the hour for @hourly', () => {
+      expect(matchesAt('@hourly', '2026-08-23T14:00:00Z')).toBe(true);
+      expect(matchesAt('@hourly', '2026-08-23T14:01:00Z')).toBe(false);
+    });
+
+    it('matches a weekday business-hours schedule', () => {
+      // 2026-08-24 is a Monday, 2026-08-23 a Sunday.
+      expect(matchesAt('0 9-17 * * 1-5', '2026-08-24T09:00:00Z')).toBe(true);
+      expect(matchesAt('0 9-17 * * 1-5', '2026-08-24T18:00:00Z')).toBe(false);
+      expect(matchesAt('0 9-17 * * 1-5', '2026-08-23T09:00:00Z')).toBe(false);
+    });
+
+    describe('the day-of-month / day-of-week rule', () => {
+      // Cron's oddest corner: with both day fields restricted, either one
+      // matching is enough. `0 0 13 * 5` is "the 13th, and every Friday".
+      it('ORs the two when both are restricted', () => {
+        expect(matchesAt('0 0 13 * 5', '2026-01-13T00:00:00Z')).toBe(true); // a Tuesday
+        expect(matchesAt('0 0 13 * 5', '2026-01-16T00:00:00Z')).toBe(true); // a Friday
+        expect(matchesAt('0 0 13 * 5', '2026-01-14T00:00:00Z')).toBe(false);
+      });
+
+      it('requires the day of month when only it is restricted', () => {
+        expect(matchesAt('0 0 13 * *', '2026-01-13T00:00:00Z')).toBe(true);
+        expect(matchesAt('0 0 13 * *', '2026-01-16T00:00:00Z')).toBe(false);
+      });
+
+      it('requires the day of week when only it is restricted', () => {
+        expect(matchesAt('0 0 * * 5', '2026-01-16T00:00:00Z')).toBe(true);
+        expect(matchesAt('0 0 * * 5', '2026-01-13T00:00:00Z')).toBe(false);
+      });
+    });
+  });
+
+  describe('timezones', () => {
+    it('evaluates in the given zone, not UTC', () => {
+      // 09:00 in São Paulo (UTC-3) is 12:00 UTC.
+      expect(matchesAt('0 9 * * *', '2026-08-24T12:00:00Z', 'America/Sao_Paulo')).toBe(true);
+      expect(matchesAt('0 9 * * *', '2026-08-24T12:00:00Z', 'UTC')).toBe(false);
+      expect(matchesAt('0 12 * * *', '2026-08-24T12:00:00Z', 'UTC')).toBe(true);
+    });
+
+    it('crosses the date line into the previous local day', () => {
+      // 2026-08-24T02:00Z is still 2026-08-23, 23:00, in São Paulo.
+      const fields = fieldsInTimezone(utc('2026-08-24T02:00:00Z'), 'America/Sao_Paulo');
+      expect(fields).toMatchObject({ hour: 23, dayOfMonth: 23, month: 8, dayOfWeek: 0 });
+    });
+
+    it('reports midnight as hour 0, not 24', () => {
+      expect(fieldsInTimezone(utc('2026-08-24T00:00:00Z'), 'UTC').hour).toBe(0);
+    });
+
+    it('skips a local hour that a spring-forward removes', () => {
+      // New York jumps 02:00 EST -> 03:00 EDT on 2026-03-08, so `0 2 * * *`
+      // simply does not occur that day.
+      expect(fieldsInTimezone(utc('2026-03-08T06:59:00Z'), 'America/New_York').hour).toBe(1);
+      expect(fieldsInTimezone(utc('2026-03-08T07:00:00Z'), 'America/New_York').hour).toBe(3);
+    });
+
+    it('sees a repeated local hour twice on a fall-back', () => {
+      // 01:00 happens once as EDT and once as EST on 2026-11-01. Both are
+      // genuine matches; the cron plugin's per-minute unique key is what keeps
+      // them from being conflated.
+      expect(fieldsInTimezone(utc('2026-11-01T05:00:00Z'), 'America/New_York').hour).toBe(1);
+      expect(fieldsInTimezone(utc('2026-11-01T06:00:00Z'), 'America/New_York').hour).toBe(1);
+    });
+
+    it('rejects a zone this runtime does not know', () => {
+      expect(() => assertTimezone('Mars/Olympus_Mons')).toThrow(/unknown timezone/);
+    });
+
+    it('accepts a real IANA zone', () => {
+      expect(() => assertTimezone('Europe/Lisbon')).not.toThrow();
+    });
+  });
+});

--- a/tests/cron.test.ts
+++ b/tests/cron.test.ts
@@ -1,0 +1,476 @@
+import Database from 'better-sqlite3';
+import {
+  createCronPlugin,
+  createIziQueue,
+  createSQLiteAdapter,
+  clearWorkers,
+  defineWorker
+} from '../src/index.js';
+import type { IziQueue } from '../src/core/izi-queue.js';
+import type { PluginContext } from '../src/plugins/plugin.js';
+import { rowToJob } from '../src/database/adapter.js';
+import type { Job, Logger } from '../src/types.js';
+import { waitFor } from './helpers/wait.js';
+
+/** Invokes the plugin's private evaluation, which is otherwise timer-driven. */
+function tick(plugin: unknown): Promise<void> {
+  return (plugin as { tick(): Promise<void> }).tick();
+}
+
+/** 2026-08-24 is a Monday. */
+const MONDAY_09_00 = Date.UTC(2026, 7, 24, 9, 0, 0);
+
+describe('CronPlugin', () => {
+  let db: Database.Database;
+  let adapter: ReturnType<typeof createSQLiteAdapter>;
+  let queue: IziQueue;
+  let logger: Logger;
+
+  function contextFor(overrides: Partial<PluginContext> = {}): PluginContext {
+    return {
+      database: adapter,
+      node: 'node-a',
+      queues: ['default'],
+      isLeader: () => true,
+      insert: (worker, options) => queue.insertWithResult(worker, options),
+      logger,
+      ...overrides
+    };
+  }
+
+  function at(instant: number): void {
+    jest.setSystemTime(instant);
+  }
+
+  function cronJobs(): Job[] {
+    return (db.prepare('SELECT * FROM izi_jobs ORDER BY id').all() as Record<string, unknown>[]).map(
+      rowToJob
+    );
+  }
+
+  beforeEach(async () => {
+    db = new Database(':memory:');
+    adapter = createSQLiteAdapter(db);
+    await adapter.migrate();
+    clearWorkers();
+
+    logger = { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() };
+    queue = createIziQueue({ database: adapter, queues: { default: 1 }, logger });
+
+    // Fake timers rather than a stubbed `Date.now`: the plugin's cursor,
+    // catch-up window and dedup key are all derived from the wall clock, and
+    // stubbing the global out from under jest's own timing hangs the run.
+    jest.useFakeTimers({ now: MONDAY_09_00 });
+  });
+
+  afterEach(async () => {
+    jest.useRealTimers();
+    await adapter.close();
+  });
+
+  describe('validation', () => {
+    it('accepts a well-formed crontab', () => {
+      const plugin = createCronPlugin({
+        crontab: [
+          { expression: '@daily', worker: 'DigestWorker' },
+          { expression: '*/5 * * * *', worker: 'PollWorker', timezone: 'America/Sao_Paulo' }
+        ]
+      });
+
+      expect(plugin.validate()).toEqual([]);
+    });
+
+    it('reports a malformed expression with its crontab position', () => {
+      const errors = createCronPlugin({
+        crontab: [
+          { expression: '@daily', worker: 'Good' },
+          { expression: '99 * * * *', worker: 'Bad' }
+        ]
+      }).validate();
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toMatch(/crontab\[1\]/);
+      expect(errors[0]).toMatch(/minute 99 is outside/);
+    });
+
+    it('reports an unknown timezone', () => {
+      const errors = createCronPlugin({
+        crontab: [{ expression: '@daily', worker: 'W', timezone: 'Mars/Olympus_Mons' }]
+      }).validate();
+
+      expect(errors[0]).toMatch(/unknown timezone/);
+    });
+
+    it('reports an entry with no worker', () => {
+      const errors = createCronPlugin({
+        crontab: [{ expression: '@daily', worker: '' }]
+      }).validate();
+
+      expect(errors[0]).toMatch(/has no worker/);
+    });
+
+    it.each([
+      [{ interval: 500 }, /at least 1000ms/],
+      [{ interval: 120000 }, /at most 60000ms/],
+      [{ maxCatchUpMinutes: -1 }, /between 0 and 60/],
+      [{ maxCatchUpMinutes: 61 }, /between 0 and 60/],
+      [{ maxCatchUpMinutes: 1.5 }, /between 0 and 60/]
+    ])('rejects %p', (config, message) => {
+      const errors = createCronPlugin({
+        crontab: [{ expression: '@daily', worker: 'W' }],
+        ...config
+      }).validate();
+
+      expect(errors.join(' ')).toMatch(message);
+    });
+
+    it('stops IziQueue from starting with an invalid crontab', () => {
+      expect(() =>
+        createIziQueue({
+          database: adapter,
+          queues: { default: 1 },
+          plugins: [createCronPlugin({ crontab: [{ expression: 'nope', worker: 'W' }] })]
+        })
+      ).toThrow(/Plugin "cron" validation failed/);
+    });
+
+    it('needs a context that can insert jobs', async () => {
+      const plugin = createCronPlugin({ crontab: [{ expression: '* * * * *', worker: 'W' }] });
+
+      await expect(plugin.start(contextFor({ insert: undefined }))).rejects.toThrow(
+        /needs a plugin context that can insert jobs/
+      );
+    });
+  });
+
+  describe('inserting scheduled runs', () => {
+    it('inserts when the minute matches', async () => {
+      const plugin = createCronPlugin({
+        crontab: [{ expression: '0 9 * * 1', worker: 'MondayWorker' }]
+      });
+
+      await plugin.start(contextFor());
+
+      const jobs = cronJobs();
+      expect(jobs).toHaveLength(1);
+      expect(jobs[0].worker).toBe('MondayWorker');
+
+      await plugin.stop();
+    });
+
+    it('does not insert when the minute does not match', async () => {
+      const plugin = createCronPlugin({
+        crontab: [{ expression: '0 10 * * 1', worker: 'TenAmWorker' }]
+      });
+
+      await plugin.start(contextFor());
+
+      expect(cronJobs()).toHaveLength(0);
+      await plugin.stop();
+    });
+
+    it('evaluates each entry in its own timezone', async () => {
+      // 09:00 UTC is 06:00 in São Paulo.
+      const plugin = createCronPlugin({
+        crontab: [
+          { expression: '0 9 * * *', worker: 'UtcWorker' },
+          { expression: '0 6 * * *', worker: 'BrasiliaWorker', timezone: 'America/Sao_Paulo' },
+          { expression: '0 9 * * *', worker: 'BrasiliaNineWorker', timezone: 'America/Sao_Paulo' }
+        ]
+      });
+
+      await plugin.start(contextFor());
+
+      expect(cronJobs().map(job => job.worker).sort()).toEqual(['BrasiliaWorker', 'UtcWorker']);
+      await plugin.stop();
+    });
+
+    it('carries the entry through to the job', async () => {
+      const plugin = createCronPlugin({
+        crontab: [
+          {
+            expression: '* * * * *',
+            worker: 'ReportWorker',
+            args: { scope: 'all' },
+            queue: 'reports',
+            priority: 3,
+            maxAttempts: 2,
+            tags: ['cron', 'reports']
+          }
+        ]
+      });
+
+      await plugin.start(contextFor());
+
+      const [job] = cronJobs();
+      expect(job.args).toEqual({ scope: 'all' });
+      expect(job.queue).toBe('reports');
+      expect(job.priority).toBe(3);
+      expect(job.maxAttempts).toBe(2);
+      expect(job.tags).toEqual(['cron', 'reports']);
+      expect(job.meta).toEqual({
+        cron: true,
+        cronExpression: '* * * * *',
+        cronMinute: '2026-08-24T09:00Z'
+      });
+
+      await plugin.stop();
+    });
+
+    it('accepts a worker definition as well as a name', async () => {
+      const worker = defineWorker('DefinedWorker', async () => undefined);
+      const plugin = createCronPlugin({ crontab: [{ expression: '* * * * *', worker }] });
+
+      await plugin.start(contextFor());
+
+      expect(cronJobs()[0].worker).toBe('DefinedWorker');
+      await plugin.stop();
+    });
+
+    it('warns about an entry whose worker was never registered', async () => {
+      const plugin = createCronPlugin({ crontab: [{ expression: '* * * * *', worker: 'Ghost' }] });
+
+      await plugin.start(contextFor());
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Cron entry references an unregistered worker',
+        { worker: 'Ghost' }
+      );
+
+      await plugin.stop();
+    });
+  });
+
+  describe('deduplication', () => {
+    it('collapses two nodes evaluating the same minute into one job', async () => {
+      const entry = { expression: '* * * * *', worker: 'HeartbeatWorker' };
+
+      const a = createCronPlugin({ crontab: [entry] });
+      const b = createCronPlugin({ crontab: [entry] });
+
+      await a.start(contextFor({ node: 'node-a' }));
+      await b.start(contextFor({ node: 'node-b' }));
+
+      expect(cronJobs()).toHaveLength(1);
+
+      await a.stop();
+      await b.stop();
+    });
+
+    it('still inserts once the minute rolls over', async () => {
+      const plugin = createCronPlugin({ crontab: [{ expression: '* * * * *', worker: 'W' }] });
+      await plugin.start(contextFor());
+
+      at(MONDAY_09_00 + 60_000);
+      await tick(plugin);
+
+      expect(cronJobs()).toHaveLength(2);
+      expect(cronJobs().map(job => job.meta.cronMinute)).toEqual([
+        '2026-08-24T09:00Z',
+        '2026-08-24T09:01Z'
+      ]);
+
+      await plugin.stop();
+    });
+
+    it('does not insert twice when it ticks more than once inside a minute', async () => {
+      const plugin = createCronPlugin({
+        crontab: [{ expression: '* * * * *', worker: 'W' }],
+        interval: 1000
+      });
+      await plugin.start(contextFor());
+
+      at(MONDAY_09_00 + 30_000);
+      await tick(plugin);
+      at(MONDAY_09_00 + 59_000);
+      await tick(plugin);
+
+      expect(cronJobs()).toHaveLength(1);
+      await plugin.stop();
+    });
+
+    it('deduplicates against a run that has already finished', async () => {
+      // The whole reason the guard spans every state: a cron job that
+      // completes in milliseconds must not be reinserted by the next node to
+      // evaluate the same minute.
+      const plugin = createCronPlugin({ crontab: [{ expression: '* * * * *', worker: 'W' }] });
+      await plugin.start(contextFor());
+
+      db.prepare(`UPDATE izi_jobs SET state = 'completed', completed_at = datetime('now')`).run();
+
+      const other = createCronPlugin({ crontab: [{ expression: '* * * * *', worker: 'W' }] });
+      await other.start(contextFor({ node: 'node-b' }));
+
+      expect(cronJobs()).toHaveLength(1);
+
+      await plugin.stop();
+      await other.stop();
+    });
+
+    it('keeps entries with different expressions apart in the same minute', async () => {
+      const plugin = createCronPlugin({
+        crontab: [
+          { expression: '* * * * *', worker: 'W' },
+          { expression: '0 9 * * 1', worker: 'W' }
+        ]
+      });
+
+      await plugin.start(contextFor());
+
+      expect(cronJobs()).toHaveLength(2);
+      await plugin.stop();
+    });
+  });
+
+  describe('catching up on missed minutes', () => {
+    it('evaluates minutes a delayed tick skipped over', async () => {
+      const plugin = createCronPlugin({ crontab: [{ expression: '* * * * *', worker: 'W' }] });
+      await plugin.start(contextFor());
+
+      at(MONDAY_09_00 + 3 * 60_000);
+      await tick(plugin);
+
+      expect(cronJobs().map(job => job.meta.cronMinute)).toEqual([
+        '2026-08-24T09:00Z',
+        '2026-08-24T09:01Z',
+        '2026-08-24T09:02Z',
+        '2026-08-24T09:03Z'
+      ]);
+
+      await plugin.stop();
+    });
+
+    it('bounds how far back a single evaluation reaches', async () => {
+      const plugin = createCronPlugin({
+        crontab: [{ expression: '* * * * *', worker: 'W' }],
+        maxCatchUpMinutes: 2
+      });
+      await plugin.start(contextFor());
+
+      at(MONDAY_09_00 + 10 * 60_000);
+      await tick(plugin);
+
+      expect(cronJobs().map(job => job.meta.cronMinute)).toEqual([
+        '2026-08-24T09:00Z',
+        '2026-08-24T09:08Z',
+        '2026-08-24T09:09Z',
+        '2026-08-24T09:10Z'
+      ]);
+
+      await plugin.stop();
+    });
+
+    it('evaluates only the current minute when catch-up is disabled', async () => {
+      const plugin = createCronPlugin({
+        crontab: [{ expression: '* * * * *', worker: 'W' }],
+        maxCatchUpMinutes: 0
+      });
+      await plugin.start(contextFor());
+
+      at(MONDAY_09_00 + 5 * 60_000);
+      await tick(plugin);
+
+      expect(cronJobs().map(job => job.meta.cronMinute)).toEqual([
+        '2026-08-24T09:00Z',
+        '2026-08-24T09:05Z'
+      ]);
+
+      await plugin.stop();
+    });
+
+    it('does nothing when the clock steps backwards', async () => {
+      const plugin = createCronPlugin({ crontab: [{ expression: '* * * * *', worker: 'W' }] });
+      await plugin.start(contextFor());
+
+      at(MONDAY_09_00 - 5 * 60_000);
+      await tick(plugin);
+
+      expect(cronJobs()).toHaveLength(1);
+      await plugin.stop();
+    });
+  });
+
+  describe('leadership', () => {
+    it('does not evaluate on a follower', async () => {
+      const plugin = createCronPlugin({ crontab: [{ expression: '* * * * *', worker: 'W' }] });
+      await plugin.start(contextFor({ isLeader: () => false }));
+
+      expect(cronJobs()).toHaveLength(0);
+      await plugin.stop();
+    });
+
+    it('starts from the minute it was elected in, not from everything it missed', async () => {
+      let leading = false;
+      const plugin = createCronPlugin({ crontab: [{ expression: '* * * * *', worker: 'W' }] });
+      await plugin.start(contextFor({ isLeader: () => leading }));
+
+      // Ten minutes pass with another node leading, then this one takes over.
+      at(MONDAY_09_00 + 10 * 60_000);
+      leading = true;
+      await tick(plugin);
+
+      expect(cronJobs().map(job => job.meta.cronMinute)).toEqual(['2026-08-24T09:10Z']);
+      await plugin.stop();
+    });
+  });
+
+  describe('failure handling', () => {
+    it('reports an insert failure as plugin:error and keeps running', async () => {
+      const plugin = createCronPlugin({ crontab: [{ expression: '* * * * *', worker: 'W' }] });
+
+      let broken = true;
+      await plugin.start(
+        contextFor({
+          insert: async (worker, options) => {
+            if (broken) throw new Error('database is down');
+            return queue.insertWithResult(worker, options);
+          }
+        })
+      );
+
+      expect(cronJobs()).toHaveLength(0);
+
+      broken = false;
+      at(MONDAY_09_00 + 60_000);
+      await tick(plugin);
+
+      expect(cronJobs()).toHaveLength(1);
+      await plugin.stop();
+    });
+  });
+
+  describe('end to end', () => {
+    it('runs a scheduled job through a real queue', async () => {
+      jest.useRealTimers();
+
+      const performed: number[] = [];
+      const running = createIziQueue({
+        database: adapter,
+        queues: { default: 1 },
+        pollInterval: 20,
+        stageInterval: 20,
+        plugins: [
+          createCronPlugin({
+            crontab: [{ expression: '* * * * *', worker: 'MinuteWorker' }],
+            interval: 1000
+          })
+        ]
+      });
+
+      running.register(
+        defineWorker('MinuteWorker', async job => {
+          performed.push(job.id);
+        })
+      );
+
+      await running.start();
+
+      await waitFor(() => performed.length > 0, { describe: 'the cron job to run' });
+
+      const [job] = cronJobs();
+      expect(job.meta.cron).toBe(true);
+
+      await running.stop();
+    });
+  });
+});

--- a/tests/unique-key.test.ts
+++ b/tests/unique-key.test.ts
@@ -121,6 +121,37 @@ describe('computeUniqueKey', () => {
     expect(key).not.toBe(computeUniqueKey(job({ args: { x: 'v' } }), { keys: ['x'] }));
   });
 
+  it('separates jobs by scope', () => {
+    const january = computeUniqueKey(job({ args: { userId: 1 } }), { scope: '2026-01' });
+    const february = computeUniqueKey(job({ args: { userId: 1 } }), { scope: '2026-02' });
+
+    expect(january).not.toBe(february);
+  });
+
+  it('collapses identical jobs sharing a scope', () => {
+    const a = computeUniqueKey(job({ args: { userId: 1 } }), { scope: 'cron:2026-08-24T09:00Z' });
+    const b = computeUniqueKey(job({ args: { userId: 1 } }), { scope: 'cron:2026-08-24T09:00Z' });
+
+    expect(a).toBe(b);
+  });
+
+  it('still distinguishes different jobs within one scope', () => {
+    const first = computeUniqueKey(job({ args: { userId: 1 } }), { scope: 'batch-7' });
+    const second = computeUniqueKey(job({ args: { userId: 2 } }), { scope: 'batch-7' });
+
+    expect(first).not.toBe(second);
+  });
+
+  it('leaves the digest untouched when no scope is given', () => {
+    // Adding scopes must not invalidate unique keys already stored in
+    // izi_jobs, or every in-flight unique job would stop deduplicating.
+    expect(computeUniqueKey(job({ args: { userId: 1 } }), DEFAULTS)).toBe(
+      // sha256 of [["worker","SendEmail"],["queue","default"],["args",[["userId",1]]]],
+      // computed independently of this implementation.
+      'c1375b5e4b05b9dc3f551d295fe37e51'
+    );
+  });
+
   it('produces a key short enough for a MySQL lock name', () => {
     // GET_LOCK names are capped at 64 characters.
     expect(computeUniqueKey(job(), DEFAULTS).length).toBeLessThanOrEqual(64);


### PR DESCRIPTION
Closes #27. **Based on `feat/leadership-election` (#89)** — merge that first, then retarget this to `main` *before* merging it, or GitHub will auto-close this PR when its base branch is deleted.

## What it does

```typescript
new CronPlugin({
  timezone: 'America/Sao_Paulo',   // default for entries below; defaults to UTC
  crontab: [
    { expression: '0 * * * *', worker: 'HourlyWorker' },
    { expression: '@daily', worker: 'DailyDigest', args: { scope: 'all' } },
    { expression: '*/15 9-17 * * 1-5', worker: 'PollWorker', queue: 'reports' },
    { expression: '0 3 * * *', worker: 'Backup', timezone: 'UTC' },
  ],
})
```

Standard five-field expressions with ranges, lists, steps and names (`*/15`, `9-17`, `0,30`, `mon-fri`, `jan,jul`, `5/10`), the `@hourly`/`@daily`/`@midnight`/`@weekly`/`@monthly`/`@yearly`/`@annually` aliases, `7` as a second spelling of Sunday, and cron's day rule — with both day fields restricted, either matching is enough, so `0 0 13 * 5` is "the 13th, and every Friday".

Per-entry `args`, `queue`, `priority`, `maxAttempts`, `tags` and `timezone`. Inserted jobs carry `meta: { cron: true, cronExpression, cronMinute }`.

The parser is hand-rolled rather than pulled in as a dependency: izi-queue has no runtime dependencies, and the grammar is small enough that adding one to avoid it would be the larger cost. It is exported on its own as `parseCron` / `matchesCron` / `fieldsInTimezone`.

## Exactly-once, and why it takes two mechanisms

**Leader-only evaluation** stops N nodes from evaluating the crontab N times over.

**A unique key scoped to `(entry, minute)`** is what makes the result *correct* rather than merely usually correct — a leadership handover can legitimately have two nodes evaluate the same minute, and leadership is advisory, not a fence.

Neither alone is enough: without the key a handover duplicates runs; without leadership every node pays for an insert all but one will lose.

The guard spans **every job state** and uses **no period window**. A cron job that completes in 10ms would otherwise be reinserted by the next node to look at that minute.

## `unique.scope`

That guard needed something the digest could not express, so `UniqueOptions` gained `scope` — an opaque discriminator folded into the uniqueness digest, so two otherwise identical jobs are only "the same" within one scope (a tenant, a billing period, a scheduled minute).

It is *exact* where a `period` window is approximate. A 59-second window would have worked most of the time and then wrongly collapsed two consecutive minutes whose inserts happened to land 200ms apart — a cron run silently skipped, at random, under load.

Digests computed without a scope are byte-for-byte unchanged (there is a test pinning the pre-change hash, computed independently of the implementation), so unique jobs already in the database keep deduplicating.

## Catch-up

A tick delayed past its minute — a stalled event loop, a long GC pause — catches up on what it skipped rather than dropping those runs, bounded by `maxCatchUpMinutes` (default 5, max 60). Catching up is only safe *because* of the per-minute key: a minute another node already ran collapses into that job.

A node that has just taken over leadership starts from the minute it was elected in, rather than replaying everything the previous leader was handling perfectly well.

## Failing loudly

An invalid expression or timezone is rejected when the queue is constructed, naming the crontab entry at fault (`crontab[1]: izi-queue: invalid cron expression "99 * * * *" -- minute 99 is outside 0-59`). A typo cannot become a job that silently never runs.

## Also in this PR

- `PluginContext.insert` — enqueue through the owning queue's insert path. Reaching for `database.insertJob` instead skips worker defaults, uniqueness and the queue wake-up; the cron plugin needs all three.
- `PluginContext.logger` and `BasePlugin.log`, so a plugin reports through the same sink as the rest of izi-queue instead of `console`.

## Testing

661 tests pass against **PostgreSQL 18, MySQL 8 and SQLite** together. New: 49 parser/timezone tests (including both DST transitions in `America/New_York`) and 30 plugin tests covering dedup across two nodes, dedup against a finished run, minute rollover, catch-up and its bound, leadership gating and handover, clock stepping backwards, and an end-to-end run through a real queue.

Schedules are tested with `jest.useFakeTimers` / `setSystemTime`; stubbing `Date.now` directly hangs the run, since jest's own timing reads it.

https://claude.ai/code/session_01QTMkU47YPxu1D3Y24SNY3d