### PR TITLE
chore(release): 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ While the version is below 1.0.0, breaking changes are released as minor version
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-08-25
+
 ### Added
 
 - **Leader election.** One node per cluster is elected leader, and only the
@@ -464,4 +466,5 @@ production. Anyone running 0.3.0 or earlier should upgrade.
 [0.6.0]: https://github.com/iagocavalcante/izi-queue/compare/v0.5.0...v0.6.0
 [0.7.0]: https://github.com/iagocavalcante/izi-queue/compare/v0.6.0...v0.7.0
 [0.7.1]: https://github.com/iagocavalcante/izi-queue/compare/v0.7.0...v0.7.1
+[0.9.0]: https://github.com/iagocavalcante/izi-queue/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/iagocavalcante/izi-queue/compare/v0.7.1...v0.8.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "izi-queue",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "izi-queue",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "izi-queue",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "A minimal, reliable, database-backed job queue for Node.js inspired by Oban",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Bump to 0.9.0 and promote the Unreleased changelog section.

Highlights: leader election (#26 / #89), cron plugin (#27 / #90), `unique.scope`, plugin context additions, AGENTS.md as canonical agent docs (#91). Migrations: PostgreSQL v8, MySQL v7, SQLite v7 create `izi_peers`.

https://claude.ai/code/session_01NQPomYeojRmUXLZH97Cscr